### PR TITLE
redis 파일 위치 변경

### DIFF
--- a/src/test/java/com/sofa/linkiving/infra/redis/RedisKeySpecTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/redis/RedisKeySpecTest.java
@@ -1,4 +1,4 @@
-package com.sofa.linkiving.infra;
+package com.sofa.linkiving.infra.redis;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -6,8 +6,6 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.sofa.linkiving.infra.redis.RedisKeySpec;
 
 public class RedisKeySpecTest {
 

--- a/src/test/java/com/sofa/linkiving/infra/redis/RedisServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/redis/RedisServiceTest.java
@@ -1,4 +1,4 @@
-package com.sofa.linkiving.infra;
+package com.sofa.linkiving.infra.redis;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -13,10 +13,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-
-import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
-import com.sofa.linkiving.infra.redis.RedisKeySpec;
-import com.sofa.linkiving.infra.redis.RedisService;
 
 @ExtendWith(MockitoExtension.class)
 public class RedisServiceTest {


### PR DESCRIPTION
## 관련 이슈

- close #96 

## PR 설명

* redis 테스트 파일의 위치를 `infra`에서 `infra/redis`로 변경했습니다