### PR TITLE
제네릭 EnumConverter 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -40,6 +38,12 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
 }
 

--- a/src/main/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverter.java
+++ b/src/main/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverter.java
@@ -1,0 +1,33 @@
+package com.sofa.linkiving.global.converter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public abstract class AbstractCodeEnumConverter<T extends Enum<T> & CodeEnum<E>, E>
+	implements AttributeConverter<T, E> {
+	private final Class<T> data;
+
+	protected AbstractCodeEnumConverter(Class<T> data) {
+		this.data = data;
+	}
+
+	@Override
+	public E convertToDatabaseColumn(T attribute) {
+		return (attribute == null) ? null : attribute.getCode();
+	}
+
+	@Override
+	public T convertToEntityAttribute(E code) {
+		if (Objects.isNull(code)) {
+			return null;
+		}
+		return Arrays.stream(data.getEnumConstants())
+			.filter(e -> e.getCode().equals(code))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Unknown code: " + code));
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/converter/CodeEnum.java
+++ b/src/main/java/com/sofa/linkiving/global/converter/CodeEnum.java
@@ -1,0 +1,5 @@
+package com.sofa.linkiving.global.converter;
+
+public interface CodeEnum<T> {
+	T getCode();
+}

--- a/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterJpaTest.java
+++ b/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterJpaTest.java
@@ -1,0 +1,61 @@
+package com.sofa.linkiving.global.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PersistenceContext;
+import lombok.Getter;
+import lombok.Setter;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AbstractCodeEnumConverterJpaTest {
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Test
+	@DisplayName("숫자 코드 컬럼을 통해 Enum을 저장·조회")
+	void shouldPersistAndLoadWithConverter() {
+		// given
+		TestEnumEntity testEnumEntity = new TestEnumEntity();
+		testEnumEntity.setName("hello");
+		testEnumEntity.setStatus(TestEnum.B); // code=2
+
+		em.persist(testEnumEntity);
+		em.flush();
+		em.clear();
+
+		// when
+		TestEnumEntity found = em.find(TestEnumEntity.class, testEnumEntity.getId());
+
+		// then
+		assertThat(found).isNotNull();
+		assertThat(found.getStatus()).isEqualTo(TestEnum.B);
+		assertThat(found.getName()).isEqualTo("hello");
+	}
+
+	@Entity(name = "TestEntity")
+	@Getter
+	@Setter
+	public static class TestEnumEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		private String name;
+
+		@Column(nullable = false)
+		private TestEnum status;
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterTest.java
+++ b/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterTest.java
@@ -1,0 +1,40 @@
+package com.sofa.linkiving.global.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AbstractCodeEnumConverterTest {
+	private final TestEnum.TestEnumConverter converter = new TestEnum.TestEnumConverter();
+
+	@Test
+	@DisplayName("Enum을 Code로 변환")
+	void shouldConvertEnumToCode() {
+		assertThat(converter.convertToDatabaseColumn(TestEnum.A)).isEqualTo(1);
+		assertThat(converter.convertToDatabaseColumn(TestEnum.C)).isEqualTo(9);
+	}
+
+	@Test
+	@DisplayName("Code 값을 Enum으로 변환")
+	void shouldConvertCodeToEnum() {
+		assertThat(converter.convertToEntityAttribute(1)).isEqualTo(TestEnum.A);
+		assertThat(converter.convertToEntityAttribute(2)).isEqualTo(TestEnum.B);
+		assertThat(converter.convertToEntityAttribute(9)).isEqualTo(TestEnum.C);
+	}
+
+	@Test
+	@DisplayName("null 입력 시에도 예외 없이 정상 동작")
+	void shouldHandleNulls() {
+		assertThat(converter.convertToDatabaseColumn(null)).isNull();
+		assertThat(converter.convertToEntityAttribute(null)).isNull();
+	}
+
+	@Test
+	@DisplayName("알 수 없는 코드 입력 시 예외 발생")
+	void shouldThrowForUnknownCode() {
+		assertThatThrownBy(() -> converter.convertToEntityAttribute(999))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Unknown code");
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/converter/TestEnum.java
+++ b/src/test/java/com/sofa/linkiving/global/converter/TestEnum.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.global.converter;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TestEnum implements CodeEnum<Integer> {
+	A(1), B(2), C(9);
+	private final Integer code;
+
+	@Converter(autoApply = false)
+	static class TestEnumConverter extends AbstractCodeEnumConverter<TestEnum, Integer> {
+		public TestEnumConverter() {
+			super(TestEnum.class);
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #74 

## PR 설명
- `Enum` 타입을 DB 저장 정수로 저장하기 위한 공통 컨버터 설계

## 변경 사항

* `CodeEnum<T>`
  * Enum이 구현할 공통 인터페이스 (int getCode())

* `AbstractCodeEnumConverter`
  * `AttributeConverter<E, T>` 제네릭 추상 클래스
  * 정수 뿐만 아니라 다양한 타입을 저장 가능
  * 공통 변환 로직 제공
  * `convertToDatabaseColumn(E attribute)`: `T`
  * `convertToEntityAttribute(T dbColum)`: `E` (코드 미존재 시 `IllegalArgumentException`)

## 테스트
* 단위: enum ↔ code 왕복 변환, 미존재 코드 예외
* 통합: JPA 매핑 저장/조회 검증 (테스트 Enum 사용 )

## 사용 방법
* `TestEnum` 참고