### PR TITLE
CustomMemberService / CustomMemberDetail 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation "org.springframework.security:spring-security-test"
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
 }
 
 checkstyle {

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.domain.member.entity;
 
 import java.util.regex.Pattern;
 
+import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.common.BaseEntity;
 import com.sofa.linkiving.global.error.exception.BusinessException;
@@ -24,6 +25,8 @@ public class Member extends BaseEntity {
 	private String email;
 	@Column(nullable = false)
 	private String password;
+	@Column(nullable = false)
+	private Role role;
 
 	@Builder
 	public Member(String email, String password) {
@@ -32,6 +35,7 @@ public class Member extends BaseEntity {
 		}
 		this.email = email;
 		this.password = password;
+		this.role = Role.USER;
 	}
 
 	private boolean isValidEmail(String email) {

--- a/src/main/java/com/sofa/linkiving/domain/member/enums/Role.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/enums/Role.java
@@ -1,0 +1,24 @@
+package com.sofa.linkiving.domain.member.enums;
+
+import com.sofa.linkiving.global.converter.AbstractCodeEnumConverter;
+import com.sofa.linkiving.global.converter.CodeEnum;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role implements CodeEnum<Integer> {
+
+	USER(1), ADMIN(2);
+
+	private final Integer code;
+
+	@Converter(autoApply = true)
+	static class RoleConverter extends AbstractCodeEnumConverter<Role, Integer> {
+		public RoleConverter() {
+			super(Role.class);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/userdetails/CustomMemberDetail.java
+++ b/src/main/java/com/sofa/linkiving/security/userdetails/CustomMemberDetail.java
@@ -1,0 +1,48 @@
+package com.sofa.linkiving.security.userdetails;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.Role;
+
+public record CustomMemberDetail(Member member, Role role) implements UserDetails {
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+	}
+
+	@Override
+	public String getPassword() {
+		return member.getPassword() == null ? "" : member.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return member.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/userdetails/CustomMemberService.java
+++ b/src/main/java/com/sofa/linkiving/security/userdetails/CustomMemberService.java
@@ -1,0 +1,31 @@
+package com.sofa.linkiving.security.userdetails;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberQueryService;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomMemberService implements UserDetailsService {
+
+	private final MemberQueryService memberQueryService;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		try {
+			Member member = memberQueryService.getUser(email);
+			return new CustomMemberDetail(member, member.getRole());
+		} catch (BusinessException e) {
+			throw new UsernameNotFoundException("User not found: " + email, e);
+		}
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.member.integration;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -54,6 +55,8 @@ public class MemberApiIntegrationTest {
 		// when & then
 		mockMvc.perform(
 				post(url)
+					.with(csrf())
+					.with(user("tester").roles("USER"))
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(req))
 					.accept(MediaType.APPLICATION_JSON)
@@ -91,6 +94,8 @@ public class MemberApiIntegrationTest {
 		// when & then
 		mockMvc.perform(
 				post(url)
+					.with(csrf())
+					.with(user("tester").roles("USER"))
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(req))
 			)
@@ -122,6 +127,8 @@ public class MemberApiIntegrationTest {
 
 		// when & then
 		mockMvc.perform(post(url)
+				.with(csrf())
+				.with(user("tester").roles("USER"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(req))
 				.accept(MediaType.APPLICATION_JSON))
@@ -158,6 +165,8 @@ public class MemberApiIntegrationTest {
 
 		// when & then
 		mockMvc.perform(post(url)
+				.with(csrf())
+				.with(user("tester").roles("USER"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(req))
 				.accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/sofa/linkiving/global/security/userdetails/CustomMemberDetailTest.java
+++ b/src/test/java/com/sofa/linkiving/global/security/userdetails/CustomMemberDetailTest.java
@@ -1,0 +1,70 @@
+package com.sofa.linkiving.global.security.userdetails;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.Role;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+public class CustomMemberDetailTest {
+
+	@Test
+	@DisplayName("ROLE_ 프리픽스가 포함된 권한 문자열을 부여한다")
+	void shouldExposeAuthoritiesWithRolePrefix() {
+		// given
+		Role role = Role.ADMIN;
+		Member member = Member.builder()
+			.email("admin@example.com")
+			.password("pw")
+			.build();
+		CustomMemberDetail detail = new CustomMemberDetail(member, role);
+
+		// when
+		Collection<? extends GrantedAuthority> authorities = detail.getAuthorities();
+
+		// then
+		assertThat(authorities)
+			.extracting(GrantedAuthority::getAuthority)
+			.containsExactly("ROLE_" + role.name()); // 단일 권한 정책일 경우
+	}
+
+	@Test
+	@DisplayName("UserDetails username/password가 Member의 email/password와 연결된다")
+	void shouldExposeUsernameAndPasswordFromMember() {
+		// given
+		String email = "test@test.com";
+		String password = "test";
+		Member member = Member.builder()
+			.email(email)
+			.password(password)
+			.build();
+		CustomMemberDetail detail = new CustomMemberDetail(member, member.getRole());
+
+		// when & then
+		assertThat(detail.getUsername()).isEqualTo(email);
+		assertThat(detail.getPassword()).isEqualTo(password); // 실제 운영에선 인코딩 적용됨
+	}
+
+	@Test
+	@DisplayName("계정 상태 플래그는 true로 동작한다")
+	void shouldReturnTrueForAccountStateFlags() {
+		// given
+		Member member = Member.builder()
+			.email("user@example.com")
+			.password("pw")
+			.build();
+		CustomMemberDetail detail = new CustomMemberDetail(member, member.getRole());
+
+		// when & then
+		assertThat(detail.isAccountNonExpired()).isTrue();
+		assertThat(detail.isAccountNonLocked()).isTrue();
+		assertThat(detail.isCredentialsNonExpired()).isTrue();
+		assertThat(detail.isEnabled()).isTrue();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/security/userdetails/CustomMemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/global/security/userdetails/CustomMemberServiceTest.java
@@ -1,0 +1,75 @@
+package com.sofa.linkiving.global.security.userdetails;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberQueryService;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+import com.sofa.linkiving.security.userdetails.CustomMemberService;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class CustomMemberServiceTest {
+
+	@Mock
+	MemberQueryService memberQueryService;
+
+	@InjectMocks
+	CustomMemberService customMemberService;
+
+	@Test
+	@DisplayName("이메일로 Member를 조회해 CustomMemberDetail 반환")
+	void shouldLoadUserByUsernameAndReturnCustomMemberDetail() {
+		String email = "example@example.com";
+		String password = "password";
+
+		Member member = Member.builder()
+			.email(email)
+			.password(password)
+			.build();
+		given(memberQueryService.getUser(email)).willReturn(member);
+
+		// when
+		UserDetails userDetails = customMemberService.loadUserByUsername(email);
+
+		// then
+		assertThat(userDetails).isInstanceOf(CustomMemberDetail.class);
+		CustomMemberDetail detail = (CustomMemberDetail)userDetails;
+		assertThat(detail.getUsername()).isEqualTo(email);
+		assertThat(detail.getPassword()).isEqualTo(password);
+		assertThat(detail.getAuthorities())
+			.extracting(GrantedAuthority::getAuthority)
+			.containsExactly("ROLE_" + member.getRole().name());
+
+		// verify
+		verify(memberQueryService, times(1)).getUser(email);
+		verifyNoMoreInteractions(memberQueryService);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 이메일일 경우 UsernameNotFoundException 발생")
+	void shouldThrowWhenUserNotFound() {
+		// given
+		String email = "nope@example.com";
+		given(memberQueryService.getUser(email)).willThrow(new UsernameNotFoundException("not found"));
+
+		// when & then
+		assertThatThrownBy(() -> customMemberService.loadUserByUsername(email))
+			.isInstanceOf(UsernameNotFoundException.class);
+
+		// verify
+		verify(memberQueryService).getUser(email);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #78 

## PR 설명
JWT 기반 인증/인가 구조 도입의 일환으로,
Spring Security 환경에서 사용자 인증 처리를 담당할 `CustomMemberService` 및 `CustomMemberDetail`을 구현했습니다.
사용자 이메일을 통해 `Member`를 조회하고, 조회된 회원의 역할(Role)을 기반으로 접근 권한을 부여합니다.

## 변경 사항
* `CustomMemberService`
  * `UserDetailsService` 구현체
  * 이메일 통해 Member 조회
  * 조회된 회원의 Role을 CustomMemberDetail에 전달하여 반환

* `CustomMemberDetail`
  * `record` 기반 `UserDetails` 구현체
  * `ROLE_{role.name()}` 형식으로 권한 생성
  * 계정 상태 관련 메서드는 모두 true 처리

* `Member` / `Role`
  * `Member` 엔티티에 `Role` 필드 추가 (USER, ADMIN)

## 테스트 코드

* `CustomMemberServiceTest`
  * 이메일로 사용자 조회 후 `CustomMemberDetail` 반환 검증
  * 존재하지 않는 이메일 시 `UsernameNotFoundException` 예외 확인

* `CustomMemberDetailTest`
  * `ROLE_` prefix 권한 문자열 생성 확인
  * `username`/`password` 필드 매핑 검증
  * 계정 상태 플래그(`isAccountNonExpired`, `isEnabled` 등) true 확인
