### PR TITLE
중복 체크 API에 linkId 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -11,6 +11,7 @@ import com.sofa.linkiving.domain.link.dto.request.LinkCreateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
+import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
@@ -23,8 +24,8 @@ import jakarta.validation.Valid;
 @Tag(name = "Link", description = "링크 관리 API")
 public interface LinkApi {
 
-	@Operation(summary = "URL 중복 체크", description = "저장하려는 URL이 이미 존재하는지 확인합니다")
-	ResponseEntity<BaseResponse<Boolean>> checkDuplicate(
+	@Operation(summary = "URL 중복 체크", description = "저장하려는 URL이 이미 존재하는지 확인하고, 존재 시 linkId를 반환합니다")
+	ResponseEntity<BaseResponse<LinkDuplicateCheckRes>> checkDuplicate(
 		@RequestParam String url,
 		@AuthMember Member member
 	);

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -19,6 +19,7 @@ import com.sofa.linkiving.domain.link.dto.request.LinkCreateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
+import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.facade.LinkFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -37,12 +38,12 @@ public class LinkController implements LinkApi {
 
 	@Override
 	@GetMapping("/duplicate")
-	public ResponseEntity<BaseResponse<Boolean>> checkDuplicate(
+	public ResponseEntity<BaseResponse<LinkDuplicateCheckRes>> checkDuplicate(
 		@RequestParam String url,
 		@AuthMember Member member
 	) {
-		boolean exists = linkFacade.checkDuplicate(member, url);
-		return ResponseEntity.ok(BaseResponse.success(exists, "URL 중복 체크 완료"));
+		LinkDuplicateCheckRes response = linkFacade.checkDuplicate(member, url);
+		return ResponseEntity.ok(BaseResponse.success(response, "URL 중복 체크 완료"));
 	}
 
 	@Override

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDuplicateCheckRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDuplicateCheckRes.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LinkDuplicateCheckRes(
+	@Schema(description = "URL 중복 여부", example = "true")
+	boolean exists,
+
+	@Schema(description = "중복된 링크 ID (exists가 true일 때만 반환)", example = "123")
+	Long linkId
+) {
+	public static LinkDuplicateCheckRes notExists() {
+		return new LinkDuplicateCheckRes(false, null);
+	}
+
+	public static LinkDuplicateCheckRes exists(Long linkId) {
+		return new LinkDuplicateCheckRes(true, linkId);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -46,7 +47,7 @@ public class LinkFacade {
 		return linkService.getLinkList(member, pageable);
 	}
 
-	public boolean checkDuplicate(Member member, String url) {
+	public LinkDuplicateCheckRes checkDuplicate(Member member, String url) {
 		return linkService.checkDuplicate(member, url);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -16,4 +18,7 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 	Page<Link> findByMemberAndIsDeleteFalse(Member member, Pageable pageable);
 
 	boolean existsByMemberAndUrlAndIsDeleteFalse(Member member, String url);
+
+	@Query("SELECT l.id FROM Link l WHERE l.member = :member AND l.url = :url AND l.isDelete = false")
+	Optional<Long> findIdByMemberAndUrlAndIsDeleteFalse(@Param("member") Member member, @Param("url") String url);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
@@ -1,5 +1,7 @@
 package com.sofa.linkiving.domain.link.service;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -34,5 +36,9 @@ public class LinkQueryService {
 
 	public boolean existsByUrl(Member member, String url) {
 		return linkRepository.existsByMemberAndUrlAndIsDeleteFalse(member, url);
+	}
+
+	public Optional<Long> findIdByUrl(Member member, String url) {
+		return linkRepository.findIdByMemberAndUrlAndIsDeleteFalse(member, url);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
@@ -97,7 +98,9 @@ public class LinkService {
 	}
 
 	@Transactional(readOnly = true)
-	public boolean checkDuplicate(Member member, String url) {
-		return linkQueryService.existsByUrl(member, url);
+	public LinkDuplicateCheckRes checkDuplicate(Member member, String url) {
+		return linkQueryService.findIdByUrl(member, url)
+			.map(LinkDuplicateCheckRes::exists)
+			.orElse(LinkDuplicateCheckRes.notExists());
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -275,7 +275,8 @@ public class LinkApiIntegrationTest {
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data").value(true))
+			.andExpect(jsonPath("$.data.exists").value(true))
+			.andExpect(jsonPath("$.data.linkId").isNumber())
 			.andExpect(jsonPath("$.message").value("URL 중복 체크 완료"));
 	}
 
@@ -295,7 +296,8 @@ public class LinkApiIntegrationTest {
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data").value(false));
+			.andExpect(jsonPath("$.data.exists").value(false))
+			.andExpect(jsonPath("$.data.linkId").isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

- close #133 

## PR 설명
 - Link 중복 체크 API 응답을 개선하여 중복 여부와 함께 중복된 링크의 ID를 반환하도록 수정했습니다.

주요 변경 내용

  1. 응답 DTO 추가
  - LinkDuplicateCheckRes 생성
    - exists: URL 중복 여부 (boolean)
    - linkId: 중복된 링크 ID (Long, 중복 시에만 값 존재)

  2. API 응답 타입 변경
  - 기존: `ResponseEntity<BaseResponse<Boolean>>`
  - 변경: `ResponseEntity<BaseResponse<LinkDuplicateCheckRes>>` 

  3. 서비스 로직 개선
  - existsByUrl() 대신 findByUrl() 활용
  - 중복된 경우 Link ID를 포함한 응답 반환

  중복되지 않은 경우:
```
  {
    "exists": false,
    "linkId": null
  }
```

  중복된 경우:
```
  {
    "exists": true,
    "linkId": 123
  }
```

 ### 개선 효과

  - 프론트엔드에서 중복된 링크로 바로 이동 가능
  - 중복 확인 후 추가 API 호출 없이 링크 ID 획득
  - 클라이언트 측 UX 개선
