### PR TITLE
회원가입 API 개발

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.member.controller;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberRes;
 import com.sofa.linkiving.global.common.BaseResponse;
 
@@ -9,6 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "User")
 public interface MemberApi {
+	@Operation(summary = "회원가입", description = "이메일, 비밀번호를 통한 회원가입을 진행합니다.")
+	BaseResponse<MemberRes> signup(SignupReq req);
+
 	@Operation(summary = "로그인", description = "이메일, 비밀번호를 통해 로그인을 진행합니다.")
 	BaseResponse<MemberRes> login(LoginReq req);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberRes;
 import com.sofa.linkiving.domain.member.service.MemberService;
 import com.sofa.linkiving.global.common.BaseResponse;
@@ -19,6 +20,14 @@ import lombok.RequiredArgsConstructor;
 public class MemberController implements MemberApi {
 
 	private final MemberService memberService;
+
+	@Override
+	@PostMapping("/signup")
+	public BaseResponse<MemberRes> signup(@RequestBody @Validated SignupReq req) {
+		MemberRes signup = memberService.signup(req);
+
+		return BaseResponse.success(signup, "회원 가입에 성공하였습니다.");
+	}
 
 	@Override
 	@PostMapping("/login")

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/request/SignupReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/request/SignupReq.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupReq(
+	@Schema(description = "이메일")
+	@Email
+	@NotBlank
+	String email,
+	@Schema(description = "비밀번호")
+	@NotBlank
+	String password
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberRes.java
@@ -13,4 +13,8 @@ public record MemberRes(
 	public MemberRes(Member member) {
 		this(member.getId(), member.getEmail());
 	}
+
+	public static MemberRes from(Member member) {
+		return new MemberRes(member.getId(), member.getEmail());
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -2,7 +2,9 @@ package com.sofa.linkiving.domain.member.entity;
 
 import java.util.regex.Pattern;
 
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.common.BaseEntity;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,7 +20,7 @@ public class Member extends BaseEntity {
 	private static final String EMAIL_REGEX = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z]{2,6}$";
 	private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX, Pattern.CASE_INSENSITIVE);
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 	@Column(nullable = false)
 	private String password;
@@ -26,8 +28,7 @@ public class Member extends BaseEntity {
 	@Builder
 	public Member(String email, String password) {
 		if (!isValidEmail(email)) {
-			// TODO: Global Error Handle 추가 시 변경 필요
-			throw new IllegalArgumentException("Invalid email format: " + email);
+			throw new BusinessException(MemberErrorCode.INVALID_EMAIL_FORMAT);
 		}
 		this.email = email;
 		this.password = password;

--- a/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
+	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M-000", "유효하지 않은 이메일 형식입니다."),
+	DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "M-001", "이미 존재하는 이메일입니다."),
 	USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "M-002", "존재하지 않는 유저입니다."),
 	INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "M-003", "잘못된 비밀번호입니다.");
 

--- a/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
@@ -2,10 +2,14 @@ package com.sofa.linkiving.domain.member.repository;
 
 import java.util.Optional;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.sofa.linkiving.domain.member.entity.Member;
 
-public interface MemberRepository extends CrudRepository<Member, Long> {
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	boolean existsMemberByEmail(String email);
+
 	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.domain.member.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandService {
+	private final MemberRepository memberRepository;
+
+	public Member addUser(String email, String password) {
+		Member member = Member.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		return memberRepository.save(member);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberQueryService.java
@@ -14,6 +14,10 @@ import lombok.RequiredArgsConstructor;
 public class MemberQueryService {
 	private final MemberRepository memberRepository;
 
+	boolean existsMemberByEmail(String email) {
+		return memberRepository.existsMemberByEmail(email);
+	}
+
 	public Member getUser(String email) {
 
 		return memberRepository.findByEmail(email).orElseThrow(

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
@@ -18,7 +19,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class MemberService {
+	private final MemberCommandService memberCommandService;
 	private final MemberQueryService memberQueryService;
+
+	public MemberRes signup(SignupReq req) {
+
+		if (memberQueryService.existsMemberByEmail(req.email())) {
+			throw new BusinessException(MemberErrorCode.DUPLICATE_EMAIL);
+		}
+
+		// TODO: Change this when Security dependency is added later
+		String encoded = Base64.getEncoder()
+			.encodeToString(req.password().getBytes(StandardCharsets.UTF_8));
+
+		Member member = memberCommandService.addUser(req.email(), encoded);
+
+		return MemberRes.from(member);
+	}
 
 	@Transactional(readOnly = true)
 	public MemberRes login(LoginReq req) {

--- a/src/main/java/com/sofa/linkiving/global/common/BaseEntity.java
+++ b/src/main/java/com/sofa/linkiving/global/common/BaseEntity.java
@@ -21,18 +21,18 @@ import lombok.NoArgsConstructor;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	@CreatedDate
-	@Column(name = "created_at", updatable = false)
-	private LocalDateTime createdAt;
 	@LastModifiedDate
 	@Column(name = "updated_at")
 	protected LocalDateTime updatedAt;
 	// reserved for future soft delete implementation
 	@Column(name = "is_delete")
 	protected boolean isDelete = false;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
 
 	public boolean isDeleted() {
 		return isDelete;

--- a/src/test/java/com/sofa/linkiving/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/entity/MemberTest.java
@@ -1,15 +1,18 @@
 package com.sofa.linkiving.domain.member.entity;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 public class MemberTest {
 	@Test
 	void shouldCreateMemberWithValidEmail() {
 		// given
-		String email = "test@example.com";
-		String password = "password123";
+		String email = "test@test.com";
+		String password = "test";
 
 		// when
 		Member member = Member.builder()
@@ -25,8 +28,8 @@ public class MemberTest {
 	@Test
 	void shouldThrowExceptionForInvalidEmail() {
 		// given
-		String invalidEmail = "invalid-email";
-		String password = "password123";
+		String invalidEmail = "test";
+		String password = "test";
 
 		// when & then
 		assertThatThrownBy(() -> Member.builder()
@@ -34,6 +37,8 @@ public class MemberTest {
 			.password(password)
 			.build()
 		)
-			.isInstanceOf(IllegalArgumentException.class);
+			.isInstanceOfSatisfying(BusinessException.class, ex ->
+				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INVALID_EMAIL_FORMAT)
+			);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberCommandServiceTest.java
@@ -1,0 +1,59 @@
+package com.sofa.linkiving.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class MemberCommandServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@InjectMocks
+	MemberCommandService memberCommandService;
+
+	@Test
+	@DisplayName("유효한 이메일과 인코딩된 비밀번호로 회원 생성")
+	void shouldCreateMemberWithValidEmailAndPassword() {
+		// given
+		String email = "test@test.com";
+		String password = "test";
+
+		Member saved = Member.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		when(memberRepository.save(any(Member.class))).thenReturn(saved);
+
+		// when
+		Member result = memberCommandService.addUser(email, password);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getEmail()).isEqualTo(email);
+		assertThat(result.getPassword()).isEqualTo(password);
+
+		// verify interaction
+		ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+		verify(memberRepository, times(1)).save(captor.capture());
+		verifyNoMoreInteractions(memberRepository);
+
+		Member captured = captor.getValue();
+		assertThat(captured.getEmail()).isEqualTo(email);
+		assertThat(captured.getPassword()).isEqualTo(password);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -1,11 +1,14 @@
 package com.sofa.linkiving.domain.member.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
@@ -24,10 +28,65 @@ import com.sofa.linkiving.global.error.exception.BusinessException;
 @ActiveProfiles("test")
 public class MemberServiceTest {
 	@Mock
-	MemberQueryService memberQueryService;
-
+	MemberCommandService memberCommandService;
 	@InjectMocks
 	MemberService memberService;
+	@Mock
+	private MemberQueryService memberQueryService;
+
+	@Test
+	@DisplayName("중복된 이메일로 회원가입 시 예외 발생")
+	void shouldThrowBusinessExceptionWhenEmailAlreadyExists() {
+		// given
+		String email = "test@example.com";
+		String password = "plainPassword";
+		SignupReq req = new SignupReq(email, password);
+
+		when(memberQueryService.existsMemberByEmail(email)).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> memberService.signup(req))
+			.isInstanceOfSatisfying(BusinessException.class, ex ->
+				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.DUPLICATE_EMAIL)
+			);
+
+		// then: addUser는 호출되지 않아야 함
+		verify(memberQueryService, times(1)).existsMemberByEmail(email);
+		verifyNoInteractions(memberCommandService);
+	}
+
+	@Test
+	@DisplayName("정상 회원가입 시 비밀번호가 Base64로 인코딩되어 저장")
+	void shouldSignupAndEncodePassword() {
+		// given
+		String email = "test@test.com";
+		String password = "test";
+		SignupReq req = new SignupReq(email, password);
+
+		String expectedEncoded = Base64.getEncoder()
+			.encodeToString(req.password().getBytes(StandardCharsets.UTF_8));
+
+		Member saved = Member.builder()
+			.email(req.email())
+			.password(expectedEncoded)
+			.build();
+
+		when(memberQueryService.existsMemberByEmail(email)).thenReturn(false);
+		when(memberCommandService.addUser(eq(req.email()), eq(expectedEncoded)))
+			.thenReturn(saved);
+
+		// when
+		MemberRes res = memberService.signup(req);
+
+		// then
+		assertThat(res).isNotNull();
+		assertThat(res.email()).isEqualTo(req.email());
+
+		// verify
+		verify(memberQueryService, times(1)).existsMemberByEmail(email);
+		verify(memberCommandService, times(1)).addUser(email, expectedEncoded);
+		verifyNoMoreInteractions(memberCommandService, memberQueryService);
+	}
 
 	@Test
 	@DisplayName("정상 로그인")
@@ -45,8 +104,8 @@ public class MemberServiceTest {
 		MemberRes res = memberService.login(req);
 
 		// then
-		assertThat(res).isNotNull();
-		assertThat(res.email()).isEqualTo(email);
+		AssertionsForClassTypes.assertThat(res).isNotNull();
+		AssertionsForClassTypes.assertThat(res.email()).isEqualTo(email);
 
 		verify(memberQueryService, times(1)).getUser(email);
 	}
@@ -68,7 +127,7 @@ public class MemberServiceTest {
 		// when & then
 		assertThatThrownBy(() -> memberService.login(req))
 			.isInstanceOfSatisfying(BusinessException.class, ex ->
-				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INCORRECT_PASSWORD)
+				AssertionsForClassTypes.assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INCORRECT_PASSWORD)
 			);
 
 		verify(memberQueryService, times(1)).getUser(email);


### PR DESCRIPTION
## 관련 이슈

- close #47 

## PR 설명
- 사용자는 이메일과 비밀번호를 통해 회원가입 요청 가능
- 비밀번호는 추후 보안 모듈(Spring Security) 도입 전까지 Base64 인코딩 방식으로 임시 처리
- 중복 이메일 가입 시 `DUPLICATE_EMAIL` 예외를 반환

## 코드 변경 사항

### Controller
#### `MemberController`
  - `/signup POST` 엔드포인트 추가
  - 성공 시 `BaseResponse<MemberRes>` 반환
  
### Service
#### `MemberService` 
  - 회원가입 요청을 받아 Command/Query 레이어 호출 
    - 중복 이메일 여부 확인
    - `Member` 엔티티 저장
  - 비밀번호 Base64 인코딩
  - 성공 시 `MemberRes` 반환
#### `MemberCommandService`
  - `Member` 엔티티 생성 및 저장 처리
#### `MemberQueryService`
  - `MemberRepository`를 통한 중복 이메일 검증
 
 ### DTO
 #### `SignupReq`
   - 회원가입 요청 DTO
   - 필드
   
       |  필드명  |  타입  |  설명  | Validation |
       | :---- | :---- | :---- | :---- |
       | `email` | String | 사용자 이메일 | 이메일 형식, 값 존재 여부 |
       | `password` | String | 사용자 비밀번호 | 값 존재 여부 |
#### `MemberRes`
  - 가입 완료 후 사용자 기본 정보 반환
  - `Member` -> `MeberRes` 변환 메소드
  - 필드
  
    |  필드명  |  타입  |  설명  |
       | :---- | :---- | :---- |
       | `userId` | String | 유저 고유 번호 |
       | `email` | String | 유저 이메일 |

#### ErrorCode
#### `MemberErrorCode`
  - 애러 코드 

    | 명칭 | 타입 | 코드 | 내용 |
    | :---- | :----- | :----- | :----- |
    | INVALID_EMAIL_FORMAT | `BAD_REQUEST` | M-000 | 유효하지 않은 이메일 형식입니다. |
    | DUPLICATE_EMAIL | `BAD_REQUEST` | M-001 | 이미 존재하는 이메일입니다. |

## 테스트코드
### 단위 테스트 
#### `MemberCommandServiceTest`
  - 유효한 이메일과 인코딩된 비밀번호로 회원 생성 검증
#### `MemberServiceTest`
   - 중복 이메일 예외 발생 검증
   - 정상 회원가입 시 Base64 인코딩 검증

#### 통합 테스트 
#### `MemberApiIntegrationTest`
   - `/api/members/signup` 성공 → 200 OK + 응답 데이터 검증
   - `/api/members/signup` 실패 → 400 BAD_REQUEST + DUPLICATE_EMAIL 코드 검증
   
 ## API 호출 결과 예시
### 성공
<img width="422" height="271" alt="image" src="https://github.com/user-attachments/assets/e30c3018-4045-4b82-9b1b-5f23f9c9dd81" />

### 실패
<img width="498" height="222" alt="image" src="https://github.com/user-attachments/assets/e32c000b-ab13-4db7-b224-e9e7c6e1a09d" />

