### PR TITLE
인메모리 H2 DB 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
@@ -34,6 +34,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // H2 Database
+    runtimeOnly 'com.h2database:h2'
 }
 
 checkstyle {


### PR DESCRIPTION
## 관련 이슈

- close #37

## PR 설명
- 개발/테스트 환경에서 사용하기 위한 H2 인메모리 데이터베이스 설정 추가
- 주석 처리되어 있던 JPA 관련 의존성 및 설정 복구
- GitHub Actions 워크플로우에 사용 될 `Action Secrets`의 `APPLICATION` 값 수정