### PR TITLE
`Chat` 도메인 엔티티 수정 및 ERD 반영

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Chat.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Chat.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.chat.entity;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -22,8 +23,12 @@ public class Chat extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
+	@Column(nullable = false)
+	private String title;
+
 	@Builder
-	public Chat(Member member) {
+	public Chat(Member member, String title) {
 		this.member = member;
+		this.title = title;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
@@ -3,11 +3,12 @@ package com.sofa.linkiving.domain.chat.entity;
 import com.sofa.linkiving.domain.chat.enums.Sentiment;
 import com.sofa.linkiving.global.common.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,8 +20,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "feedbacks")
 public class Feedback extends BaseEntity {
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "message_id", nullable = false)
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinColumn(name = "message_id")
 	private Message message;
 
 	@Column(columnDefinition = "text", nullable = false)

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
@@ -3,8 +3,6 @@ package com.sofa.linkiving.domain.chat.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.annotations.BatchSize;
-
 import com.sofa.linkiving.domain.chat.enums.Type;
 import com.sofa.linkiving.global.common.BaseEntity;
 import com.sofa.linkiving.global.converter.LongListToStringConverter;
@@ -15,7 +13,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,24 +36,17 @@ public class Message extends BaseEntity {
 	@Column(columnDefinition = "text", nullable = false)
 	private String content;
 
-	@Column(name = "original_prompt", columnDefinition = "text")
-	private String originalPrompt;
-
 	@Convert(converter = LongListToStringConverter.class)
 	private List<Long> linkIds = new ArrayList<>();
 
-	@OneToMany(mappedBy = "message")
-	@BatchSize(size = 100)
-	private List<Feedback> feedbacks = new ArrayList<>();
+	@OneToOne(mappedBy = "message")
+	private Feedback feedback;
 
 	@Builder
-	public Message(Chat chat, Type type, String content, String originalPrompt, List<Long> linkIds,
-		List<Feedback> feedbacks) {
+	public Message(Chat chat, Type type, String content, List<Long> linkIds) {
 		this.chat = chat;
 		this.type = type;
 		this.content = content;
-		this.originalPrompt = originalPrompt;
 		this.linkIds = linkIds;
-		this.feedbacks = feedbacks;
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/ChatTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/ChatTest.java
@@ -30,6 +30,7 @@ public class ChatTest {
 
 		Chat chat = Chat.builder()
 			.member(member)
+			.title("test")
 			.build();
 
 		// when

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
@@ -23,7 +23,6 @@ public class FeedbackTest {
 	private TestEntityManager em;
 
 	@Test
-	// ❌ "저장된다" (X) -> ⭕ "정상 저장" (O)
 	@DisplayName("피드백 저장 시 메시지 연관관계 및 감정 상태 정상 저장")
 	void shouldSaveFeedbackWithSentiment() {
 		// given
@@ -34,7 +33,10 @@ public class FeedbackTest {
 			.build();
 		em.persist(member);
 
-		Chat chat = Chat.builder().member(member).build();
+		Chat chat = Chat.builder()
+			.member(member)
+			.title("test")
+			.build();
 		em.persist(chat);
 
 		Message message = Message.builder()
@@ -59,7 +61,7 @@ public class FeedbackTest {
 
 		// then
 		assertThat(savedFeedback).isNotNull();
-		assertThat(savedFeedback.getMessage()).isEqualTo(message);
+		assertThat(savedFeedback.getMessage().getId()).isEqualTo(message.getId());
 		assertThat(savedFeedback.getText()).isEqualTo(feedbackText);
 		assertThat(savedFeedback.getSentiment()).isEqualTo(sentiment);
 	}

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/MessageTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/MessageTest.java
@@ -32,18 +32,19 @@ public class MessageTest {
 			.build();
 		em.persist(member);
 
-		Chat chat = Chat.builder().member(member).build();
+		Chat chat = Chat.builder()
+			.member(member)
+			.title("test")
+			.build();
 		em.persist(chat);
 
 		List<Long> linkIds = List.of(1L, 100L, 500L);
 		String content = "테스트 메시지입니다.";
-		String prompt = "원본 프롬프트";
 
 		Message message = Message.builder()
 			.chat(chat)
 			.type(Type.AI)
 			.content(content)
-			.originalPrompt(prompt)
 			.linkIds(linkIds)
 			.build();
 
@@ -53,7 +54,6 @@ public class MessageTest {
 		// then
 		assertThat(savedMessage).isNotNull();
 		assertThat(savedMessage.getContent()).isEqualTo(content);
-		assertThat(savedMessage.getOriginalPrompt()).isEqualTo(prompt);
 		assertThat(savedMessage.getChat()).isEqualTo(chat);
 
 		// Converter 동작 검증


### PR DESCRIPTION
## 관련 이슈

- close #130 

## PR 설명
최신 ERD 수정 사항을 반영하여 Chat 도메인의 엔티티(`Chat`, `Message`, `Feedback`) 구조를 변경함.
불필요한 필드를 제거하고, 엔티티 간 연관관계를 재정의하여 데이터 모델을 최적화함.

## 작업 내용

### 1. Entity 수정
* **`Chat`**
    * `title` 필드 추가
* **`Message`**
    * `originalPrompt` 필드 삭제함.
    * `Feedback`과의 양방향 매핑을 위해 `mappedBy` 설정 추가
* **`Feedback`**
    * `Message`와의 연관관계를 `1:1`(`@OneToOne`)로 변경
    * `message_id`를 FK로 소유하며, `CascadeType.ALL`을 적용하여 메시지 삭제 시 피드백도 함께 관리되도록 설정

### 2. 테스트 수정
* **`FeedbackTest`**: `1:1` 관계 변경에 따른 빌더 패턴 수정 및 저장 로직 검증
* **`MessageTest`**: 필드 삭제 사항을 반영
* **`ChatTest`**: 변경된 구조 기반으로 `Member`와의 연관관계 매핑 정상 동작 확인
