### PR TITLE
인증 사용자 바인딩 간소화를 위한 커스텀 어노테이션(@AuthMember) 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/config/WebMvcConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.sofa.linkiving.security.resolver.AuthMemberArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authMemberArgumentResolver);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/annotation/AuthMember.java
+++ b/src/main/java/com/sofa/linkiving/security/annotation/AuthMember.java
@@ -1,0 +1,14 @@
+package com.sofa.linkiving.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
+public @interface AuthMember {
+}

--- a/src/main/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.sofa.linkiving.security.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.code.CommonErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.security.annotation.AuthMember;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+@Component
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthMember.class)
+			&& Member.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || authentication.getPrincipal() == null || "anonymousUser".equals(
+			authentication.getPrincipal())) {
+			throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+		}
+
+		Object principal = authentication.getPrincipal();
+
+		if (principal instanceof CustomMemberDetail userDetails) {
+			return userDetails.member();
+		}
+
+		throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolverTest.java
+++ b/src/test/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolverTest.java
@@ -1,0 +1,92 @@
+package com.sofa.linkiving.security.resolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.security.annotation.AuthMember;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthMemberArgumentResolverTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Test
+	@DisplayName("인증된 CustomMemberDetail 존재 시 Member 객체 정상 주입")
+	void shouldResolveMemberWhenAuthenticated() throws Exception {
+		// given
+		Member member = Member.builder()
+			.email("test@test.com")
+			.build();
+
+		CustomMemberDetail userDetails = new CustomMemberDetail(member, member.getRole());
+
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+		);
+
+		// when & then
+		mockMvc.perform(get("/test/auth-member")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("Resolved: test@test.com"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 토큰 존재 시 401 Unauthorized 및 C-005 에러 코드 반환")
+	@WithAnonymousUser
+	void shouldThrowUnauthorizedWhenAnonymous() throws Exception {
+		// when & then
+		mockMvc.perform(get("/test/auth-member")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.status").value("UNAUTHORIZED"))
+			.andExpect(jsonPath("$.data").value("C-005"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("인증 정보 부재 시 401 Unauthorized 예외 발생")
+	void shouldThrowUnauthorizedWhenNoContext() throws Exception {
+		// SecurityContext 비우기
+		SecurityContextHolder.clearContext();
+
+		// when & then
+		mockMvc.perform(get("/test/auth-member")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isUnauthorized())
+			.andDo(print());
+	}
+
+	// 1. 테스트를 위한 임시 컨트롤러 생성
+	@TestConfiguration
+	static class TestConfig {
+		@RestController
+		static class TestController {
+			@GetMapping("/test/auth-member")
+			public String testEndpoint(@AuthMember Member member) {
+				return "Resolved: " + member.getEmail();
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #107 

## PR 설명
컨트롤러에서 인증된 사용자 정보를 받아올 때 반복되는 `@AuthenticationPrincipal` 및 Swagger 설정 코드를 줄이기 위해, 커스텀 어노테이션(`@AuthMember`)과 `ArgumentResolver`를 구현함.

### 1. 커스텀 어노테이션 (`AuthMember`)
* `@AuthenticationPrincipal`을 대체할 마커 어노테이션 정의함.
* `@Parameter(hidden = true)`를 적용하여 Swagger UI 노출을 방지함.

### 2. Argument Resolver 구현 (`AuthMemberArgumentResolver`)
* `HandlerMethodArgumentResolver`를 구현하여 파라미터 바인딩 로직 정의함.
* **동작 방식**:
  1. 요청 파라미터에 `@AuthMember`가 있고 타입이 `Member`인지 확인.
  2. `SecurityContextHolder`에서 `Authentication` 객체 조회.
  3. 인증 정보 부재 혹은 익명 사용자(`anonymousUser`)일 경우 `BusinessException(UNAUTHORIZED)` 발생.
  4. `Principal`이 `CustomMemberDetail` 타입인 경우 `Member` 엔티티 반환.

### 3. 설정 등록 (`WebMvcConfig`)
* 구현한 `AuthMemberArgumentResolver`를 `WebMvcConfigurer`에 등록하여 전역 적용함.

### 4. 테스트 작성 (`AuthMemberArgumentResolverTest`)
* `@SpringBootTest` 기반 통합 테스트 작성함.
* **성공**: 인증 상태에서 `Member` 객체 주입 확인.
* **실패**: 익명 사용자/인증 정보 누락 시 `401 Unauthorized` 및 에러 코드(`C-005`) 반환 검증.

## 특이 사항 (OAuth 연동 관련)
* **현재 로직은 일반 로그인(`UserDetails` 기반) 환경에 맞춰져 있음.**
* 추후 OAuth2 로그인 연동 시 `Principal` 객체 타입이 `OAuth2User` 등으로 변경될 수 있음을 인지하고 있음.
* OAuth 환경 통합 시, `AuthMemberArgumentResolver` 내부에서 `Principal` 타입을 체크하여 분기 처리하거나 어댑터를 사용하는 방식으로 수정할 예정임.

## 리뷰 포인트
* **예외 처리**: `AuthMemberArgumentResolver`의 `UNAUTHORIZED` 예외 발생 시점이 적절한지 확인 바람.
