### PR TITLE
JPA 테스트에서 enum 컨버터 적용 보장

### DIFF
--- a/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterJpaTest.java
+++ b/src/test/java/com/sofa/linkiving/global/converter/AbstractCodeEnumConverterJpaTest.java
@@ -45,6 +45,21 @@ class AbstractCodeEnumConverterJpaTest {
 		assertThat(found.getName()).isEqualTo("hello");
 	}
 
+	@Test
+	void shouldPersistCodeValue() {
+		TestEnumEntity entity = new TestEnumEntity();
+		entity.setStatus(TestEnum.B);
+		em.persist(entity);
+		em.flush();
+		Long id = entity.getId();
+
+		Number rawCode = (Number)em.createNativeQuery(
+				"select status from test_entity where id = :id")
+			.setParameter("id", id).getSingleResult();
+		assertThat(rawCode.intValue()).isEqualTo(2);
+		assertThat(rawCode).isEqualTo(2);
+	}
+
 	@Entity(name = "TestEntity")
 	@Getter
 	@Setter

--- a/src/test/java/com/sofa/linkiving/global/converter/TestEnum.java
+++ b/src/test/java/com/sofa/linkiving/global/converter/TestEnum.java
@@ -10,7 +10,7 @@ public enum TestEnum implements CodeEnum<Integer> {
 	A(1), B(2), C(9);
 	private final Integer code;
 
-	@Converter(autoApply = false)
+	@Converter(autoApply = true)
 	static class TestEnumConverter extends AbstractCodeEnumConverter<TestEnum, Integer> {
 		public TestEnumConverter() {
 			super(TestEnum.class);


### PR DESCRIPTION
## 관련 이슈

- close #81

## PR 설명

<img width="640" height="53" alt="image" src="https://github.com/user-attachments/assets/11e804ae-4d0c-43b2-a115-add2ff9e5239" />

Enum이 아닌, 실제 db에 저장되는 값을 비교하도록 수정했습니다.