### PR TITLE
AWS CloudWatch 로깅 시스템 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'checkstyle'
-    id 'jacoco'
 }
 
 group = 'com.sofa'
@@ -16,12 +15,11 @@ java {
 }
 
 configurations {
-    configureEach {
-        exclude group: 'commons-logging', module: 'commons-logging'
-    }
-
     compileOnly {
         extendsFrom annotationProcessor
+    }
+    configureEach {
+        exclude group: 'commons-logging', module: 'commons-logging'
     }
 }
 
@@ -33,9 +31,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    //Test
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
@@ -52,7 +55,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    //redis
+    // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
@@ -72,7 +75,7 @@ dependencies {
     testImplementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 
-    // Jsoup (HTML parsing for OG tag crawling)
+    // Jsoup
     implementation 'org.jsoup:jsoup:1.18.3'
 
     // WebSocket
@@ -81,14 +84,17 @@ dependencies {
     // WebFlux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    //s3
+    // S3
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    //Event
+    // Event
     implementation 'org.springframework.retry:spring-retry'
-    implementation 'org.springframework:spring-aspects'
+    implementation 'org.springframework.aspects:spring-aspects'
+
+    // AWS CloudWatch appender
+    implementation "ca.pjer:logback-awslogs-appender:1.6.0"
 }
 
 dependencyManagement {
@@ -109,87 +115,4 @@ compileTestJava.options.encoding = 'UTF-8'
 
 tasks.named('test') {
     useJUnitPlatform()
-    finalizedBy jacocoTestReport
-}
-
-jacoco {
-    toolVersion = "0.8.12"
-}
-
-jacocoTestReport {
-    dependsOn test
-    reports {
-        xml.required = true
-        html.required = true
-        csv.required = false
-    }
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                    '**/*Dto.class',
-                    '**/*Dto$*.class',
-                    '**/*Request.class',
-                    '**/*Request$*.class',
-                    '**/*Response.class',
-                    '**/*Response$*.class',
-                    '**/*Req.class',
-                    '**/*Req$*.class',
-                    '**/*Res.class',
-                    '**/*Res$*.class',
-                    '**/config/**',
-                    '**/configuration/**',
-                    '**/exception/**',
-                    '**/*Application.class',
-                    '**/Q*.class',
-                    '**/entity/**',
-                    '**/domain/**/*Entity.class',
-                    '**/domain/link/util/OgTagCrawler.class',
-                    "**/security/auth/**"
-            ])
-        }))
-    }
-}
-
-jacocoTestCoverageVerification {
-    dependsOn jacocoTestReport
-
-    violationRules {
-        rule {
-            enabled = true
-            element = 'CLASS'
-
-            limit {
-                counter = 'LINE'
-                value = 'COVEREDRATIO'
-                minimum = 0.30  // 30%부터 시작, 점진적으로 0.50 -> 0.70으로 상향
-            }
-        }
-    }
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                    '**/*Dto.class',
-                    '**/*Dto$*.class',
-                    '**/*Request.class',
-                    '**/*Request$*.class',
-                    '**/*Response.class',
-                    '**/*Response$*.class',
-                    '**/*Req.class',
-                    '**/*Req$*.class',
-                    '**/*Res.class',
-                    '**/*Res$*.class',
-                    '**/config/**',
-                    '**/configuration/**',
-                    '**/exception/**',
-                    '**/*Application.class',
-                    '**/Q*.class',
-                    '**/entity/**',
-                    '**/domain/**/*Entity.class',
-                    '**/domain/link/util/OgTagCrawler.class',
-                    "**/security/auth/**"
-            ])
-        }))
-    }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,60 +1,43 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<configuration>
-    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration packagingData="true">
 
-    <property name="CONSOLE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%-40.40logger{39}) : %msg%n"/>
+    <!-- CloudWatch Appender -->
+    <appender name="aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+        <layout>
+            <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+        </layout>
+        <logGroupName>/aws/linkiving/application</logGroupName>
+        <logStreamUuidPrefix>linkiving-server</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>30</retentionTimeDays>
+        <accessKeyId>${AWS_ACCESS_KEY_ID}</accessKeyId>
+        <secretAccessKey>${AWS_SECRET_ACCESS_KEY}</secretAccessKey>
+    </appender>
 
-    <property name="FILE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
-
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="console_log" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <pattern>%highlight(%-5level) %date [%thread] %cyan([%C{0} :: %M :: %L]) - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/application.log</file>
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
-
-    <springProfile name="local">
+    <springProfile name="!prod">
         <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="console_log"/>
         </root>
-    </springProfile>
-
-    <springProfile name="default">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ROLLING_FILE"/>
-        </root>
-        <logger level="DEBUG" name="org.hibernate.SQL"/>
-        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
-    </springProfile>
-
-    <springProfile name="dev">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ROLLING_FILE"/>
-        </root>
-        <logger level="DEBUG" name="org.hibernate.SQL"/>
-        <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
     </springProfile>
 
     <springProfile name="prod">
         <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ROLLING_FILE"/>
+            <appender-ref ref="console_log"/>
+            <appender-ref ref="aws_cloud_watch_log"/>
         </root>
     </springProfile>
+
+    <root level="INFO">
+        <appender-ref ref="console_log"/>
+    </root>
 
 </configuration>


### PR DESCRIPTION
## 관련 이슈

- close #44 

## PR 설명
* `build.gradle`에 `logback-awslogs-appender` 의존성 추가
* `logback-spring.xml` 설정 파일 추가
  - 로컬 개발: Active profiles에 `dev` 설정
  - 운영 배포: Active profiles를 `prod`로 설정하고 AWS 환경변수 필요 (`AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY`)
  - 환경변수 기반 AWS 인증
* AWS /aws/linkiving/application 로그 그룹으로 중앙화 관리
* 로컬 개발 시 비용 발생 없음, 운영 배포 시에만 `CloudWatch` 사용
### Test 결과
  - `dev` 프로필에서 `CloudWatch` 전송 비활성화 확인
  - `prod` 프로필에서 AWS 로그 그룹 생성 및 전송 성공
  - 로그 레벨별 정상 출력 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled centralized log streaming to AWS CloudWatch in production to improve observability, diagnostics, and log retention.
  * Maintains existing console logging; non-production environments continue to log to console only.
  * Tuned batching and flush behavior to reduce overhead while ensuring timely log delivery.
  * No impact on application functionality or APIs; changes are operational/monitoring focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->