### PR TITLE
Redis 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
+
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation "org.springframework.security:spring-security-test"

--- a/src/main/java/com/sofa/linkiving/infra/redis/RedisConfig.java
+++ b/src/main/java/com/sofa/linkiving/infra/redis/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.sofa.linkiving.infra.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+
+		Hibernate5JakartaModule hibernate5Module = new Hibernate5JakartaModule();
+		hibernate5Module.disable(Hibernate5JakartaModule.Feature.USE_TRANSIENT_ANNOTATION);
+		mapper.registerModule(hibernate5Module);
+
+		mapper.activateDefaultTyping(mapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL);
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+		redisTemplate.setValueSerializer(serializer);
+		redisTemplate.setHashValueSerializer(serializer);
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/infra/redis/RedisKeyRegistry.java
+++ b/src/main/java/com/sofa/linkiving/infra/redis/RedisKeyRegistry.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.infra.redis;
+
+import java.time.Duration;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RedisKeyRegistry {
+
+	public static final RedisKeySpec REFRESH_TOKEN = new RedisKeySpec("rt", Duration.ofDays(180));
+}

--- a/src/main/java/com/sofa/linkiving/infra/redis/RedisKeySpec.java
+++ b/src/main/java/com/sofa/linkiving/infra/redis/RedisKeySpec.java
@@ -1,0 +1,11 @@
+package com.sofa.linkiving.infra.redis;
+
+import java.time.Duration;
+
+public record RedisKeySpec(String prefix, Duration defaultTtl) {
+	public String key(String... parts) {
+		return parts == null || parts.length == 0
+			? prefix
+			: prefix + ":" + String.join(":", parts);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/infra/redis/RedisService.java
+++ b/src/main/java/com/sofa/linkiving/infra/redis/RedisService.java
@@ -1,0 +1,65 @@
+package com.sofa.linkiving.infra.redis;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final StringRedisTemplate redisTemplate;
+
+	/* -------- Raw key APIs -------- */
+
+	public void save(String key, String value) {
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		ops.set(key, value);
+	}
+
+	public void save(String key, String value, Duration ttl) {
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		ops.set(key, value, ttl);
+	}
+
+	public String get(String key) {
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		return ops.get(key);
+	}
+
+	public Boolean hasNoKey(String key) {
+		Boolean exists = redisTemplate.hasKey(key);
+		return !Boolean.TRUE.equals(exists);
+	}
+
+	public void delete(String key) {
+		redisTemplate.delete(key);
+	}
+
+	/* -------- Spec-based APIs -------- */
+
+	public void save(RedisKeySpec type, String value, String... keys) {
+		String key = type.key(keys);
+		Duration ttl = type.defaultTtl();
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		ops.set(key, value, ttl);
+	}
+
+	public String get(RedisKeySpec type, String... keys) {
+		ValueOperations<String, String> ops = redisTemplate.opsForValue();
+		return ops.get(type.key(keys));
+	}
+
+	public Boolean hasNoKey(RedisKeySpec type, String... keys) {
+		Boolean exists = redisTemplate.hasKey(type.key(keys));
+		return !Boolean.TRUE.equals(exists);
+	}
+
+	public void delete(RedisKeySpec type, String... keys) {
+		redisTemplate.delete(type.key(keys));
+	}
+}

--- a/src/test/java/com/sofa/linkiving/LinkivingApplicationTests.java
+++ b/src/test/java/com/sofa/linkiving/LinkivingApplicationTests.java
@@ -2,8 +2,10 @@ package com.sofa.linkiving;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class LinkivingApplicationTests {
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/infra/RedisKeySpecTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/RedisKeySpecTest.java
@@ -1,0 +1,28 @@
+package com.sofa.linkiving.infra;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.infra.redis.RedisKeySpec;
+
+public class RedisKeySpecTest {
+
+	@Test
+	@DisplayName("숫자 코드 컬럼을 통해 Enum을 저장·조회")
+	void shouldBuildKeyWithPrefixAndParts() {
+		// given
+		RedisKeySpec spec = new RedisKeySpec("rt", Duration.ofDays(180));
+
+		// when
+		String k1 = spec.key();
+		String k2 = spec.key("user", "123"); // rt:user:123
+
+		// then
+		assertThat(k1).isEqualTo("rt");
+		assertThat(k2).isEqualTo("rt:user:123");
+	}
+}

--- a/src/test/java/com/sofa/linkiving/infra/RedisServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/RedisServiceTest.java
@@ -1,0 +1,207 @@
+package com.sofa.linkiving.infra;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
+import com.sofa.linkiving.infra.redis.RedisKeySpec;
+import com.sofa.linkiving.infra.redis.RedisService;
+
+@ExtendWith(MockitoExtension.class)
+public class RedisServiceTest {
+
+	@Mock
+	StringRedisTemplate redisTemplate;
+
+	@Mock
+	ValueOperations<String, String> valueOps;
+
+	@InjectMocks
+	RedisService redisService;
+
+	/* -------- Raw key APIs -------- */
+
+	@Test
+	@DisplayName("키/값을 저장")
+	void shouldSaveValue() {
+		// given
+		String key = "key";
+		String value = "value";
+
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+		// when
+		redisService.save(key, value);
+
+		// then & verify
+		verify(valueOps, times(1)).set(key, value);
+	}
+
+	@Test
+	@DisplayName("TTL과 함께 키/값을 저장")
+	void shouldSaveValueWithTtl() {
+		// given
+		String key = "key";
+		String value = "value";
+		Duration ttl = Duration.ofMinutes(5);
+
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+		// when
+		redisService.save(key, value, ttl);
+
+		// then
+		verify(valueOps, times(1)).set(key, value, ttl);
+	}
+
+	@Test
+	@DisplayName("키로 값을 조회한다")
+	void shouldGetValue() {
+		// given
+		String key = "key";
+		String value = "value";
+		given(valueOps.get(key)).willReturn(value);
+
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+		// when
+		String result = redisService.get(key);
+
+		// then
+		assertThat(result).isEqualTo(value);
+		verify(valueOps, times(1)).get(key);
+	}
+
+	@Test
+	@DisplayName("키가 없으면 hasNo가 true를 반환한다")
+	void shouldReturnTrueWhenKeyNotExists() {
+		// given
+		String key = "key";
+
+		given(redisTemplate.hasKey(key)).willReturn(false);
+
+		// when
+		boolean result = redisService.hasNoKey(key);
+
+		// then
+		assertThat(result).isTrue();
+		verify(redisTemplate).hasKey(key);
+	}
+
+	@Test
+	@DisplayName("키가 있으면 hasNo가 false를 반환한다")
+	void shouldReturnFalseWhenKeyExists() {
+		// given
+		String key = "key";
+
+		given(redisTemplate.hasKey(key)).willReturn(true);
+
+		// when
+		boolean result = redisService.hasNoKey(key);
+
+		// then
+		assertThat(result).isFalse();
+		verify(redisTemplate).hasKey(key);
+	}
+
+	@Test
+	@DisplayName("키를 삭제한다")
+	void shouldDeleteKey() {
+		// when
+		String key = "key";
+
+		redisService.delete(key);
+
+		// then
+		verify(redisTemplate, times(1)).delete(key);
+	}
+
+	/* -------- Spec-based APIs -------- */
+
+	@Test
+	@DisplayName("스펙 기반 키 생성과 TTL 프로퍼티가 적용된다")
+	void shouldSaveUsingSpecAndTtlProperties() {
+		// given
+		RedisKeySpec spec = RedisKeyRegistry.REFRESH_TOKEN; //prefix: rt, duration: 180d
+		String token = "exampleToken";
+
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+		// when
+		redisService.save(spec, token, "user", "42");
+
+		// then
+		verify(valueOps, times(1)).set("rt:user:42", token, spec.defaultTtl());
+	}
+
+	@Test
+	@DisplayName("스펙과 파츠를 조합해 키로 값을 조회한다")
+	void shouldGetValueBySpecAndParts() {
+		// given
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+
+		RedisKeySpec spec = RedisKeyRegistry.REFRESH_TOKEN;
+		String expectedKey = "rt:user:42";
+		String token = "exampleToken";
+		given(valueOps.get(expectedKey)).willReturn(token);
+
+		// when
+		String value = redisService.get(spec, "user", "42");
+
+		// then
+		assertThat(value).isEqualTo(token);
+		verify(valueOps, times(1)).get(expectedKey);
+		verifyNoMoreInteractions(valueOps);
+	}
+
+	@Test
+	@DisplayName("스펙과 파츠를 조합해 hasKey=true/false를 판별한다")
+	void shouldCheckHasKeyBySpecAndParts() {
+		// given
+		RedisKeySpec spec = RedisKeyRegistry.REFRESH_TOKEN;
+		String expectedKey = "rt:user:42";
+
+		// when (exists = true)
+		given(redisTemplate.hasKey(expectedKey)).willReturn(true);
+		boolean exists = redisService.hasNoKey(spec, "user", "42");
+
+		// then
+		assertThat(exists).isFalse();
+		verify(redisTemplate, times(1)).hasKey(expectedKey);
+
+		// when (exists = false)
+		reset(redisTemplate);
+		given(redisTemplate.hasKey(expectedKey)).willReturn(false);
+		boolean notExists = redisService.hasNoKey(spec, "user", "42");
+
+		// then
+		assertThat(notExists).isTrue();
+		verify(redisTemplate, times(1)).hasKey(expectedKey);
+	}
+
+	@Test
+	@DisplayName("스펙과 파츠를 조합해 키를 삭제한다")
+	void shouldDeleteBySpecAndParts() {
+		// given
+		RedisKeySpec spec = RedisKeyRegistry.REFRESH_TOKEN;
+		String expectedKey = "rt:user:42";
+
+		// when
+		redisService.delete(spec, "user", "42");
+
+		// then
+		verify(redisTemplate, times(1)).delete(expectedKey);
+		verifyNoMoreInteractions(redisTemplate);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #84 

## PR 설명
JWT 기반 인증 구조에서 Refresh Token의 저장·검증을 위해 `Redis` 도입
Redis 연결 설정, TTL 프로퍼티 관리, Key 스펙 구조 정의, 서비스 및 테스트 코드까지 포함해 토큰 외에도 다양한 캐시·세션용 확장성을 고려한 구조로 구성

## PR 중점 사항
* `RedisService`의 경우 `RedisKeyRegistry`에 등록된 키 뿐만 아니라 `Raw` 타입의 `Key`와 `Value`에 대한 함수도 Overloading하여 구현하였는데 해당 함수의 필요성
* `RedisService`에 저장될 수 있는 `Value`에 대해서 `String` 값만 가능하도록 하였는데 확장성을 위해 Value에 저장되는 타입을 `Object` 값으로 설정하는 방향에 대한 필요성

## 변경 사항
* `RedisConfig`
  * `LettuceConnectionFactory` 기반 Redis 연결 설정
  * `RedisTemplate<String, Object> Bean` 등록
  * `StringRedisSerializer` + `GenericJackson2JsonRedisSerializer` 사용
  * `@EnableConfigurationProperties(RedisTtlProperties.class)` 및 `Jackson` 모듈 등록 (`JavaTimeModule`, `Hibernate5JakartaModule`)

* RedisService
  * `StringRedisTemplate`을 이용한 기본 `save`, `get`, `delete`, `hasNoKey` 기능 구현
  * TTL 지정 저장, 스펙 기반 키(RedisKeySpec) 저장/조회/삭제 지원
  * TTL은 RedisTtlProperties에서 동적으로 가져와 적용

* `RedisKeySpec`
  * 키 이름, prefix, 기본 TTL 등을 정의하는 스펙 인터페이스
  * 전달받은 값들을 prefix와 조합해 최종 Redis key를 생성해주는 `key()` 메소드 제공
  
* `RedisKeyRegistry`
  * `RedisKeySpec` 기반으로 하는 키의 기본 스펙(프리픽스, TTL 등)을 등록하고 관리

## 테스트 코드

* `RedisKeySpecTest`
  * prefix + parts 기반 키 문자열 조합 검증 (rt:user:123)
  
* `RedisServiceTest`
  * Raw 키 저장/조회/삭제 검증
  * TTL 적용 저장 검증
  * 스펙 기반 저장/조회/삭제 및 키 존재 여부 확인