### PR TITLE
IDE 환경에서 `AuthMemberArgumentResolverTest` 컨텍스트 로드 실패 해결

### DIFF
--- a/src/test/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolverTest.java
+++ b/src/test/java/com/sofa/linkiving/security/resolver/AuthMemberArgumentResolverTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,7 @@ import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class AuthMemberArgumentResolverTest {
 
 	@Autowired


### PR DESCRIPTION
## 관련 이슈

- close #111 

## PR 설명
- `AuthMemberArgumentResolverTest` 클래스에 `@ActiveProfiles("test")` 어노테이션 추가
- 테스트 실행 시 `test` 프로필을 활성화하여 `application-test.yml` 설정을 정상적으로 로드하도록 수정
- `application-test.yml`에 `test.external.base-url` 값 추가

## 💬 기타 사항
- `@SpringBootTest` 사용 시 `@ActiveProfiles("test")` 추가 필요