### PR TITLE
JaCoCo 코드 커버리지 측정 및 PR 자동 리포팅 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       SPRING_PROFILES_ACTIVE: test
 
@@ -52,6 +55,33 @@ jobs:
 
       - name: 🧪 테스트 실행
         run: ./gradlew test
+
+      - name: 📊 JaCoCo 커버리지 리포트 생성
+        run: ./gradlew jacocoTestReport
+
+      - name: 📈 JaCoCo 커버리지 검증
+        run: ./gradlew jacocoTestCoverageVerification
+
+      - name: 💬 PR에 JaCoCo 커버리지 코멘트 추가
+        if: github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 30
+          min-coverage-changed-files: 30
+          title: '📊 코드 커버리지 리포트'
+          update-comment: true
+
+      - name: 📊 JaCoCo 리포트 업로드
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report-${{ github.run_number }}
+          path: |
+            build/reports/jacoco/
+            build/jacoco/
+          retention-days: 7
 
       - name: Docker 빌드 테스트 (push 없음)
         uses: docker/build-push-action@v4

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 group = 'com.sofa'
@@ -88,4 +89,75 @@ compileTestJava.options.encoding = 'UTF-8'
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/*Dto.class',
+                    '**/*Dto$*.class',
+                    '**/*Request.class',
+                    '**/*Request$*.class',
+                    '**/*Response.class',
+                    '**/*Response$*.class',
+                    '**/config/**',
+                    '**/configuration/**',
+                    '**/exception/**',
+                    '**/*Application.class',
+                    '**/Q*.class',
+                    '**/entity/**',
+                    '**/domain/**/*Entity.class'
+            ])
+        }))
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.30  // 30%부터 시작, 점진적으로 0.50 -> 0.70으로 상향
+            }
+        }
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/*Dto.class',
+                    '**/*Dto$*.class',
+                    '**/*Request.class',
+                    '**/*Request$*.class',
+                    '**/*Response.class',
+                    '**/*Response$*.class',
+                    '**/config/**',
+                    '**/configuration/**',
+                    '**/exception/**',
+                    '**/*Application.class',
+                    '**/Q*.class',
+                    '**/entity/**',
+                    '**/domain/**/*Entity.class'
+            ])
+        }))
+    }
 }


### PR DESCRIPTION
## 관련 이슈

- close #114 

## PR 설명
- JaCoCo 플러그인을 추가하여 코드 커버리지 측정 자동화
- DTO, Config, Entity 등 로직 테스트가 불필요한 클래스는 커버리지 측정에서 제외
- GitHub Actions CI에 Madrapps/jacoco-report 추가하여 PR 생성 시 커버리지 리포트를 자동으로 코멘트에 표시
- 커버리지 기준을 30%로 설정 
