### PR TITLE
Link 엔티티 재설계 및 Summary 엔티티 분리

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
@@ -29,22 +29,30 @@ public class Link extends BaseEntity {
 	private String title;
 
 	@Column(columnDefinition = "TEXT")
-	private String summary;
-
-	@Column(columnDefinition = "TEXT")
 	private String memo;
 
-	@Column(length = 2048)
+	@Column(name = "image_url", length = 2048)
 	private String imageUrl;
 
+	@Column(name = "metadata_json", columnDefinition = "TEXT")
+	private String metadataJson;
+
+	@Column(columnDefinition = "TEXT")
+	private String tags;
+
+	@Column(name = "is_important", nullable = false)
+	private boolean isImportant = false;
+
 	@Builder
-	public Link(Member member, String url, String title, String summary, String memo, String imageUrl) {
+	public Link(Member member, String url, String title, String memo, String imageUrl,
+		String metadataJson, String tags, boolean isImportant) {
 		this.member = member;
 		this.url = url;
 		this.title = title;
-		this.summary = summary;
 		this.memo = memo;
 		this.imageUrl = imageUrl;
+		this.metadataJson = metadataJson;
+		this.tags = tags;
+		this.isImportant = isImportant;
 	}
 }
-

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
@@ -1,0 +1,53 @@
+package com.sofa.linkiving.domain.link.entity;
+
+import com.sofa.linkiving.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Summary extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "link_id", nullable = false)
+	private Link link;
+
+	@Column(nullable = false)
+	private int version;
+
+	@Column(name = "summary_format", nullable = false, length = 64)
+	private String summaryFormat;
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	private String body;
+
+	@Column(name = "token_count")
+	private Integer tokenCount;
+
+	@Column(name = "created_by", length = 255)
+	private String createdBy;
+
+	@Column(nullable = false, length = 64)
+	private String status;
+
+	@Builder
+	public Summary(Link link, int version, String summaryFormat, String body,
+		Integer tokenCount, String createdBy, String status) {
+		this.link = link;
+		this.version = version;
+		this.summaryFormat = summaryFormat;
+		this.body = body;
+		this.tokenCount = tokenCount;
+		this.createdBy = createdBy;
+		this.status = status;
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/LinkTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/LinkTest.java
@@ -1,0 +1,66 @@
+package com.sofa.linkiving.domain.link.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+
+public class LinkTest {
+
+	@Test
+	void shouldCreateLinkWithRequiredFields() {
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		String url = "https://example.com";
+		String title = "Example Title";
+
+		Link link = Link.builder()
+			.member(member)
+			.url(url)
+			.title(title)
+			.build();
+
+		assertThat(link.getMember()).isEqualTo(member);
+		assertThat(link.getUrl()).isEqualTo(url);
+		assertThat(link.getTitle()).isEqualTo(title);
+		assertThat(link.isImportant()).isFalse();
+	}
+
+	@Test
+	void shouldCreateLinkWithAllFields() {
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		String url = "https://example.com";
+		String title = "Example Title";
+		String memo = "Test memo";
+		String imageUrl = "https://example.com/image.jpg";
+		String metadataJson = "{\"key\":\"value\"}";
+		String tags = "[\"tag1\",\"tag2\"]";
+		boolean isImportant = true;
+
+		Link link = Link.builder()
+			.member(member)
+			.url(url)
+			.title(title)
+			.memo(memo)
+			.imageUrl(imageUrl)
+			.metadataJson(metadataJson)
+			.tags(tags)
+			.isImportant(isImportant)
+			.build();
+
+		assertThat(link.getMember()).isEqualTo(member);
+		assertThat(link.getUrl()).isEqualTo(url);
+		assertThat(link.getTitle()).isEqualTo(title);
+		assertThat(link.getMemo()).isEqualTo(memo);
+		assertThat(link.getImageUrl()).isEqualTo(imageUrl);
+		assertThat(link.getMetadataJson()).isEqualTo(metadataJson);
+		assertThat(link.getTags()).isEqualTo(tags);
+		assertThat(link.isImportant()).isTrue();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
@@ -1,0 +1,78 @@
+package com.sofa.linkiving.domain.link.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+
+public class SummaryTest {
+
+	@Test
+	void shouldCreateSummaryWithRequiredFields() {
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		Link link = Link.builder()
+			.member(member)
+			.url("https://example.com")
+			.title("Test Title")
+			.build();
+		int version = 1;
+		String summaryFormat = "concise";
+		String body = "This is a summary";
+		String status = "completed";
+
+		Summary summary = Summary.builder()
+			.link(link)
+			.version(version)
+			.summaryFormat(summaryFormat)
+			.body(body)
+			.status(status)
+			.build();
+
+		assertThat(summary.getLink()).isEqualTo(link);
+		assertThat(summary.getVersion()).isEqualTo(version);
+		assertThat(summary.getSummaryFormat()).isEqualTo(summaryFormat);
+		assertThat(summary.getBody()).isEqualTo(body);
+		assertThat(summary.getStatus()).isEqualTo(status);
+	}
+
+	@Test
+	void shouldCreateSummaryWithAllFields() {
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		Link link = Link.builder()
+			.member(member)
+			.url("https://example.com")
+			.title("Test Title")
+			.build();
+		int version = 2;
+		String summaryFormat = "detail";
+		String body = "This is a detailed summary";
+		Integer tokenCount = 150;
+		String createdBy = "AI";
+		String status = "completed";
+
+		Summary summary = Summary.builder()
+			.link(link)
+			.version(version)
+			.summaryFormat(summaryFormat)
+			.body(body)
+			.tokenCount(tokenCount)
+			.createdBy(createdBy)
+			.status(status)
+			.build();
+
+		assertThat(summary.getLink()).isEqualTo(link);
+		assertThat(summary.getVersion()).isEqualTo(version);
+		assertThat(summary.getSummaryFormat()).isEqualTo(summaryFormat);
+		assertThat(summary.getBody()).isEqualTo(body);
+		assertThat(summary.getTokenCount()).isEqualTo(tokenCount);
+		assertThat(summary.getCreatedBy()).isEqualTo(createdBy);
+		assertThat(summary.getStatus()).isEqualTo(status);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #79 

## PR 설명
### 변경사항
최종 명세에 맞춰 Link 엔티티를 재설계하고, Summary를 별도 엔티티로 분리했습니다.

| 구분 | 내용 |
|------|------|
| Link 엔티티 | `summary` 필드 제거, `metadata_json`, `tags`, `is_important` 추가 |
| Summary 엔티티 | `Link`와 1:N 관계로 분리 (`version`, `format`, `body`, `status` 등) |
| 테스트 | `LinkTest`,`SummaryTes`t 추가 |

