### PR TITLE
CI 환경에서 test 프로파일 적용 (#78)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      SPRING_PROFILES_ACTIVE: test
 
     steps:
       - name: ✨ Checkout repository


### PR DESCRIPTION
## 관련 이슈

- close #78

## PR 설명

* GitHub Actions 워크플로우의 해당 job에 환경 변수 추가:
```YAML
env:
  SPRING_PROFILES_ACTIVE: test
```
* CI에서 실행되는 테스트가 항상 `spring.profiles.active=test` 상태로 동작하도록 보장
* `application-test.yml`이 CI 환경에서도 일관되게 로드되도록 프로파일 설정 정리
