### PR TITLE
IntelliJ 코드 스타일 설정 경로 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
 
 checkstyle {
     maxWarnings = 0
-    configFile = file("${rootDir}/naver-checkstyle-rules.xml")
-    configProperties = ["suppressionFile": "${rootDir}/naver-checkstyle-suppressions.xml"]
+    configFile = file("${rootDir}/codestyle/naver-checkstyle-rules.xml")
+    configProperties = ["suppressionFile": "${rootDir}/codestyle/naver-checkstyle-suppressions.xml"]
     toolVersion = "8.42"
 }
 


### PR DESCRIPTION
## 관련 이슈

- close #32

## PR 설명

- IntelliJ 코드 스타일 설정 파일 경로 오류 수정
  - 기존 gradlew 실행 시 잘못된 경로로 인해 발생하던 빌드 실패 문제 해결
  - 올바른 경로로 스타일 XML 파일을 참조하도록 설정 수정