### PR TITLE
GitHub Actions CI 워크플로우 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,65 @@
+name: ✨ Linkiving backend CI ✨
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ✨ Checkout repository
+        uses: actions/checkout@v5
+
+      - name: ✨ JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: ✨ Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: 🗂️ Create test application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          cat > ./src/main/resources/application.yml << EOF
+          server:
+            port: 8080
+          spring:
+            datasource:
+              driver-class-name: org.h2.Driver
+              url: jdbc:h2:mem:testdb
+              username: sa
+              password:
+            jpa:
+              hibernate:
+                ddl-auto: create-drop
+              show_sql: false
+          EOF
+
+      - name: ✨ Gradlew 권한 설정
+        run: chmod +x ./gradlew
+
+      - name: 🏗️ Gradle 빌드
+        run: ./gradlew build
+
+      - name: 🧪 테스트 실행
+        run: ./gradlew test
+
+      - name: 📊 테스트 결과 업로드
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results
+          path: build/reports/tests/test/

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,8 +40,8 @@ jobs:
             datasource:
               driver-class-name: org.h2.Driver
               url: jdbc:h2:mem:testdb
-              username: ${{ secrets.TEST_DB_USERNAME }} 
-              password: ${{ secrets.TEST_DB_PASSWORD }}   
+              username: ${{ secrets.TEST_DB_USERNAME }}
+              password: ${{ secrets.TEST_DB_PASSWORD }}
             jpa:
               hibernate:
                 ddl-auto: create-drop
@@ -57,9 +57,32 @@ jobs:
       - name: 🧪 테스트 실행
         run: ./gradlew test
 
+      - name: 📢 Discord 알림 (성공)
+        if: success()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: success
+          title: "✅ CI 빌드 성공!"
+          description: "모든 테스트가 통과했습니다."
+          color: 0x00ff00
+
+      - name: 📢 Discord 알림 (실패)
+        if: failure()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: failure
+          title: "❌ CI 빌드 실패!"
+          description: "테스트 또는 빌드에 실패했습니다."
+          color: 0xff0000
+
       - name: 📊 테스트 결과 업로드
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()  # 성공/실패 관계없이 항상 업로드
         with:
-          name: test-results
-          path: build/reports/tests/test/
+          name: test-results-${{ github.run_number }}
+          path: |
+            build/reports/tests/test/
+            build/test-results/test/
+          retention-days: 7  # 7일 후 자동 삭제

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,8 +40,8 @@ jobs:
             datasource:
               driver-class-name: org.h2.Driver
               url: jdbc:h2:mem:testdb
-              username: sa
-              password:
+              username: ${{ secrets.TEST_DB_USERNAME }} 
+              password: ${{ secrets.TEST_DB_PASSWORD }}   
             jpa:
               hibernate:
                 ddl-auto: create-drop


### PR DESCRIPTION
## 관련 이슈

- close #54 

## PR 설명
Linkiving 프로젝트에 CI 워크플로우를 추가했습니다.  
`push` 및 `pull_request` 이벤트 시 자동으로 실행되며, Gradle 빌드와 테스트를 수행하고 실패 시 테스트 리포트를 업로드하도록 구성했습니다.  

### 주요 변경 사항
- GitHub Actions 워크플로우 파일 추가
- JDK 17 환경 세팅
- Gradle 캐시 적용
- 테스트 실행 및 리포트 업로드 단계 포함

### 확인 사항
- push 이벤트 트리거 확인 완료
- PR 생성 시에도 CI가 정상 실행되는지 확인 필요

