### PR TITLE
로그인 API 개발

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
@@ -1,0 +1,14 @@
+package com.sofa.linkiving.domain.member.controller;
+
+import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.response.MemberRes;
+import com.sofa.linkiving.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User")
+public interface MemberApi {
+	@Operation(summary = "로그인", description = "이메일, 비밀번호를 통해 로그인을 진행합니다.")
+	BaseResponse<MemberRes> login(LoginReq req);
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.sofa.linkiving.domain.member.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.response.MemberRes;
+import com.sofa.linkiving.domain.member.service.MemberService;
+import com.sofa.linkiving.global.common.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/member")
+public class MemberController implements MemberApi {
+
+	private final MemberService memberService;
+
+	@Override
+	@PostMapping("/login")
+	public BaseResponse<MemberRes> login(@Validated @RequestBody LoginReq req) {
+		MemberRes login = memberService.login(req);
+
+		return BaseResponse.success(login, "로그인에 성공하였습니다.");
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/request/LoginReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/request/LoginReq.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginReq(
+	@Schema(description = "이메일")
+	@Email
+	@NotBlank
+	String email,
+	@Schema(description = "비밀번호")
+	@NotBlank
+	String password
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberRes.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.domain.member.dto.response;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberRes(
+	@Schema(description = "유저 고유 번호")
+	Long userId,
+	@Schema(description = "유저 이메일")
+	String email
+) {
+	public MemberRes(Member member) {
+		this(member.getId(), member.getEmail());
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -36,4 +36,8 @@ public class Member extends BaseEntity {
 	private boolean isValidEmail(String email) {
 		return EMAIL_PATTERN.matcher(email).matches();
 	}
+
+	public boolean verifyPassword(String rawPassword) {
+		return this.password.equals(rawPassword);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.sofa.linkiving.domain.member.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "M-002", "존재하지 않는 유저입니다."),
+	INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "M-003", "잘못된 비밀번호입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.sofa.linkiving.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+
+public interface MemberRepository extends CrudRepository<Member, Long> {
+	Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberQueryService.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.domain.member.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberQueryService {
+	private final MemberRepository memberRepository;
+
+	public Member getUser(String email) {
+
+		return memberRepository.findByEmail(email).orElseThrow(
+			() -> new BusinessException(MemberErrorCode.USER_NOT_FOUND)
+		);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
@@ -1,0 +1,37 @@
+package com.sofa.linkiving.domain.member.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.response.MemberRes;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberQueryService memberQueryService;
+
+	@Transactional(readOnly = true)
+	public MemberRes login(LoginReq req) {
+		Member member = memberQueryService.getUser(req.email());
+
+		// TODO: Change this when Security dependency is added later
+		String encoded = Base64.getEncoder()
+			.encodeToString(req.password().getBytes(StandardCharsets.UTF_8));
+
+		if (!member.verifyPassword(encoded)) {
+			throw new BusinessException(MemberErrorCode.INCORRECT_PASSWORD);
+		}
+
+		return new MemberRes(member);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.sofa.linkiving.domain.member.integration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class MemberApiIntegrationTest {
+	private static final String BASE_URL = "/v1/member";
+	@Autowired
+	MockMvc mockMvc;
+	@Autowired
+	ObjectMapper objectMapper;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("올바른 이메일과 비밀번호로 로그인 시 성공")
+	void shouldLoginSuccess() throws Exception {
+		// given
+		String url = BASE_URL + "/login";
+
+		String email = "test@test.com";
+		String rawPassword = "test";
+		String encoded = Base64.getEncoder()
+			.encodeToString(rawPassword.getBytes(StandardCharsets.UTF_8));
+
+		memberRepository.save(Member.builder()
+			.email(email)
+			.password(encoded)
+			.build());
+
+		LoginReq req = new LoginReq(email, rawPassword);
+
+		// when & then
+		mockMvc.perform(post(url)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req))
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.status").value("OK"))
+			.andExpect(jsonPath("$.data.email").value(email))
+			.andExpect(jsonPath("$.data.userId").isNumber())
+			.andExpect(jsonPath("$.message").value("로그인에 성공하였습니다."));
+
+		Member saved = memberRepository.findByEmail(email).orElseThrow();
+		assertThat(saved.getEmail()).isEqualTo(email);
+		assertThat(saved.getPassword()).isEqualTo(encoded);
+	}
+
+	@Test
+	@DisplayName("잘못된 비밀번호로 로그인 시 400과 INCORRECT_PASSWORD 코드 반환")
+	void shouldFailWhenIncorrectPassword() throws Exception {
+		// given
+		String url = BASE_URL + "/login";
+
+		String email = "test@test.com";
+		String correctPassword = "test";
+		String wrongPassword = "wrong";
+		String encoded = Base64.getEncoder()
+			.encodeToString(correctPassword.getBytes(StandardCharsets.UTF_8));
+
+		memberRepository.save(Member.builder()
+			.email(email)
+			.password(encoded)
+			.build());
+
+		LoginReq req = new LoginReq(email, wrongPassword);
+
+		// when & then
+		mockMvc.perform(post(url)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req))
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.status").value(MemberErrorCode.INCORRECT_PASSWORD.getStatus().name()))
+			.andExpect(jsonPath("$.message").value(MemberErrorCode.INCORRECT_PASSWORD.getMessage()))
+			.andExpect(jsonPath("$.data").value(MemberErrorCode.INCORRECT_PASSWORD.getCode()));
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberQueryServiceTest.java
@@ -1,0 +1,59 @@
+package com.sofa.linkiving.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberQueryServiceTest {
+	@Mock
+	MemberRepository memberRepository;
+
+	@InjectMocks
+	MemberQueryService memberQueryService;
+
+	@Test
+	@DisplayName("이메일로 회원 조회")
+	void shouldGetUserByEmail() {
+		// given
+		String email = "test@test.com";
+		String password = "test";
+		Member member = Member.builder().email(email).password(password).build();
+		given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
+
+		// when
+		Member result = memberQueryService.getUser(email);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getEmail()).isEqualTo(email);
+	}
+
+	@Test
+	@DisplayName("이메일로 회원 조회 실패 시 예외 발생")
+	void shouldThrowWhenUserNotFound() {
+		//given
+		String email = "test@test.com";
+		given(memberRepository.findByEmail(email)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> memberQueryService.getUser(email))
+			.isInstanceOfSatisfying(BusinessException.class,
+				ex -> assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.USER_NOT_FOUND)
+			);
+	}
+
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,76 @@
+package com.sofa.linkiving.domain.member.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.member.dto.request.LoginReq;
+import com.sofa.linkiving.domain.member.dto.response.MemberRes;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class MemberServiceTest {
+	@Mock
+	MemberQueryService memberQueryService;
+
+	@InjectMocks
+	MemberService memberService;
+
+	@Test
+	@DisplayName("정상 로그인")
+	void shouldLoginSuccessfully() {
+		// given
+		String email = "test@test.com";
+		String raw = "test";
+		String encoded = Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+		LoginReq req = new LoginReq(email, raw);
+
+		Member member = Member.builder().email(email).password(encoded).build();
+		given(memberQueryService.getUser(email)).willReturn(member);
+
+		// when
+		MemberRes res = memberService.login(req);
+
+		// then
+		assertThat(res).isNotNull();
+		assertThat(res.email()).isEqualTo(email);
+
+		verify(memberQueryService, times(1)).getUser(email);
+	}
+
+	@Test
+	@DisplayName("잘못된 비밀번호로 로그인 시 INCORRECT_PASSWORD 에러코드로 예외 발생")
+	void shouldThrowIncorrectPasswordErrorCodeWhenPasswordNotMatch() {
+		// given
+		String email = "test@test.com";
+		String correct = "correctPassword";
+		String incorrect = "incorrectPassword";
+		String encodedCorrect = Base64.getEncoder().encodeToString(correct.getBytes(StandardCharsets.UTF_8));
+
+		LoginReq req = new LoginReq(email, incorrect);
+
+		Member member = Member.builder().email(email).password(encodedCorrect).build();
+		given(memberQueryService.getUser(email)).willReturn(member);
+
+		// when & then
+		assertThatThrownBy(() -> memberService.login(req))
+			.isInstanceOfSatisfying(BusinessException.class, ex ->
+				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INCORRECT_PASSWORD)
+			);
+
+		verify(memberQueryService, times(1)).getUser(email);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #48 

## PR 설명
- `Member` 도메인에 로그인 기능 추가
- 사용자는 이메일과 비밀번호를 입력하여 인증 수행
- MVP 단계에서는 인증 토큰 없이 단순 자격 검증 방식으로 처리

## 코드 변경 사항
### Controller
#### `MemberController`
- `/login GET` 엔드포인트 추가
- 요청 시 `LoginReq` 검증 후 `MemberService.login()` 호출
- 로그인 성공 시 `BaseResponse<MemberRes>` 형태로 응답

### Service
#### `MemberService`
- 로그인 로직 구현
- 이메일 기반으로 회원 조회 → 비밀번호 일치 여부 검증
- 검증 실패 시 `BusinessException` 발생 (`INVALID_PASSWORD` 혹은 `NOT_FOUND_MEMBER`)
#### `MemberQueryService`
- `findByEmail(String email)` 로 회원 조회
- 회원 조회 실패 시 `BusinessException` 발생 ( `NOT_FOUND_MEMBER` )

### DTO
#### `LoginReq`
- 로그인 요청 DTO
   - 필드
   
       |  필드명  |  타입  |  설명  | Validation |
       | :---- | :---- | :---- | :---- |
       | `email` | String | 사용자 이메일 | 이메일 형식, 값 존재 여부 |
       | `password` | String | 사용자 비밀번호 | 값 존재 여부 |
       
#### `MemberRes`
  - 로그인 성공 시 회원 기본 정보 반환
  - `Member` -> `MeberRes` 변환 메소드
  - 필드
  
    |  필드명  |  타입  |  설명  |
       | :---- | :---- | :---- |
       | `userId` | String | 유저 고유 번호 |
       | `email` | String | 유저 이메일 |
       
### Entity
#### `Member`
- `verifyPassword` 메소드 추가
  - 입력 받은 비밀번호와 저장된 비밀번호 비교 후 결과 반환

### ErrorCode
#### `MemberErrorCode`
| 명칭 | 타입 | 코드 | 내용 |
| :---- | :----- | :----- | :----- |
| INVALID_PASSWORD | `BAD_REQUEST` | M-002 | 존재하지 않는 유저입니다. |
| INCORRECT_PASSWORD | `BAD_REQUEST` | M-003 | 잘못된 비밀번호입니다. |

## 테스트 코드
### `MemberApiIntegrationTest`
- 회원가입 후 로그인 요청 시 정상 응답 검증
- 잘못된 비밀번호 입력 시 400 응답 및 에러 메시지 확인

### `MemberServiceTest`
- `login()` 성공/실패 케이스 단위 테스트

### `MemberQueryServiceTest`
- 이메일로 회원 조회 검증

## API 호출 결과 예시
### 호출 성공
<img width="2108" height="281" alt="image" src="https://github.com/user-attachments/assets/22778374-a11b-470b-8604-52583cfabc61" />
### 호출 실패
<img width="2123" height="220" alt="image" src="https://github.com/user-attachments/assets/600661cc-3cc5-400d-a9e3-ad864c9a4148" />

