### PR TITLE
채팅 답변 생성 및 취소 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ dependencies {
     testImplementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // WebFlux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 dependencyManagement {

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
@@ -7,9 +7,25 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Chat", description = "채팅 관리 API")
+@Tag(name = "Chat", description = """
+	AI 채팅 통합 명세 (HTTP + WebSocket)
+
+	### 📡 1. WebSocket 연결 정보 (필수)
+		답변을 실시간으로 수신하기 위해 **반드시 소켓 연결 및 구독**이 선행되어야 합니다.
+
+		* **Socket Endpoint:** `ws://{domain}/ws/chat`
+		* **Subscribe Path:** `/topic/chat/{chatId}`
+		* **Auth Header:** `Authorization: Bearer {accessToken}` (CONNECT 프레임 헤더)
+	### 🚀 2. 동작 흐름
+		1. **소켓 연결:** 프론트엔드에서 WebSocket 연결 및 `/topic/chat/{chatId}` 구독
+		2. **질문 전송:** `/app/send/{chatId}` (STOMP)로 질문 전송
+		3. **답변 수신:** 소켓 구독 채널로 토큰 단위 답변 스트리밍 (`String` 데이터)
+		4. **완료:** `END_OF_STREAM` 메시지 수신 시 스트리밍 종료
+
+	""")
 public interface ChatApi {
 	@Operation(summary = "채팅방 목록 조회", description = "사용자의 채팅방 목록 정보(채팅방 Id, 제목)을 조회합니다.")
 	BaseResponse<ChatsRes> getChats(Member member);
@@ -19,4 +35,9 @@ public interface ChatApi {
 		CreateChatReq req,
 		Member member
 	);
+
+	void sendMessage(@Parameter(description = "채팅방 Id", required = true) Long chatId,
+		@Parameter(description = "사용자 질문 내용", required = true) String message, Member member);
+
+	void cancelMessage(@Parameter(description = "채팅방 Id", required = true) Long chatId, Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
@@ -1,5 +1,8 @@
 package com.sofa.linkiving.domain.chat.controller;
 
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,5 +38,17 @@ public class ChatController implements ChatApi {
 	public BaseResponse<CreateChatRes> createChat(@RequestBody @Valid CreateChatReq req, @AuthMember Member member) {
 		CreateChatRes res = chatFacade.createChat(req.firstChat(), member);
 		return BaseResponse.success(res, "채팅방 생성 완료");
+	}
+
+	@MessageMapping("/send/{chatId}")
+	@Override
+	public void sendMessage(@DestinationVariable Long chatId, @Payload String message, @AuthMember Member member) {
+		chatFacade.generateAnswer(chatId, member, message);
+	}
+
+	@MessageMapping("/cancel/{chatId}")
+	@Override
+	public void cancelMessage(@DestinationVariable Long chatId, @AuthMember Member member) {
+		chatFacade.cancelAnswer(chatId, member);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/MockAiController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/MockAiController.java
@@ -1,0 +1,33 @@
+package com.sofa.linkiving.domain.chat.controller;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/mock/ai")
+public class MockAiController {
+
+	@PostMapping(value = "/generate", produces = MediaType.APPLICATION_NDJSON_VALUE) // 또는 TEXT_EVENT_STREAM_VALUE
+	public Flux<String> generateAnswer(@RequestBody Map<String, String> request) {
+		String userPrompt = request.get("prompt");
+
+		String fakeResponse = """
+			안녕하세요! 저는 임시 AI 봇입니다. 🤖
+			현재 AI 서버가 구축되지 않아서 테스트용 답변을 드리고 있어요.
+			질문하신 내용인 "%s"에 대해 답변을 생성하는 척 하고 있습니다.
+			취소 기능을 테스트하시려면 지금 바로 취소 버튼을 눌러보세요!
+			타이핑 효과를 위해 천천히 답변을 보내고 있습니다...
+			""".formatted(userPrompt);
+
+		return Flux.fromArray(fakeResponse.split(""))
+			.delayElements(Duration.ofMillis(100));
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/error/ChatErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/error/ChatErrorCode.java
@@ -1,0 +1,20 @@
+package com.sofa.linkiving.domain.chat.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+
+	CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "C-001", "채팅을 찾을 수 없습니다."),
+	ALREADY_GENERATING(HttpStatus.BAD_REQUEST, "C-002", "현재 답변이 생성 중입니다. 잠시만 기다려주세요.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -37,4 +37,15 @@ public class ChatFacade {
 		List<Chat> chats = chatService.getChats(member);
 		return ChatsRes.from(chats);
 	}
+
+	@Transactional
+	public void generateAnswer(Long chatId, Member member, String message) {
+		Chat chat = chatService.getChat(chatId, member);
+		messageService.generateAnswer(chat, message);
+	}
+
+	public void cancelAnswer(Long chatId, Member member) {
+		Chat chat = chatService.getChat(chatId, member);
+		messageService.cancelAnswer(chat);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/manager/SubscriptionManager.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/manager/SubscriptionManager.java
@@ -1,0 +1,39 @@
+package com.sofa.linkiving.domain.chat.manager;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import reactor.core.Disposable;
+
+@Component
+public class SubscriptionManager {
+
+	private final Map<String, Disposable> activeSubscriptions = new ConcurrentHashMap<>();
+
+	/**
+	 * 구독 추가 (기존 작업이 있다면 취소 후 등록)
+	 */
+	public void add(String key, Disposable subscription) {
+		cancel(key); // 안전하게 기존 작업 정리
+		activeSubscriptions.put(key, subscription);
+	}
+
+	/**
+	 * 구독 취소 및 자원 해제
+	 */
+	public void cancel(String key) {
+		Disposable subscription = activeSubscriptions.remove(key);
+		if (subscription != null && !subscription.isDisposed()) {
+			subscription.dispose();
+		}
+	}
+
+	/**
+	 * 완료된 구독 제거 (자원 해제 없이 Map에서만 삭제)
+	 */
+	public void remove(String key) {
+		activeSubscriptions.remove(key);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.chat.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +22,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 		ORDER BY MAX(m.createdAt) DESC
 		""")
 	List<Chat> findAllByMemberOrderByLastMessageDesc(@Param("member") Member member);
+
+	Optional<Chat> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatQueryService.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.error.ChatErrorCode;
 import com.sofa.linkiving.domain.chat.repository.ChatRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +16,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatQueryService {
 	private final ChatRepository chatRepository;
+
+	public Chat findChat(Long chatId, Member member) {
+		return chatRepository.findByIdAndMember(chatId, member).orElseThrow(
+			() -> new BusinessException(ChatErrorCode.CHAT_NOT_FOUND)
+		);
+	}
 
 	public List<Chat> findAllOrderByLastMessageDesc(Member member) {
 		return chatRepository.findAllByMemberOrderByLastMessageDesc(member);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/ChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/ChatService.java
@@ -8,12 +8,18 @@ import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.member.entity.Member;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatService {
 	private final ChatCommandService chatCommandService;
 	private final ChatQueryService chatQueryService;
+
+	public Chat getChat(Long chatId, Member member) {
+		return chatQueryService.findChat(chatId, member);
+	}
 
 	public List<Chat> getChats(Member member) {
 		return chatQueryService.findAllOrderByLastMessageDesc(member);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.domain.chat.service;
 
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.repository.MessageRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MessageCommandService {
 	private final MessageRepository messageRepository;
+
+	public Message saveMessage(Message message) {
+		return messageRepository.save(message);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
@@ -1,12 +1,88 @@
 package com.sofa.linkiving.domain.chat.service;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Type;
+import com.sofa.linkiving.domain.chat.manager.SubscriptionManager;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.Disposable;
 
 @Service
 @RequiredArgsConstructor
 public class MessageService {
 	private final MessageCommandService messageCommandService;
 	private final MessageQueryService messageQueryService;
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final SubscriptionManager subscriptionManager;
+
+	private final WebClient webClient = WebClient.create("http://localhost:8080/mock/ai");
+	private final Map<String, StringBuilder> messageBuffers = new ConcurrentHashMap<>();
+
+	public void generateAnswer(Chat chat, String userMessage) {
+
+		String roomId = chat.getId().toString();
+
+		if (messageBuffers.containsKey(roomId)) {
+			return;
+		}
+
+		messageBuffers.put(roomId, new StringBuilder());
+
+		Disposable subscription = webClient.post()
+			.uri("/generate")
+			.bodyValue(Map.of("prompt", userMessage))
+			.retrieve()
+			.bodyToFlux(String.class)
+			.doOnComplete(() -> {
+				String fullAnswer = messageBuffers.remove(roomId).toString();
+
+				saveMessage(chat, Type.USER, userMessage);
+				saveMessage(chat, Type.AI, fullAnswer);
+
+				subscriptionManager.remove(roomId);
+				messagingTemplate.convertAndSend("/topic/chat/" + roomId, "END_OF_STREAM");
+			})
+			.doOnError(e -> {
+				subscriptionManager.remove(roomId);
+				messagingTemplate.convertAndSend("/topic/chat/" + roomId, "ERROR: " + e.getMessage());
+			})
+			.subscribe(token -> {
+				StringBuilder buffer = messageBuffers.get(roomId);
+				if (buffer != null) {
+					buffer.append(token);
+				}
+
+				messagingTemplate.convertAndSend("/topic/chat/" + roomId, token);
+			});
+
+		subscriptionManager.add(roomId, subscription);
+	}
+
+	public void cancelAnswer(Chat chat) {
+		String roomId = chat.getId().toString();
+
+		subscriptionManager.cancel(roomId);
+		messageBuffers.remove(roomId);
+
+		messagingTemplate.convertAndSend("/topic/chat/" + roomId, "GENERATION_CANCELLED");
+	}
+
+	private void saveMessage(Chat chat, Type type, String content) {
+		Message message = Message.builder()
+			.chat(chat)
+			.type(type)
+			.content(content)
+			.build();
+
+		messageCommandService.saveMessage(message);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/WebMvcConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/WebMvcConfig.java
@@ -3,7 +3,10 @@ package com.sofa.linkiving.global.config;
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.sofa.linkiving.security.resolver.AuthMemberArgumentResolver;
@@ -19,5 +22,20 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(authMemberArgumentResolver);
+	}
+
+	@Override
+	public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+		configurer.setTaskExecutor(mvcTaskExecutor());
+	}
+
+	public AsyncTaskExecutor mvcTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(10);
+		executor.setMaxPoolSize(100);
+		executor.setQueueCapacity(50);
+		executor.setThreadNamePrefix("mvc-async-");
+		executor.initialize();
+		return executor;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/WebSocketConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/WebSocketConfig.java
@@ -1,0 +1,48 @@
+package com.sofa.linkiving.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import com.sofa.linkiving.security.config.StompHandler;
+import com.sofa.linkiving.security.resolver.AuthMemberWebsocketArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final StompHandler stompHandler;
+	private final AuthMemberWebsocketArgumentResolver authMemberWebsocketArgumentResolver;
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		config.enableSimpleBroker("/topic/chat");
+		config.setApplicationDestinationPrefixes("/ws/chat");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws/chat")
+			.setAllowedOriginPatterns("*")
+			.withSockJS();
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(stompHandler);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(authMemberWebsocketArgumentResolver);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/infra/redis/RedisService.java
+++ b/src/main/java/com/sofa/linkiving/infra/redis/RedisService.java
@@ -33,7 +33,7 @@ public class RedisService {
 
 	public Boolean hasNoKey(String key) {
 		Boolean exists = redisTemplate.hasKey(key);
-		return !Boolean.TRUE.equals(exists);
+		return !exists;
 	}
 
 	public void delete(String key) {
@@ -56,7 +56,7 @@ public class RedisService {
 
 	public Boolean hasNoKey(RedisKeySpec type, String... keys) {
 		Boolean exists = redisTemplate.hasKey(type.key(keys));
-		return !Boolean.TRUE.equals(exists);
+		return !exists;
 	}
 
 	public void delete(RedisKeySpec type, String... keys) {

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -39,10 +39,10 @@ public class SecurityConfig {
 		"/h2-console/**",
 
 		/* web socket */
-		"/v1/chat/**",
+		"/ws/chat/**",
 
 		/* temp */
-		"/v1/member/**"
+		"/v1/member/**", "/mock/**"
 
 	};
 	private static final String[] SEMI_PERMIT_URLS = {

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -1,0 +1,62 @@
+package com.sofa.linkiving.security.config;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.security.jwt.JwtKeys;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+public class StompHandler implements ChannelInterceptor {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+
+			String authorizationHeader = accessor.getFirstNativeHeader(JwtKeys.Headers.AUTHORIZATION);
+			String token = null;
+
+			if (authorizationHeader != null && authorizationHeader.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
+				token = authorizationHeader.substring(JwtKeys.Headers.BEARER_PREFIX.length());
+			}
+
+			try {
+				if (token == null) {
+					throw new BusinessException(JwtErrorCode.EMPTY_TOKEN);
+				}
+
+				if (jwtTokenProvider.validateAccessToken(token)) {
+					Authentication authentication = jwtTokenProvider.getAuthentication(token);
+					accessor.setUser(authentication);
+				}
+
+			} catch (BusinessException e) {
+				throw new MessagingException(e.getMessage());
+
+			} catch (Exception e) {
+				throw new MessagingException("서버 내부 오류로 연결에 실패했습니다.");
+			}
+		}
+
+		return message;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/resolver/AuthMemberWebsocketArgumentResolver.java
+++ b/src/main/java/com/sofa/linkiving/security/resolver/AuthMemberWebsocketArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.sofa.linkiving.security.resolver;
+
+import java.security.Principal;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.code.CommonErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.security.annotation.AuthMember;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+@Component
+public class AuthMemberWebsocketArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthMember.class)
+			&& Member.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+		Principal principal = SimpMessageHeaderAccessor.getUser(message.getHeaders());
+
+		if (principal instanceof AbstractAuthenticationToken authentication) {
+			Object userDetails = authentication.getPrincipal();
+
+			if (userDetails instanceof CustomMemberDetail customMemberDetail) {
+				return customMemberDetail.member();
+			}
+		}
+
+		throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.sofa.linkiving.domain.chat.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.repository.ChatRepository;
+import com.sofa.linkiving.domain.chat.service.MessageService;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.infra.redis.RedisService;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class WebSocketChatIntegrationTest {
+
+	@LocalServerPort
+	private int port;
+
+	private WebSocketStompClient stompClient;
+
+	@Autowired
+	private MessageService messageService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private ChatRepository chatRepository;
+
+	@MockitoBean
+	private RedisService redisService;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider; // 실제 토큰 생성 로직 사용 (또는 MockBean)
+
+	private Chat savedChat;
+	private String validToken;
+
+	@BeforeEach
+	void setUp() {
+		// 1. WebSocket Client 설정
+		StandardWebSocketClient standardWebSocketClient = new StandardWebSocketClient();
+		WebSocketTransport webSocketTransport = new WebSocketTransport(standardWebSocketClient);
+		List<Transport> transports = List.of(webSocketTransport);
+		SockJsClient sockJsClient = new SockJsClient(transports);
+
+		stompClient = new WebSocketStompClient(sockJsClient);
+		stompClient.setMessageConverter(new StringMessageConverter());
+
+		// 2. MockAiController 연결을 위한 WebClient 주소 조작 (핵심)
+		String testUrl = "http://localhost:" + port + "/mock/ai";
+		WebClient testWebClient = WebClient.create(testUrl);
+		ReflectionTestUtils.setField(messageService, "webClient", testWebClient);
+
+		// 3. 테스트 데이터 생성
+		String uniqueEmail = "socket_" + UUID.randomUUID().toString().substring(0, 8) + "@test.com";
+
+		Member savedMember = memberRepository.save(Member.builder()
+			.email(uniqueEmail)
+			.password("password")
+			.build());
+
+		savedChat = chatRepository.save(Chat.builder()
+			.member(savedMember)
+			.title("test")
+			.build());
+
+		// 4. 유효한 토큰 생성 (StompHandler 통과용)
+		validToken = jwtTokenProvider.createAccessToken(savedMember.getEmail());
+	}
+
+	@Test
+	@DisplayName("메시지 전송 시 MockAiController를 통해 스트리밍 답변 수신")
+	void shouldReceiveStreamingResponseWhenSendMessage() throws Exception {
+		// given
+		String wsUrl = String.format("ws://localhost:%d/ws/chat", port);
+		StompHeaders headers = new StompHeaders();
+		headers.add("Authorization", "Bearer " + validToken);
+
+		WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+
+		StompSession session = stompClient.connectAsync(wsUrl, handshakeHeaders, headers,
+				new StompSessionHandlerAdapter() {
+				})
+			.get(5, TimeUnit.SECONDS);
+
+		Long chatId = savedChat.getId();
+		String userMessage = "테스트 질문";
+		BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+
+		// when: 구독 (/topic/chat/{chatId})
+		session.subscribe("/topic/chat/" + chatId, new StompFrameHandler() {
+			@NotNull
+			@Override
+			public Type getPayloadType(@NotNull StompHeaders headers) {
+				return String.class;
+			}
+
+			@Override
+			public void handleFrame(@NotNull StompHeaders headers, Object payload) {
+				queue.add((String)payload);
+			}
+		});
+
+		// when: 메시지 전송
+		session.send("/ws/chat/send/" + chatId, userMessage);
+
+		// then: MockAiController가 보내는 응답 검증
+		String response = queue.poll(5, TimeUnit.SECONDS);
+
+		assertThat(response).isNotNull();
+		assertThat(response).startsWith("안");
+	}
+
+	@Test
+	@DisplayName("취소 요청 시 GENERATION_CANCELLED 메시지 수신")
+	void shouldReceiveCancelledMessageWhenCancelRequest() throws Exception {
+		// given
+		String wsUrl = String.format("ws://localhost:%d/ws/chat", port);
+		StompHeaders headers = new StompHeaders();
+		headers.add("Authorization", "Bearer " + validToken);
+
+		WebSocketHttpHeaders handshakeHeaders = new WebSocketHttpHeaders();
+
+		StompSession session = stompClient.connectAsync(wsUrl, handshakeHeaders, headers,
+				new StompSessionHandlerAdapter() {
+				})
+			.get(5, TimeUnit.SECONDS);
+
+		Long chatId = savedChat.getId();
+		BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+
+		session.subscribe("/topic/chat/" + chatId, new StompFrameHandler() {
+			@NotNull
+			@Override
+			public Type getPayloadType(@NotNull StompHeaders headers) {
+				return String.class;
+			}
+
+			@Override
+			public void handleFrame(@NotNull StompHeaders headers, Object payload) {
+				queue.add((String)payload);
+			}
+		});
+
+		// when: 취소 요청 전송
+		session.send("/ws/chat/cancel/" + chatId, "");
+
+		// then
+		String response = queue.poll(5, TimeUnit.SECONDS);
+		assertThat(response).isEqualTo("GENERATION_CANCELLED");
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/manager/SubscriptionManagerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/manager/SubscriptionManagerTest.java
@@ -1,0 +1,67 @@
+package com.sofa.linkiving.domain.chat.manager;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reactor.core.Disposable;
+
+@ExtendWith(MockitoExtension.class)
+public class SubscriptionManagerTest {
+
+	@InjectMocks
+	private SubscriptionManager subscriptionManager;
+
+	@Mock
+	private Disposable disposable;
+
+	@Test
+	@DisplayName("구독 추가 요청 시 기존 구독이 있다면 취소 후 등록")
+	void shouldDisposeOldSubscriptionWhenAdd() {
+		// given
+		String key = "chat-1";
+		Disposable oldDisposable = mock(Disposable.class);
+
+		// 먼저 하나 등록
+		subscriptionManager.add(key, oldDisposable);
+
+		// when: 같은 키로 새로운 구독 등록
+		subscriptionManager.add(key, disposable);
+
+		// then: 이전 구독은 dispose 되어야 함
+		verify(oldDisposable).dispose();
+	}
+
+	@Test
+	@DisplayName("구독 취소 요청 시 dispose 호출 및 제거")
+	void shouldDisposeWhenCancel() {
+		// given
+		String key = "chat-1";
+		subscriptionManager.add(key, disposable);
+
+		// when
+		subscriptionManager.cancel(key);
+
+		// then
+		verify(disposable).dispose();
+	}
+
+	@Test
+	@DisplayName("완료된 구독 제거 요청 시 dispose 없이 맵에서만 제거")
+	void shouldNotDisposeWhenRemove() {
+		// given
+		String key = "chat-1";
+		subscriptionManager.add(key, disposable);
+
+		// when
+		subscriptionManager.remove(key);
+
+		// then: remove는 dispose를 호출하지 않음 (이미 완료된 상태 가정)
+		verify(disposable, never()).dispose();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/ChatQueryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,8 +14,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.error.ChatErrorCode;
 import com.sofa.linkiving.domain.chat.repository.ChatRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
 public class ChatQueryServiceTest {
@@ -40,5 +43,34 @@ public class ChatQueryServiceTest {
 		// then
 		assertThat(result).isEqualTo(chats);
 		verify(chatRepository).findAllByMemberOrderByLastMessageDesc(member);
+	}
+
+	@Test
+	@DisplayName("채팅방 조회 성공 시 Chat 엔티티 반환")
+	void shouldReturnChatWhenChatExists() {
+		// given
+		Long chatId = 1L;
+		Chat chat = mock(Chat.class);
+		given(chatRepository.findByIdAndMember(chatId, member)).willReturn(Optional.of(chat));
+
+		// when
+		Chat result = chatQueryService.findChat(chatId, member);
+
+		// then
+		assertThat(result).isEqualTo(chat);
+		verify(chatRepository).findByIdAndMember(chatId, member);
+	}
+
+	@Test
+	@DisplayName("채팅방 미존재 시 BusinessException(CHAT_NOT_FOUND) 발생")
+	void shouldThrowExceptionWhenChatNotFound() {
+		// given
+		Long chatId = 999L;
+		given(chatRepository.findByIdAndMember(chatId, member)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> chatQueryService.findChat(chatId, member))
+			.isInstanceOf(BusinessException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ChatErrorCode.CHAT_NOT_FOUND);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
@@ -1,0 +1,39 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageCommandServiceTest {
+
+	@InjectMocks
+	private MessageCommandService messageCommandService;
+
+	@Mock
+	private MessageRepository messageRepository;
+
+	@Test
+	@DisplayName("MessageRepository.save 호출 및 저장된 Message 반환")
+	void shouldReturnSavedMessageWhenSaveMessage() {
+		// given
+		Message message = mock(Message.class);
+		given(messageRepository.save(any(Message.class))).willReturn(message);
+
+		// when
+		Message result = messageCommandService.saveMessage(message);
+
+		// then
+		assertThat(result).isEqualTo(message);
+		verify(messageRepository).save(message);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/MessageServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/MessageServiceTest.java
@@ -1,0 +1,74 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.manager.SubscriptionManager;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageServiceTest {
+
+	@InjectMocks
+	private MessageService messageService;
+
+	@Mock
+	private SimpMessagingTemplate messagingTemplate;
+
+	@Mock
+	private SubscriptionManager subscriptionManager;
+
+	@Mock
+	private Chat chat;
+
+	@BeforeEach
+	void setUp() {
+		// Chat ID Mocking
+		lenient().when(chat.getId()).thenReturn(1L);
+	}
+
+	@Test
+	@DisplayName("답변 취소 요청 시 구독 취소 및 취소 메시지 전송")
+	void shouldCancelSubscriptionAndSendMessageWhenCancelAnswer() {
+		// given
+		String roomId = "1";
+
+		// when
+		messageService.cancelAnswer(chat);
+
+		// then
+		verify(subscriptionManager).cancel(roomId);
+		verify(messagingTemplate).convertAndSend(eq("/topic/chat/" + roomId), eq("GENERATION_CANCELLED"));
+	}
+
+	@Test
+	@DisplayName("이미 답변 생성 중일 경우 중복 요청 무시")
+	void shouldIgnoreRequestWhenAlreadyGenerating() {
+		// given
+		// messageBuffers 필드에 강제로 현재 채팅방 ID를 넣어 생성 중인 상태로 만듦
+		@SuppressWarnings("unchecked")
+		Map<String, StringBuilder> buffers = (Map<String, StringBuilder>)ReflectionTestUtils.getField(messageService,
+			"messageBuffers");
+		Assertions.assertNotNull(buffers);
+		buffers.put("1", new StringBuilder());
+
+		// when
+		messageService.generateAnswer(chat, "질문");
+
+		// then
+		// WebClient 호출 로직으로 넘어가지 않아야 하므로 SubscriptionManager 호출이 없어야 함
+		verify(subscriptionManager, never()).add(anyString(), any());
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #113 

## PR 설명
* 사용자의 질문에 대해 AI 답변을 실시간 스트리밍으로 제공하고, 필요 시 생성을 즉시 취소할 수 있는 기능을 구현함.
* `WebSocket(STOMP)`과 `WebFlux(Reactor)`를 활용하여 비동기 논블로킹 방식으로 AI 응답 처리

## 동작 흐름 (Operation Flow)

### 1. 연결 및 구독 (Connection)
1. **Socket 연결**: 클라이언트가 `ws://{domain}/ws/chat` 엔드포인트로 연결을 수립함.
2. **구독 (Subscribe)**: 클라이언트가 `/topic/chat/{chatId}` 경로를 구독하여 메시지 수신 대기 상태로 진입함.

### 2. 답변 생성 (Generate)
1. **질문 전송**: 클라이언트가 `/app/send/{chatId}`로 질문 메시지 전송.
2. **AI 요청 (Async)**: 서버(`MessageService`)가 `WebClient`를 통해 AI 서버로 비동기 요청 전송.
3. **스트리밍**: AI 응답이 오는 즉시 `WebSocket`을 통해 토큰 단위로 클라이언트에게 실시간 푸시.
4. **완료 처리**: 스트림 종료 시 `END_OF_STREAM` 메시지 전송 및 전체 대화 내용 DB 저장.

### 3. 답변 취소 (Cancel)
1. **취소 요청**: 클라이언트가 답변 생성 중 `/app/cancel/{chatId}`로 취소 요청 전송.
2. **리소스 해제**: `SubscriptionManager`가 해당 채팅방의 활성 구독(`Disposable`)을 즉시 해제(`dispose`).
3. **중단 알림**: 클라이언트에게 `GENERATION_CANCELLED` 메시지를 전송하고 스트림 종료.

## 작업 내용

### 1. WebSocket 및 비동기 환경 설정
* **`WebSocketConfig`**: STOMP 엔드포인트(`/ws/chat`) 설정 및 메시지 브로커(`/topic`)를 구성함.
* **`WebMvcConfig`**: 비동기 작업 처리를 위한 `mvcTaskExecutor` 설정을 추가함.
* **`StompHandler`**: WebSocket 연결 시 JWT 토큰을 검증하고 인증 정보(`Authentication`)를 주입하는 인터셉터를 구현함.

### 2. 비즈니스 로직 (`MessageService`, `SubscriptionManager`)
* **스트리밍 아키텍처**: `WebClient`를 사용하여 AI 서버로부터 스트림 데이터를 수신(`Flux`)하고, `SimpMessagingTemplate`으로 실시간 전송함.
* **취소 기능**: `SubscriptionManager`를 통해 활성 구독(`Disposable`)을 관리하며, 취소 요청 시 즉시 자원을 해제함.
* **중복 방지**: `MessageService` 내부 버퍼를 확인하여 이미 답변 생성 중인 채팅방에 대한 중복 요청을 무시함.

### 3. 테스트 작성 (통합 및 유닛 테스트)
* **Integration Test (`WebSocketChatIntegrationTest`)**:
    * 실제 웹소켓 환경(`WebSocketStompClient`)을 구축하여 연결, 구독, 메시지 전송, 스트리밍 수신, 취소 기능까지 전체 흐름을 검증함.
    * `ReflectionTestUtils`로 `WebClient` 타겟을 `MockAiController`로 변경하여 외부 AI 서버 없이 테스트 가능하도록 구성함.
* **Unit Test (Service/Manager Layer)**:
    * **`SubscriptionManagerTest`**: 구독 추가, 취소, 제거 시 `Disposable` 자원 해제가 올바르게 호출되는지 검증함.
    * **`MessageServiceTest`**: 답변 취소 시 구독 해제 및 취소 메시지 전송 여부, 중복 요청 무시 로직을 테스트함.
    * **`ChatQueryServiceTest`**: 존재하지 않는 채팅방 조회 시 예외 처리(`CHAT_NOT_FOUND`)를 확인함.
* **Repository Test (`ChatRepositoryTest`)**:
    * **보안 검증**: `getChatByIdAndMember` 메서드가 본인의 채팅방만 조회하고, 타인의 채팅방 접근 시 `Empty`를 반환하는지 확인함.

## 테스트 방법

### 1. 테스트 페이지 생성 (`src/main/resources/static/chat.html`)
* **기능**:
    * JWT 토큰 기반 STOMP 연결.
    * `/topic/chat/{chatId}` 구독 및 메시지 수신.
    * 메시지 전송 및 답변 생성 취소 버튼 구현.
* **파일 내용**: [chat.html](https://github.com/user-attachments/files/24154148/chat.html)

### 2. Security 설정 허용 (`SecurityConfig`)
* 테스트 페이지(`chat.html`)에 브라우저에서 직접 접근할 수 있도록 `PERMIT_URLS` 목록에 `/chat.html`을 추가합니다.

### 3. 테스트 실행 순서
1. 서버 실행 후 `http://localhost:8080/chat.html` 접속.
2. 발급받은 `AccessToken` 입력 및 `chatId` 입력 후 `연결` 버튼 클릭.
3. 메시지 전송 및 취소 기능 테스트.

