### PR TITLE
전역 예외 처리 구조 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/common/BaseResponse.java
+++ b/src/main/java/com/sofa/linkiving/global/common/BaseResponse.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
 
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -35,12 +37,12 @@ public class BaseResponse<T> {
 			.build();
 	}
 
-	public static BaseResponse<String> error(HttpStatus status, String message, String errorCode) {
+	public static BaseResponse<String> error(ErrorCode errorCode) {
 		return BaseResponse.<String>builder()
-			.status(status)
+			.status(errorCode.getStatus())
 			.success(false)
-			.message(message)
-			.data(errorCode)
+			.message(errorCode.getMessage())
+			.data(errorCode.getCode())
 			.timestamp(LocalDateTime.now())
 			.build();
 	}

--- a/src/main/java/com/sofa/linkiving/global/error/code/CommonErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/global/error/code/CommonErrorCode.java
@@ -1,0 +1,27 @@
+package com.sofa.linkiving.global.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C-000", "서버 내부 오류가 발생하였습니다."),
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "C-001", "잘못된 요청입니다."),
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C-002", "유효하지 않은 입력입니다."),
+	TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "C-003", "입력 타입이 일치하지 않습니다."),
+	MISSING_REQUEST_PARAMS(HttpStatus.BAD_REQUEST, "C-004", "입력 파라미터가 필요합니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C-005", "로그인이 필요합니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "C-006", "리소스를 찾을 수 없습니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C-007", "허용되지 않은 HTTP 메소드입니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "C-008", "접근이 허용되지 않았습니다."),
+	NULL_POINTER(HttpStatus.INTERNAL_SERVER_ERROR, "C-009", "NullPointerException이 발생했습니다."),
+	HTTP_MEDIA_NOT_SUPPORT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "C-010", "지원하지 않는 미디어입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,88 @@
+package com.sofa.linkiving.global.error.handler;
+
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.error.code.CommonErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/* =========================
+	  도메인 비즈니스 예외
+	  ========================= */
+	@ExceptionHandler(BusinessException.class)
+	public BaseResponse<String> handleBusinessException(BusinessException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(ex.getErrorCode());
+	}
+
+	/* =========================
+       검증/바인딩 예외
+       ========================= */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public BaseResponse<String> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public BaseResponse<String> handleConstraintViolation(ConstraintViolationException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public BaseResponse<String> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.TYPE_MISMATCH);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public BaseResponse<String> handleMissingParam(MissingServletRequestParameterException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.MISSING_REQUEST_PARAMS);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public BaseResponse<String> handleNotReadable(HttpMessageNotReadableException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.BAD_REQUEST);
+	}
+
+	/* =========================
+	 HTTP 관련 예외
+	 ========================= */
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public BaseResponse<String> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.METHOD_NOT_ALLOWED);
+	}
+
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public BaseResponse<String> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.HTTP_MEDIA_NOT_SUPPORT);
+	}
+
+	/* =========================
+       그 외 모든 예외
+       ========================= */
+	@ExceptionHandler(Exception.class)
+	public BaseResponse<String> handleException(Exception ex) {
+		log.error(ex.getMessage(), ex);
+		return BaseResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #56 

## PR 설명

### BaseResponse
- 기존 `error(HttpStatus, String, String)` 를 `error(ErrorCode)` 로 변경
- ErrorCode 기반 응답 변환으로 일관성 강화

### CommonErrorCode 구조 추가
- `CommonErrorCode enum` 생성
- 필드: `HttpStatus status`, `String code`, `String message`
- `INVALID_PARAMETER,` `INTERNAL_SERVER_ERROR` 등 기본 예외 코드 정의

### GlobalExceptionHandler
- `@RestControllerAdvice` 기반 전역 예외 처리기 추가
- `@ExceptionHandler` 통해 `BusinessException`, `MethodArgumentNotValidException`, `Exception` 등 공통 처리
- 응답은 BaseResponse.error(ErrorCode) 형태로 반환

## 예외 응답 예시
- DTO 유효성 실패
``` Json
{
  "status": 400,
  "success": false,
  "message": "잘못된 요청 파라미터입니다.",
  "data": "C-001",
  "timestamp": "2025-09-28T12:00:00"
}
```

- 서버 내부 오류
```Json
{
  "status": 500,
  "success": false,
  "message": "서버 내부 오류가 발생했습니다.",
  "data": "C-999",
  "timestamp": "2025-09-28T12:00:00"
}
```