### PR TITLE
Google OAuth2 소셜 로그인 및 JWT 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
 
     // Security
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation "org.springframework.security:spring-security-test"
 
@@ -130,7 +131,8 @@ jacocoTestReport {
                     '**/Q*.class',
                     '**/entity/**',
                     '**/domain/**/*Entity.class',
-                    '**/domain/link/util/OgTagCrawler.class'
+                    '**/domain/link/util/OgTagCrawler.class',
+                    "**/security/auth/**"
             ])
         }))
     }
@@ -172,7 +174,8 @@ jacocoTestCoverageVerification {
                     '**/Q*.class',
                     '**/entity/**',
                     '**/domain/**/*Entity.class',
-                    '**/domain/link/util/OgTagCrawler.class'
+                    '**/domain/link/util/OgTagCrawler.class',
+                    "**/security/auth/**"
             ])
         }))
     }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
@@ -20,4 +20,16 @@ public class MemberCommandService {
 
 		return memberRepository.save(member);
 	}
+
+	public Member createOrUpdate(String email) {
+		return memberRepository.findByEmail(email)
+			.orElseGet(() -> {
+				Member newMember = Member.builder()
+					.email(email)
+					.password(email)
+					.build();
+
+				return memberRepository.save(newMember);
+			});
+	}
 }

--- a/src/main/java/com/sofa/linkiving/security/auth/code/AuthErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/code/AuthErrorCode.java
@@ -1,0 +1,24 @@
+package com.sofa.linkiving.security.auth.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+	LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "A-000", "로그인에 실패했습니다."),
+	INVALID_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "A-001", "지원하지 않는 소셜 로그인입니다."),
+	AUTHORIZATION_REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST, "A-002", "인증 요청 정보를 찾을 수 없습니다. (쿠키 누락 등)"),
+	USER_CANCELLED(HttpStatus.BAD_REQUEST, "A-003", "사용자가 로그인을 취소했습니다."),
+	PROVIDER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A-100", "소셜 공급자(Google) 서버 오류입니다."),
+	INTERNAL_AUTH_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A-101", "인증 처리 중 서버 내부 오류가 발생했습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/config/OAuth2Properties.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/OAuth2Properties.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.security.auth.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.oauth2")
+public record OAuth2Properties(
+	String successRedirectUrl,
+	String failureRedirectUrl
+) {
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
@@ -1,0 +1,57 @@
+package com.sofa.linkiving.security.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.security.auth.code.AuthErrorCode;
+import com.sofa.linkiving.security.auth.config.OAuth2Properties;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final OAuth2Properties oauth2Properties;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+
+		ErrorCode errorCode = AuthErrorCode.LOGIN_FAILED;
+		Throwable cause = exception.getCause();
+
+		if (cause instanceof BusinessException businessException) {
+			errorCode = businessException.getErrorCode();
+
+		} else if (exception instanceof OAuth2AuthenticationException oauthException) {
+			OAuth2Error error = oauthException.getError();
+			errorCode = determineAuthErrorCode(error.getErrorCode());
+		}
+
+		String targetUrl = UriComponentsBuilder.fromUriString(oauth2Properties.failureRedirectUrl())
+			.queryParam("code", errorCode.getCode())
+			.build().toUriString();
+
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+	private AuthErrorCode determineAuthErrorCode(String providerErrorCode) {
+		return switch (providerErrorCode) {
+			case "access_denied" -> AuthErrorCode.USER_CANCELLED;
+			case "invalid_client", "invalid_request" -> AuthErrorCode.INVALID_SOCIAL_PROVIDER;
+			case "server_error", "temporarily_unavailable" -> AuthErrorCode.PROVIDER_SERVER_ERROR;
+			default -> AuthErrorCode.LOGIN_FAILED;
+		};
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,62 @@
+package com.sofa.linkiving.security.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.security.auth.config.OAuth2Properties;
+import com.sofa.linkiving.security.jwt.JwtProperties;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final OAuth2Properties oauth2Properties;
+	private final JwtProperties jwtProperties;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String email = oAuth2User.getAttribute("email");
+
+		String accessToken = jwtTokenProvider.createAccessToken(email);
+		String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+		int accessExp = (int)(jwtProperties.accessTokenValidTime() / 1000);
+		int refreshExp = (int)(jwtProperties.refreshTokenValidTime() / 1000);
+
+		addCookie(request, response, "accessToken", accessToken, accessExp);
+		addCookie(request, response, "refreshToken", refreshToken, refreshExp);
+
+		String targetUrl = oauth2Properties.successRedirectUrl();
+		getRedirectStrategy().sendRedirect(request, response, targetUrl);
+	}
+
+	private void addCookie(HttpServletRequest request, HttpServletResponse response, String name, String value,
+		int maxAge) {
+		String domain = request.getServerName();
+		boolean isLocal = "localhost".equals(domain) || "127.0.0.1".equals(domain);
+
+		ResponseCookie cookie = ResponseCookie.from(name, value)
+			.path("/")
+			.maxAge(maxAge)
+			.httpOnly(!isLocal)
+			.secure(!isLocal)
+			.sameSite("Lax")
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/info/GoogleOAuth2User.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/info/GoogleOAuth2User.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.security.auth.info;
+
+import java.util.Map;
+
+public record GoogleOAuth2User(
+	Map<String, Object> attributes,
+	String name,
+	String email,
+	String picture
+) {
+	public GoogleOAuth2User(Map<String, Object> attributes) {
+		this(
+			attributes,
+			(String)attributes.get("name"),
+			(String)attributes.get("email"),
+			(String)attributes.get("picture")
+		);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,43 @@
+package com.sofa.linkiving.security.auth.service;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberCommandService;
+import com.sofa.linkiving.security.auth.info.GoogleOAuth2User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	private final MemberCommandService memberCommandService;
+
+	@Override
+	@Transactional
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+		GoogleOAuth2User googleUser = new GoogleOAuth2User(oAuth2User.getAttributes());
+
+		Member member = memberCommandService.createOrUpdate(googleUser.email());
+
+		return new DefaultOAuth2User(
+			Collections.singleton(new SimpleGrantedAuthority("ROLE_" + member.getRole().name())),
+			googleUser.attributes(),
+			"sub"
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #8 

## 작업 내용
Spring Security OAuth2 Client를 이용하여 Google 소셜 로그인 기능을 구현했습니다. 로그인 성공 시 JWT(Access/Refresh Token)를 발급하여 클라이언트에게 전달하는 로직이 포함되어 있습니다.

### 1. Security 설정 (`SecurityConfig`)
* `oauth2Login()` 설정을 활성화하여 소셜 로그인 필터 체인을 구성했습니다.
* `UserInfoEndpoint`, `SuccessHandler`, `FailureHandler`를 각각 커스텀 구현체로 등록했습니다.
* OAuth2 관련 설정값(Redirect URL 등) 관리를 위해 `OAuth2Properties`를 도입했습니다.

### 2. 사용자 정보 동기화 (`CustomOAuth2UserService`)
* 구글 인증 서버로부터 받은 사용자 정보를 `GoogleOAuth2User` 레코드로 매핑합니다.
* `MemberCommandService.createOrUpdate()`를 호출하여, 신규 사용자는 회원가입 처리하고 기존 사용자는 정보를 갱신하도록 구현했습니다.

### 3. 로그인 성공/실패 핸들링
* **성공 시 (`OAuth2SuccessHandler`)**: 
  * 인증된 이메일을 기반으로 Access Token과 Refresh Token을 생성합니다.
  * 생성된 토큰을 `Cookie`에 담아 클라이언트(프론트엔드)의 성공 페이지로 리다이렉트합니다.
* **실패 시 (`OAuth2FailureHandler`)**:
  * `OAuth2AuthenticationException` 및 내부 `BusinessException`을 포착합니다.
  * 에러 상황에 맞는 `AuthErrorCode`를 파싱하여, 에러 코드와 함께 실패 페이지로 리다이렉트합니다.

### 4. 에러 코드 정의 (`AuthErrorCode`)
* 소셜 로그인 과정에서 발생할 수 있는 예외(사용자 취소, 제공자 서버 오류, 유효하지 않은 요청 등)를 처리하기 위한 Enum 코드를 추가했습니다.

# 5. JaCoCo 설정
* OAuth 관련 클래스들이 테스트 커버리지 집계에 제외되도록 하였습니다.

## 중요 알림 (로컬 테스트 관련)
* **기존 일반 로그인/회원가입 API 유지**: 프론트엔드 팀의 로컬 환경 테스트 및 개발 편의성을 위해, 소셜 로그인 외에 기존에 개발된 일반 로그인 및 회원가입 API 엔드포인트는 제거하지 않고 남겨두었습니다. 추후 배포 단계에서 제거 여부를 다시 논의할 예정입니다.

## 테스트 방법
1. 로그인 시도
    * `http://localhost:8080/oauth2/authorization/google` 접속 -> 구글 로그인 -> `http://localhost:3000/login/success...` 리다이렉트 확인
2. DB 확인
    * `H2 Console` 등에서 회원 정보(`MEMBER` 테이블) 저장 여부 확인
3. 쿠키 확인
    * 개발자 도구(F12) Application 탭에서 `accessToken`, `refreshToken` 쿠키 생성 확인
4. API 호출
    * `Postman` 등을 이용해 `Bearer <accessToken>` 헤더를 담아 인증 필요한 API 호출 -> `200 OK` 확인

## 실행 결과
<img width="2559" height="1392" alt="image" src="https://github.com/user-attachments/assets/5b6187b5-38eb-4001-abcb-3279d94f9a7d" />
<img width="2558" height="738" alt="image" src="https://github.com/user-attachments/assets/40d9ac47-99c8-4cd1-8bb0-4abf48dfe569" />
