### PR TITLE
Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 
     // H2 Database
     runtimeOnly 'com.h2database:h2'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+
 }
 
 checkstyle {


### PR DESCRIPTION
## 관련 이슈

- close #24 

## PR 설명
- `build.gradle`에 `Swagger` 설정 추가
  - M1 버전을 제외한 최신 버전인 2.8.11 사용
  - 참고 자료 : https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-common
