### PR TITLE
BaseResponse error 응답 시 HTTP Status 코드 미반영 문제 수정

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.sofa.linkiving.global.error.handler;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -12,6 +13,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import com.sofa.linkiving.global.common.BaseResponse;
 import com.sofa.linkiving.global.error.code.CommonErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.error.util.ErrorResponse;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -24,65 +26,66 @@ public class GlobalExceptionHandler {
 	  도메인 비즈니스 예외
 	  ========================= */
 	@ExceptionHandler(BusinessException.class)
-	public BaseResponse<String> handleBusinessException(BusinessException ex) {
+	public ResponseEntity<BaseResponse<String>> handleBusinessException(BusinessException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(ex.getErrorCode());
+		return ErrorResponse.build(ex.getErrorCode());
 	}
 
 	/* =========================
        검증/바인딩 예외
        ========================= */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public BaseResponse<String> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+	public ResponseEntity<BaseResponse<String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE);
+		return ErrorResponse.build(CommonErrorCode.INVALID_INPUT_VALUE);
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
-	public BaseResponse<String> handleConstraintViolation(ConstraintViolationException ex) {
+	public ResponseEntity<BaseResponse<String>> handleConstraintViolation(ConstraintViolationException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.INVALID_INPUT_VALUE);
+		return ErrorResponse.build(CommonErrorCode.INVALID_INPUT_VALUE);
 	}
 
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
-	public BaseResponse<String> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+	public ResponseEntity<BaseResponse<String>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.TYPE_MISMATCH);
+		return ErrorResponse.build(CommonErrorCode.TYPE_MISMATCH);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
-	public BaseResponse<String> handleMissingParam(MissingServletRequestParameterException ex) {
+	public ResponseEntity<BaseResponse<String>> handleMissingParam(MissingServletRequestParameterException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.MISSING_REQUEST_PARAMS);
+		return ErrorResponse.build(CommonErrorCode.MISSING_REQUEST_PARAMS);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public BaseResponse<String> handleNotReadable(HttpMessageNotReadableException ex) {
+	public ResponseEntity<BaseResponse<String>> handleNotReadable(HttpMessageNotReadableException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.BAD_REQUEST);
+		return ErrorResponse.build(CommonErrorCode.BAD_REQUEST);
 	}
 
 	/* =========================
 	 HTTP 관련 예외
 	 ========================= */
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public BaseResponse<String> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+	public ResponseEntity<BaseResponse<String>> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.METHOD_NOT_ALLOWED);
+		return ErrorResponse.build(CommonErrorCode.METHOD_NOT_ALLOWED);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-	public BaseResponse<String> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
+	public ResponseEntity<BaseResponse<String>> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.HTTP_MEDIA_NOT_SUPPORT);
+		return ErrorResponse.build(CommonErrorCode.HTTP_MEDIA_NOT_SUPPORT);
 	}
 
 	/* =========================
        그 외 모든 예외
        ========================= */
 	@ExceptionHandler(Exception.class)
-	public BaseResponse<String> handleException(Exception ex) {
+	public ResponseEntity<BaseResponse<String>> handleException(Exception ex) {
 		log.error(ex.getMessage(), ex);
-		return BaseResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR);
+		return ErrorResponse.build(CommonErrorCode.INTERNAL_SERVER_ERROR);
 	}
+
 }

--- a/src/main/java/com/sofa/linkiving/global/error/util/ErrorResponse.java
+++ b/src/main/java/com/sofa/linkiving/global/error/util/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.global.error.util;
+
+import org.springframework.http.ResponseEntity;
+
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+public class ErrorResponse {
+	private ErrorResponse() {
+	}
+
+	public static ResponseEntity<BaseResponse<String>> build(ErrorCode code) {
+		return ResponseEntity.status(code.getStatus())
+			.body(BaseResponse.error(code));
+	}
+}


### PR DESCRIPTION
- `BaseResponse`를 `body` 값으로 가지는 `ResponseEntity` 빌더

## 관련 이슈

- close #61 

## 문제 상황
- 기존 `BaseResponse.error()` 호출 시, 응답 바디에는 `status` 값이 담기지만 HTTP 응답 헤더의 Status 코드는 항상 `200 OK`로 내려가는 문제 존재

## PR 설명
- 애러 핸들러 응답 형태를 `ResponseEntity.status(errorCode.getStatus()).body(BaseResponse.error(errorCode))`로 변경
  - HTTP 응답 헤더와 바디의 Status 값이 일치하도록 동작 
- `ErrorResponse` 유틸 추가
   - `BaseResponse`를 `body` 값으로 가지는 `ResponseEntity` 빌더 메소드 추가
## 동작 예시
- 기존 
<img width="825" height="209" alt="image" src="https://github.com/user-attachments/assets/402558ce-4335-4afe-af59-a5b3092943fd" />
- 수정 후
<img width="843" height="224" alt="image" src="https://github.com/user-attachments/assets/a0b842e6-e60b-4041-88d5-6f148e81feef" />
