### PR TITLE
GitHub Actions에서 `application.yml` 시크릿 미적용 문제 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -44,7 +44,7 @@ jobs:
           # yml 파일 생성
           
           touch ./application.yml
-          echo "APPLICATION" > ./application.yml
+          echo "$APPLICATION" > ./application.yml
 
         env:
           APPLICATION: ${{ secrets.APPLICATION }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -36,7 +36,11 @@ jobs:
           cd ./src/main/resources
           
           touch ./application-test.yml
-          echo "APPLICATION_TEST" > ./application-test.yml         
+          echo "$APPLICATION_TEST" > ./application-test.yml      
+
+        env:
+          APPLICATION_TEST: ${{ secrets.APPLICATION_TEST }}
+        shell: bash
 
       - name: ✨ Gradlew 권한 설정
         run: chmod +x ./gradlew


### PR DESCRIPTION
## 관련 이슈

- close #88 

## PR 설명

GitHub Actions 워크플로우에서 테스트 환경 구성 파일(application-test.yml)을 생성하는 단계에서,
실제 시크릿 값이 아닌 "APPLICATION_TEST" 문자열이 고정으로 파일에 기록되고 있었습니다.
그 결과 테스트 프로파일에서 올바른 환경 설정이 로드되지 않는 문제가 발생하여 이를 수정합니다.

## 변경 사항 요약

기존 하드코딩된 내용:
```
echo "APPLICATION_TEST" > ./application-test.yml
```

아래와 같이 실제 시크릿이 정상적으로 파일에 기록되도록 수정:
```
echo "$APPLICATION_TEST" > ./application-test.yml

env:
     APPLICATION_TEST: ${{ secrets.APPLICATION_TEST }}
shell: bash
```