### PR TITLE
OpenFeign 공통 설정 및 글로벌 예외 처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,17 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
+    // Spring Cloud OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    testImplementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
+
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+    }
 }
 
 checkstyle {

--- a/src/main/java/com/sofa/linkiving/LinkivingApplication.java
+++ b/src/main/java/com/sofa/linkiving/LinkivingApplication.java
@@ -2,10 +2,12 @@ package com.sofa.linkiving;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.sofa.linkiving.infra.feign")
 public class LinkivingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiErrorCode.java
@@ -1,0 +1,21 @@
+package com.sofa.linkiving.infra.feign;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExternalApiErrorCode implements ErrorCode {
+	EXTERNAL_API_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "E_000", "외부 API 통신 중 오류가 발생했습니다."),
+	EXTERNAL_API_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "E_001", "외부 API 응답 시간이 초과되었습니다."),
+	EXTERNAL_API_INVALID_RESPONSE(HttpStatus.BAD_GATEWAY, "E_002", "외부 API 응답 포맷이 올바르지 않습니다."),
+	EXTERNAL_API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E_003", "외부 API 인증에 실패했습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/infra/feign/GlobalFeignConfig.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/GlobalFeignConfig.java
@@ -1,0 +1,27 @@
+package com.sofa.linkiving.infra.feign;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.Logger;
+import feign.Request;
+import feign.codec.ErrorDecoder;
+
+@Configuration
+public class GlobalFeignConfig {
+
+	@Bean
+	public ErrorDecoder globalErrorDecoder() {
+		return new GlobalFeignErrorDecoder();
+	}
+
+	@Bean
+	public Logger.Level feignLoggerLevel() {
+		return Logger.Level.BASIC;
+	}
+
+	@Bean
+	public Request.Options feignRequestOptions() {
+		return new Request.Options(3000, 5000);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/infra/feign/GlobalFeignErrorDecoder.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/GlobalFeignErrorDecoder.java
@@ -1,0 +1,31 @@
+package com.sofa.linkiving.infra.feign;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class GlobalFeignErrorDecoder implements ErrorDecoder {
+	@Override
+	public Exception decode(String methodKey, Response response) {
+		ExternalApiErrorCode errorCode = mapErrorCode(response.status());
+		return new BusinessException(errorCode);
+	}
+
+	private ExternalApiErrorCode mapErrorCode(int status) {
+		if (status == 401) {
+			return ExternalApiErrorCode.EXTERNAL_API_UNAUTHORIZED;
+		}
+
+		if (status == 504) {
+			return ExternalApiErrorCode.EXTERNAL_API_TIMEOUT;
+		}
+
+		if (status >= 500) {
+			return ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR;
+		}
+
+		return ExternalApiErrorCode.EXTERNAL_API_INVALID_RESPONSE;
+	}
+
+}

--- a/src/test/java/com/sofa/linkiving/infra/feign/OpenFeignIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/feign/OpenFeignIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.sofa.linkiving.infra.feign;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.NONE,
+	properties = "spring.main.allow-bean-definition-overriding=true"
+)
+@EnableFeignClients(clients = TestExternalClient.class)
+public class OpenFeignIntegrationTest {
+
+	@TestConfiguration
+	static class TestConfig {
+		@Bean
+		public CorsConfigurationSource corsConfigurationSource() {
+			return new UrlBasedCorsConfigurationSource();
+		}
+	}
+
+	private static MockWebServer mockWebServer;
+
+	@Autowired
+	TestExternalClient testExternalClient;
+
+	@BeforeAll
+	static void setUp() throws Exception {
+		mockWebServer = new MockWebServer();
+		mockWebServer.start();
+	}
+
+	@AfterAll
+	static void tearDown() throws Exception {
+		mockWebServer.shutdown();
+	}
+
+	@DynamicPropertySource
+	static void overrideProps(DynamicPropertyRegistry registry) {
+		registry.add("test.external.base-url", () ->
+			"http://localhost:" + mockWebServer.getPort());
+	}
+
+	@Test
+	@DisplayName("정상 200 응답 시 FeignClient 통해 응답 본문 수신")
+	void shouldCallExternalApiSuccessfullyWhenResponse200() {
+		// given
+		mockWebServer.enqueue(
+			new MockResponse()
+				.setResponseCode(200)
+				.setBody("pong")
+		);
+
+		// when
+		String result = testExternalClient.ping();
+
+		// then
+		assertThat(result).isEqualTo("pong");
+	}
+
+	@Test
+	@DisplayName("HTTP 502 응답 시 GlobalFeignErrorDecoder 통해 ExternalApiErrorCode 매핑 예외 발생")
+	void shouldThrowBusinessExceptionWhenBadGateway() {
+		// given
+		mockWebServer.enqueue(
+			new MockResponse()
+				.setResponseCode(502)
+				.setBody("bad gateway")
+		);
+
+		// when & then
+		assertThatThrownBy(() -> testExternalClient.ping())
+			.isInstanceOf(BusinessException.class)
+			.satisfies(ex -> {
+				BusinessException be = (BusinessException)ex;
+				assertThat(be.getErrorCode())
+					.isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+			});
+	}
+}

--- a/src/test/java/com/sofa/linkiving/infra/feign/TestExternalClient.java
+++ b/src/test/java/com/sofa/linkiving/infra/feign/TestExternalClient.java
@@ -1,0 +1,15 @@
+package com.sofa.linkiving.infra.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+	name = "testExternalClient",
+	url = "${test.external.base-url}",
+	configuration = GlobalFeignConfig.class
+)
+public interface TestExternalClient {
+
+	@GetMapping("/ping")
+	String ping();
+}


### PR DESCRIPTION
## 관련 이슈

- close #95 

## PR 설명
외부 API와의 통신을 담당할 OpenFeign의 전역 설정을 구성하고, 통신 과정에서 발생할 수 있는 예외를 우리 서비스의 비즈니스 로직(`BusinessException`)으로 일관성 있게 처리하기 위한 구현체 및 테스트 코드를 작성했습니다.

### 1. OpenFeign 공통 설정 (`GlobalFeignConfig`)
* **Logger Level 설정**: 디버깅 및 모니터링을 위해 `BASIC` 레벨로 설정 (요청 메소드, URL, 응답 코드 등 로깅).
* **Timeout 설정**: 외부 서비스 지연 시 스레드 점유를 방지하기 위해 명시적으로 설정했습니다.
    * `connectTimeout`: 3000ms (3초)
    * `readTimeout`: 5000ms (5초)
* **ErrorDecoder 등록**: 커스텀 에러 디코더(`GlobalFeignErrorDecoder`)를 빈으로 등록하여 모든 Feign Client에 적용.

### 2. 글로벌 에러 핸들링 (`GlobalFeignErrorDecoder`, `ExternalApiErrorCode`)
* Feign 통신 시 발생하는 HTTP 에러 상태 코드를 가로채어 `BusinessException`으로 변환합니다.
* **에러 코드 매핑 전략**:
    * `401 Unauthorized` → `EXTERNAL_API_UNAUTHORIZED` (인증 실패)
    * `504 Gateway Timeout` → `EXTERNAL_API_TIMEOUT` (응답 시간 초과)
    * `500 이상 (Server Error)` → `EXTERNAL_API_COMMUNICATION_ERROR` (통신 오류)
    * 그 외 에러 → `EXTERNAL_API_INVALID_RESPONSE` (포맷/기타 오류)

### 3. 테스트 환경 구축 및 검증 (`OpenFeignIntegrationTest`)
* 실제 외부 서버에 의존하지 않고 테스트하기 위해 `MockWebServer`를 도입했습니다.
* **검증 시나리오**:
    * **성공 케이스 (200 OK)**: `TestExternalClient`를 통해 `pong` 응답이 정상적으로 바인딩되는지 확인.
    * **실패 케이스 (502 Bad Gateway)**: `GlobalFeignErrorDecoder`가 동작하여 `EXTERNAL_API_COMMUNICATION_ERROR` 코드를 가진 `BusinessException`이 던져지는지 검증.

## 리뷰 포인트
* **Timeout 설정값**: 현재 `3s / 5s`로 설정되어 있습니다. 타겟 외부 API의 일반적인 응답 속도를 고려했을 때 적절한지 의견 부탁드립니다.
* **Exception 매핑**: `ExternalApiErrorCode`에 정의된 에러 외에 추가적으로 핸들링해야 할 필수적인 상태 코드나 예외 상황이 있는지 확인 부탁드립니다.
