### PR TITLE
`Chat` 도메인 Entity 추가 및 기본 레이어 구조 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
@@ -1,0 +1,7 @@
+package com.sofa.linkiving.domain.chat.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Chat", description = "링크 관리 API")
+public interface ChatApi {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.domain.chat.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/chat")
+@RequiredArgsConstructor
+public class ChatController implements ChatApi {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Chat.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Chat.java
@@ -1,0 +1,29 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.common.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chats")
+public class Chat extends BaseEntity {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Builder
+	public Chat(Member member) {
+		this.member = member;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
@@ -1,0 +1,38 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+import com.sofa.linkiving.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "feedbacks")
+public class Feedback extends BaseEntity {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "message_id", nullable = false)
+	private Message message;
+
+	@Column(columnDefinition = "text", nullable = false)
+	private String text;
+
+	@Column(nullable = false, columnDefinition = "SMALLINT")
+	private Sentiment sentiment;
+
+	@Builder
+	public Feedback(Message message, String text, Sentiment sentiment) {
+		this.message = message;
+		this.text = text;
+		this.sentiment = sentiment;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
@@ -1,0 +1,61 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+
+import com.sofa.linkiving.domain.chat.enums.Type;
+import com.sofa.linkiving.global.common.BaseEntity;
+import com.sofa.linkiving.global.converter.LongListToStringConverter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "messages")
+public class Message extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chat_id", nullable = false)
+	private Chat chat;
+
+	@Column(nullable = false)
+	private Type type;
+
+	@Column(columnDefinition = "text", nullable = false)
+	private String content;
+
+	@Column(name = "original_prompt", columnDefinition = "text")
+	private String originalPrompt;
+
+	@Convert(converter = LongListToStringConverter.class)
+	private List<Long> linkIds = new ArrayList<>();
+
+	@OneToMany(mappedBy = "message")
+	@BatchSize(size = 100)
+	private List<Feedback> feedbacks = new ArrayList<>();
+
+	@Builder
+	public Message(Chat chat, Type type, String content, String originalPrompt, List<Long> linkIds,
+		List<Feedback> feedbacks) {
+		this.chat = chat;
+		this.type = type;
+		this.content = content;
+		this.originalPrompt = originalPrompt;
+		this.linkIds = linkIds;
+		this.feedbacks = feedbacks;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/enums/Sentiment.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/enums/Sentiment.java
@@ -1,0 +1,22 @@
+package com.sofa.linkiving.domain.chat.enums;
+
+import com.sofa.linkiving.global.converter.AbstractCodeEnumConverter;
+import com.sofa.linkiving.global.converter.CodeEnum;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Sentiment implements CodeEnum<Integer> {
+	LIKE(0), DISLIKE(1);
+	private final Integer code;
+
+	@Converter(autoApply = true)
+	static class SentimentConverter extends AbstractCodeEnumConverter<Sentiment, Integer> {
+		public SentimentConverter() {
+			super(Sentiment.class);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/enums/Type.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/enums/Type.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.domain.chat.enums;
+
+import com.sofa.linkiving.global.converter.AbstractCodeEnumConverter;
+import com.sofa.linkiving.global.converter.CodeEnum;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Type implements CodeEnum<Integer> {
+	USER(0), AI(1);
+
+	private final Integer code;
+
+	@Converter(autoApply = true)
+	static class TypeConverter extends AbstractCodeEnumConverter<Type, Integer> {
+		public TypeConverter() {
+			super(Type.class);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sofa.linkiving.domain.chat.entity.Chat;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/FeedbackRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/FeedbackRepository.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/MessageRepository.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sofa.linkiving.domain.chat.entity.Message;
+
+@Repository
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatCommandService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.ChatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatCommandService {
+	private final ChatRepository chatRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatFacade.java
@@ -1,0 +1,15 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatFacade {
+	private final ChatService chatService;
+	private final MessageService messageService;
+	private final FeedbackService feedbackService;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatQueryService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.ChatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatQueryService {
+	private final ChatRepository chatRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatService.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+	private final ChatCommandService chatCommandService;
+	private final ChatQueryService chatQueryService;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackCommandService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackCommandService {
+	private final FeedbackRepository feedbackRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackQueryService {
+	private final FeedbackRepository feedbackRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+	private final FeedbackQueryService feedbackQueryService;
+	private final FeedbackCommandService feedbackCommandService;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MessageCommandService {
+	private final MessageRepository messageRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageQueryService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MessageQueryService {
+	private final MessageRepository messageRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+	private final MessageCommandService messageCommandService;
+	private final MessageQueryService messageQueryService;
+}

--- a/src/main/java/com/sofa/linkiving/global/converter/LongListToStringConverter.java
+++ b/src/main/java/com/sofa/linkiving/global/converter/LongListToStringConverter.java
@@ -1,0 +1,33 @@
+package com.sofa.linkiving.global.converter;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class LongListToStringConverter implements AttributeConverter<List<Long>, String> {
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	@Override
+	public String convertToDatabaseColumn(List<Long> attribute) {
+		try {
+			return (attribute == null || attribute.isEmpty()) ? "[]" : mapper.writeValueAsString(attribute);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to convert List<Long> to JSON", e);
+		}
+	}
+
+	@Override
+	public List<Long> convertToEntityAttribute(String dbData) {
+		try {
+			return mapper.readValue(dbData, new TypeReference<List<Long>>() {
+			});
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to convert JSON to List<Long>", e);
+		}
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/ChatTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/ChatTest.java
@@ -1,0 +1,43 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class ChatTest {
+
+	@Autowired
+	private TestEntityManager em;
+
+	@Test
+	@DisplayName("채팅방 생성 시 멤버 연관관계 정상 매핑")
+	void shouldSaveChatWithMember() {
+		// given
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		em.persist(member);
+
+		Chat chat = Chat.builder()
+			.member(member)
+			.build();
+
+		// when
+		Chat savedChat = em.persistFlushFind(chat);
+
+		// then
+		assertThat(savedChat).isNotNull();
+		assertThat(savedChat.getMember()).isEqualTo(member);
+		assertThat(savedChat.getMember().getEmail()).isEqualTo("test@test.com");
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
@@ -1,0 +1,66 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+import com.sofa.linkiving.domain.chat.enums.Type;
+import com.sofa.linkiving.domain.member.entity.Member;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class FeedbackTest {
+
+	@Autowired
+	private TestEntityManager em;
+
+	@Test
+	// ❌ "저장된다" (X) -> ⭕ "정상 저장" (O)
+	@DisplayName("피드백 저장 시 메시지 연관관계 및 감정 상태 정상 저장")
+	void shouldSaveFeedbackWithSentiment() {
+		// given
+		Member member = Member
+			.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		em.persist(member);
+
+		Chat chat = Chat.builder().member(member).build();
+		em.persist(chat);
+
+		Message message = Message.builder()
+			.chat(chat)
+			.type(Type.USER)
+			.content("답변입니다.")
+			.linkIds(Collections.emptyList())
+			.build();
+		em.persist(message);
+
+		String feedbackText = "좋은 답변 감사합니다.";
+		Sentiment sentiment = Sentiment.LIKE;
+
+		Feedback feedback = Feedback.builder()
+			.message(message)
+			.text(feedbackText)
+			.sentiment(sentiment)
+			.build();
+
+		// when
+		Feedback savedFeedback = em.persistFlushFind(feedback);
+
+		// then
+		assertThat(savedFeedback).isNotNull();
+		assertThat(savedFeedback.getMessage()).isEqualTo(message);
+		assertThat(savedFeedback.getText()).isEqualTo(feedbackText);
+		assertThat(savedFeedback.getSentiment()).isEqualTo(sentiment);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/MessageTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/MessageTest.java
@@ -1,0 +1,63 @@
+package com.sofa.linkiving.domain.chat.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.sofa.linkiving.domain.chat.enums.Type;
+import com.sofa.linkiving.domain.member.entity.Member;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class MessageTest {
+
+	@Autowired
+	private TestEntityManager em;
+
+	@Test
+	@DisplayName("메시지 저장 시 내용 및 링크 ID 목록 정상 저장 및 조회")
+	void shouldSaveMessageWithContentAndLinkIds() {
+		// given
+		Member member = Member
+			.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
+		em.persist(member);
+
+		Chat chat = Chat.builder().member(member).build();
+		em.persist(chat);
+
+		List<Long> linkIds = List.of(1L, 100L, 500L);
+		String content = "테스트 메시지입니다.";
+		String prompt = "원본 프롬프트";
+
+		Message message = Message.builder()
+			.chat(chat)
+			.type(Type.AI)
+			.content(content)
+			.originalPrompt(prompt)
+			.linkIds(linkIds)
+			.build();
+
+		// when
+		Message savedMessage = em.persistFlushFind(message);
+
+		// then
+		assertThat(savedMessage).isNotNull();
+		assertThat(savedMessage.getContent()).isEqualTo(content);
+		assertThat(savedMessage.getOriginalPrompt()).isEqualTo(prompt);
+		assertThat(savedMessage.getChat()).isEqualTo(chat);
+
+		// Converter 동작 검증
+		assertThat(savedMessage.getLinkIds()).hasSize(3)
+			.containsExactly(1L, 100L, 500L);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #70 

## PR 설명
* 채팅 서비스 제공을 위한 핵심 도메인인 `Chat`, `Message`, `Feedback` Entity 설계
* 비즈니스 로직 처리를 위한 `Service` 계층의 기본 구조 구축

### 1. Entity 구현
* **`Chat`**
   * 사용자(`Member`)와 1:N 관계를 가지는 채팅방 Entity.
* **`Message`**
    * 채팅방 내 오고 가는 대화 정보를 저장
    * `Type`으로 사용자 질문과 AI 답변을 구분
    * `linkIds`는 `LongListToStringConverter`를 통해 DB에 문자열로 저장
* **`Feedback`**
  * AI 답변에 대한 사용자의 평가(`Sentiment`)와 피드백 내용(`text`) 저장

* 모든 Entity는 `BaseEntity`를 상속받아 생성/수정 시간을 관리함.

### 2. Enum
* **`Type`**: 메시지 화자 구분 (`USER`, `AI`).
* **`Sentiment`**: 답변 평가 구분 (`LIKE`, `DISLIKE`).

### 3. Service 계층 구조 설계
* **Facade 패턴 적용**: `ChatFacade`를 통해 트랜잭션 단위 및 서비스 간 조율을 담당하도록 구성함.
* **CQRS 패턴 적용**: 읽기 로직(`QueryService`)과 쓰기 로직(`CommandService`)을 분리하여 유지보수성을 높임.
  * `ChatService`: `ChatCommandService`, `ChatQueryService` 조합
  * `MessageService`: `MessageCommandService`, `MessageQueryService` 조합
  * `FeedbackService`: `FeedbackCommandService`, `FeedbackQueryService` 조합

### 4. Controller 및 API 명세
* `ChatController`: API 엔드포인트 진입점.
* `ChatApi`: Swagger 문서화를 위한 인터페이스 정의.

## 리뷰 포인트
* **Entity 관계 설정**: `FetchType.LAZY` 적용 및 연관 관계 매핑(`@OneToMany`, `@ManyToOne`)이 적절한지 확인 바람.
