### PR TITLE
.gitignore 설정 추가 (*.yml, .editorconfig)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ out/
 /dist/
 /nbdist/
 /.nb-gradle/
+
+### Spring
+*.yml
+.editorconfig


### PR DESCRIPTION
## 관련 이슈

- close #124 

## PR 설명
프로젝트 내 보안상 민감한 파일과 불필요한 로컬 설정 파일이 Git에 업로드되지 않도록 `.gitignore` 규칙을 업데이트

## 작업 내용

### 1. 설정 파일 제외 (`.gitignore`)
* **`*.yml` 추가**: DB 접속 정보, Secret Key 등 민감 정보가 포함될 수 있는 YAML 파일을 추적 대상에서 제외
* **`.editorconfig` 추가**: 개발자 개인별 IDE 설정 차이로 인한 불필요한 변경 및 충돌을 방지
