### PR TITLE
Link 도메인 엔티티 수정

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -57,10 +57,7 @@ public class LinkController implements LinkApi {
 			request.url(),
 			request.title(),
 			request.memo(),
-			request.imageUrl(),
-			request.metadataJson(),
-			request.tags(),
-			request.isImportant()
+			request.imageUrl()
 		);
 		return ResponseEntity.ok(BaseResponse.success(response, "링크 생성 완료"));
 	}
@@ -76,10 +73,7 @@ public class LinkController implements LinkApi {
 			id,
 			member,
 			request.title(),
-			request.memo(),
-			request.metadataJson(),
-			request.tags(),
-			request.isImportant()
+			request.memo()
 		);
 		return ResponseEntity.ok(BaseResponse.success(response, "링크 수정 완료"));
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
@@ -19,15 +19,6 @@ public record LinkCreateReq(
 	String memo,
 
 	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
-	String imageUrl,
-
-	@Schema(description = "메타데이터 JSON")
-	String metadataJson,
-
-	@Schema(description = "태그 (쉼표로 구분)", example = "개발,자료,참고")
-	String tags,
-
-	@Schema(description = "중요 여부", example = "false")
-	boolean isImportant
+	String imageUrl
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkUpdateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkUpdateReq.java
@@ -9,15 +9,6 @@ public record LinkUpdateReq(
 	String title,
 
 	@Schema(description = "메모", example = "나중에 읽어볼 것")
-	String memo,
-
-	@Schema(description = "메타데이터 JSON")
-	String metadataJson,
-
-	@Schema(description = "태그 (쉼표로 구분)", example = "개발,자료,참고")
-	String tags,
-
-	@Schema(description = "중요 여부", example = "true")
-	Boolean isImportant
+	String memo
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
@@ -1,7 +1,5 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
-import java.time.LocalDateTime;
-
 import com.sofa.linkiving.domain.link.entity.Link;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,22 +18,7 @@ public record LinkRes(
 	String memo,
 
 	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
-	String imageUrl,
-
-	@Schema(description = "메타데이터 JSON")
-	String metadataJson,
-
-	@Schema(description = "태그 (쉼표로 구분)", example = "개발,자료,참고")
-	String tags,
-
-	@Schema(description = "중요 여부")
-	boolean isImportant,
-
-	@Schema(description = "생성 일시")
-	LocalDateTime createdAt,
-
-	@Schema(description = "수정 일시")
-	LocalDateTime updatedAt
+	String imageUrl
 ) {
 	public static LinkRes from(Link link) {
 		return new LinkRes(
@@ -43,12 +26,7 @@ public record LinkRes(
 			link.getUrl(),
 			link.getTitle(),
 			link.getMemo(),
-			link.getImageUrl(),
-			link.getMetadataJson(),
-			link.getTags(),
-			link.isImportant(),
-			link.getCreatedAt(),
-			link.getUpdatedAt()
+			link.getImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
@@ -34,57 +34,31 @@ public class Link extends BaseEntity {
 	@Column(name = "image_url", length = 2048)
 	private String imageUrl;
 
-	@Column(name = "metadata_json", columnDefinition = "TEXT")
-	private String metadataJson;
-
-	@Column(columnDefinition = "TEXT")
-	private String tags;
-
-	@Column(name = "is_important", nullable = false)
-	private boolean isImportant = false;
-
 	@Builder
-	public Link(Member member, String url, String title, String memo, String imageUrl,
-		String metadataJson, String tags, boolean isImportant) {
+	public Link(Member member, String url, String title, String memo, String imageUrl) {
 		this.member = member;
 		this.url = url;
 		this.title = title;
 		this.memo = memo;
 		this.imageUrl = imageUrl;
-		this.metadataJson = metadataJson;
-		this.tags = tags;
-		this.isImportant = isImportant;
 	}
 
-	public static Link create(Member member, String url, String title, String memo,
-		String imageUrl, String metadataJson, String tags, boolean isImportant) {
+	public static Link create(Member member, String url, String title, String memo, String imageUrl) {
 		return Link.builder()
 			.member(member)
 			.url(url)
 			.title(title)
 			.memo(memo)
 			.imageUrl(imageUrl)
-			.metadataJson(metadataJson)
-			.tags(tags)
-			.isImportant(isImportant)
 			.build();
 	}
 
-	public void updateDetails(String title, String memo, String metadataJson, String tags, Boolean isImportant) {
+	public void updateDetails(String title, String memo) {
 		if (title != null) {
 			this.title = title;
 		}
 		if (memo != null) {
 			this.memo = memo;
-		}
-		if (metadataJson != null) {
-			this.metadataJson = metadataJson;
-		}
-		if (tags != null) {
-			this.tags = tags;
-		}
-		if (isImportant != null) {
-			this.isImportant = isImportant;
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
@@ -22,20 +22,20 @@ public class Summary extends BaseEntity {
 	@JoinColumn(name = "link_id", nullable = false)
 	private Link link;
 
-	@Column(nullable = false)
-	private int version;
-
 	@Column(length = 64)
 	private Format format;
 
 	@Column(columnDefinition = "TEXT", nullable = false)
-	private String body;
+	private String content;
+
+	@Column(name = "select", columnDefinition = "TEXT")
+	private String select;
 
 	@Builder
-	public Summary(Link link, int version, Format format, String body) {
+	public Summary(Link link, Format format, String content, String select) {
 		this.link = link;
-		this.version = version;
 		this.format = format;
-		this.body = body;
+		this.content = content;
+		this.select = select;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -17,14 +17,12 @@ public class LinkFacade {
 
 	private final LinkService linkService;
 
-	public LinkRes createLink(Member member, String url, String title, String memo,
-		String imageUrl, String metadataJson, String tags, boolean isImportant) {
-		return linkService.createLink(member, url, title, memo, imageUrl, metadataJson, tags, isImportant);
+	public LinkRes createLink(Member member, String url, String title, String memo, String imageUrl) {
+		return linkService.createLink(member, url, title, memo, imageUrl);
 	}
 
-	public LinkRes updateLink(Long linkId, Member member, String title, String memo,
-		String metadataJson, String tags, Boolean isImportant) {
-		return linkService.updateLink(linkId, member, title, memo, metadataJson, tags, isImportant);
+	public LinkRes updateLink(Long linkId, Member member, String title, String memo) {
+		return linkService.updateLink(linkId, member, title, memo);
 	}
 
 	public LinkRes updateTitle(Long linkId, Member member, String title) {

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
@@ -16,15 +16,13 @@ public class LinkCommandService {
 
 	private final LinkRepository linkRepository;
 
-	public Link saveLink(Member member, String url, String title, String memo,
-		String imageUrl, String metadataJson, String tags, boolean isImportant) {
-		Link link = Link.create(member, url, title, memo, imageUrl, metadataJson, tags, isImportant);
+	public Link saveLink(Member member, String url, String title, String memo, String imageUrl) {
+		Link link = Link.create(member, url, title, memo, imageUrl);
 		return linkRepository.save(link);
 	}
 
-	public Link updateLink(Link link, String title, String memo,
-		String metadataJson, String tags, Boolean isImportant) {
-		link.updateDetails(title, memo, metadataJson, tags, isImportant);
+	public Link updateLink(Link link, String title, String memo) {
+		link.updateDetails(title, memo);
 		return link;
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -24,22 +24,20 @@ public class LinkService {
 	private final LinkCommandService linkCommandService;
 	private final LinkQueryService linkQueryService;
 
-	public LinkRes createLink(Member member, String url, String title, String memo,
-		String imageUrl, String metadataJson, String tags, boolean isImportant) {
+	public LinkRes createLink(Member member, String url, String title, String memo, String imageUrl) {
 		if (linkQueryService.existsByUrl(member, url)) {
 			throw new BusinessException(LinkErrorCode.DUPLICATE_URL);
 		}
 
-		Link link = linkCommandService.saveLink(member, url, title, memo, imageUrl, metadataJson, tags, isImportant);
+		Link link = linkCommandService.saveLink(member, url, title, memo, imageUrl);
 		log.info("Link created - id: {}, memberId: {}, url: {}", link.getId(), member.getId(), url);
 
 		return LinkRes.from(link);
 	}
 
-	public LinkRes updateLink(Long linkId, Member member, String title, String memo,
-		String metadataJson, String tags, Boolean isImportant) {
+	public LinkRes updateLink(Long linkId, Member member, String title, String memo) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(link, title, memo, metadataJson, tags, isImportant);
+		Link updatedLink = linkCommandService.updateLink(link, title, memo);
 
 		log.info("Link updated - id: {}, memberId: {}", linkId, member.getId());
 
@@ -48,14 +46,7 @@ public class LinkService {
 
 	public LinkRes updateTitle(Long linkId, Member member, String title) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(
-			link,
-			title,
-			link.getMemo(),
-			link.getMetadataJson(),
-			link.getTags(),
-			link.isImportant()
-		);
+		Link updatedLink = linkCommandService.updateLink(link, title, link.getMemo());
 
 		log.info("Link title updated - id: {}, memberId: {}", linkId, member.getId());
 
@@ -64,14 +55,7 @@ public class LinkService {
 
 	public LinkRes updateMemo(Long linkId, Member member, String memo) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(
-			link,
-			link.getTitle(),
-			memo,
-			link.getMetadataJson(),
-			link.getTags(),
-			link.isImportant()
-		);
+		Link updatedLink = linkCommandService.updateLink(link, link.getTitle(), memo);
 
 		log.info("Link memo updated - id: {}, memberId: {}", linkId, member.getId());
 

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/LinkTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/LinkTest.java
@@ -26,7 +26,6 @@ public class LinkTest {
 		assertThat(link.getMember()).isEqualTo(member);
 		assertThat(link.getUrl()).isEqualTo(url);
 		assertThat(link.getTitle()).isEqualTo(title);
-		assertThat(link.isImportant()).isFalse();
 	}
 
 	@Test
@@ -39,9 +38,6 @@ public class LinkTest {
 		String title = "Example Title";
 		String memo = "Test memo";
 		String imageUrl = "https://example.com/image.jpg";
-		String metadataJson = "{\"key\":\"value\"}";
-		String tags = "[\"tag1\",\"tag2\"]";
-		boolean isImportant = true;
 
 		Link link = Link.builder()
 			.member(member)
@@ -49,9 +45,6 @@ public class LinkTest {
 			.title(title)
 			.memo(memo)
 			.imageUrl(imageUrl)
-			.metadataJson(metadataJson)
-			.tags(tags)
-			.isImportant(isImportant)
 			.build();
 
 		assertThat(link.getMember()).isEqualTo(member);
@@ -59,8 +52,5 @@ public class LinkTest {
 		assertThat(link.getTitle()).isEqualTo(title);
 		assertThat(link.getMemo()).isEqualTo(memo);
 		assertThat(link.getImageUrl()).isEqualTo(imageUrl);
-		assertThat(link.getMetadataJson()).isEqualTo(metadataJson);
-		assertThat(link.getTags()).isEqualTo(tags);
-		assertThat(link.isImportant()).isTrue();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
@@ -23,23 +23,20 @@ public class SummaryTest {
 			.title("Test Title")
 			.build();
 
-		int version = 1;
 		Format format = Format.DETAILED;
-		String body = "This is a summary";
+		String content = "This is a summary";
 
 		//when
 		Summary summary = Summary.builder()
 			.link(link)
-			.version(version)
 			.format(format)
-			.body(body)
+			.content(content)
 			.build();
 
 		//then
 		assertThat(summary.getLink()).isEqualTo(link);
-		assertThat(summary.getVersion()).isEqualTo(version);
 		assertThat(summary.getFormat()).isEqualTo(format);
-		assertThat(summary.getBody()).isEqualTo(body);
+		assertThat(summary.getContent()).isEqualTo(content);
 	}
 
 	@Test
@@ -56,20 +53,20 @@ public class SummaryTest {
 			.title("Test Title")
 			.build();
 
-		int version = 2;
 		Format format = Format.DETAILED;
-		String body = "This is a detailed summary";
+		String content = "This is a detailed summary";
+		String select = "Selected text from the page";
 
 		Summary summary = Summary.builder()
 			.link(link)
-			.version(version)
 			.format(format)
-			.body(body)
+			.content(content)
+			.select(select)
 			.build();
 
 		assertThat(summary.getLink()).isEqualTo(link);
-		assertThat(summary.getVersion()).isEqualTo(version);
-		assertThat(summary.getBody()).isEqualTo(body);
+		assertThat(summary.getContent()).isEqualTo(content);
 		assertThat(summary.getFormat()).isEqualTo(format);
+		assertThat(summary.getSelect()).isEqualTo(select);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ActiveProfiles;
@@ -29,7 +28,6 @@ import com.sofa.linkiving.domain.link.repository.LinkRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
-import com.sofa.linkiving.infra.feign.TestExternalClient;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
 @SpringBootTest
@@ -51,11 +49,8 @@ public class LinkApiIntegrationTest {
 
 	@Autowired
 	MemberRepository memberRepository;
-
-	@MockBean
-	private TestExternalClient testExternalClient;
-
 	private Member testMember;
+
 	private Member otherMember;
 	private UserDetails testUserDetails;
 	private UserDetails otherUserDetails;
@@ -80,15 +75,7 @@ public class LinkApiIntegrationTest {
 	@DisplayName("링크 생성 성공 시 DB에 저장되고 200 OK 응답")
 	void shouldCreateLinkSuccessfully() throws Exception {
 		// given
-		LinkCreateReq req = new LinkCreateReq(
-			"https://example.com",
-			"테스트 링크",
-			"테스트 메모",
-			null,
-			null,
-			"tag1,tag2",
-			false
-		);
+		LinkCreateReq req = new LinkCreateReq("https://example.com", "테스트 링크", "테스트 메모", null);
 
 		// when & then
 		mockMvc.perform(
@@ -105,9 +92,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.message").value("링크 생성 완료"))
 			.andExpect(jsonPath("$.data.url").value(req.url()))
 			.andExpect(jsonPath("$.data.title").value(req.title()))
-			.andExpect(jsonPath("$.data.memo").value(req.memo()))
-			.andExpect(jsonPath("$.data.tags").value(req.tags()))
-			.andExpect(jsonPath("$.data.isImportant").value(req.isImportant()));
+			.andExpect(jsonPath("$.data.memo").value(req.memo()));
 
 		// DB 검증
 		boolean exists = linkRepository.existsByMemberAndUrlAndIsDeleteFalse(testMember, req.url());
@@ -125,15 +110,7 @@ public class LinkApiIntegrationTest {
 			.title("기존 링크")
 			.build());
 
-		LinkCreateReq req = new LinkCreateReq(
-			duplicateUrl,
-			"새 링크",
-			null,
-			null,
-			null,
-			null,
-			false
-		);
+		LinkCreateReq req = new LinkCreateReq(duplicateUrl, "새 링크", null, null);
 
 		// when & then
 		mockMvc.perform(
@@ -341,17 +318,9 @@ public class LinkApiIntegrationTest {
 			.url("https://example.com")
 			.title("원래 제목")
 			.memo("원래 메모")
-			.tags("tag1")
-			.isImportant(false)
 			.build());
 
-		LinkUpdateReq req = new LinkUpdateReq(
-			"수정된 제목",
-			"수정된 메모",
-			null,
-			"tag1,tag2",
-			true
-		);
+		LinkUpdateReq req = new LinkUpdateReq("수정된 제목", "수정된 메모");
 
 		// when & then
 		mockMvc.perform(
@@ -366,16 +335,12 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("링크 수정 완료"))
 			.andExpect(jsonPath("$.data.title").value(req.title()))
-			.andExpect(jsonPath("$.data.memo").value(req.memo()))
-			.andExpect(jsonPath("$.data.tags").value(req.tags()))
-			.andExpect(jsonPath("$.data.isImportant").value(req.isImportant()));
+			.andExpect(jsonPath("$.data.memo").value(req.memo()));
 
 		// DB 검증
 		Link updated = linkRepository.findById(link.getId()).orElseThrow();
 		assertThat(updated.getTitle()).isEqualTo(req.title());
 		assertThat(updated.getMemo()).isEqualTo(req.memo());
-		assertThat(updated.getTags()).isEqualTo(req.tags());
-		assertThat(updated.isImportant()).isEqualTo(req.isImportant());
 	}
 
 	@Test
@@ -516,8 +481,7 @@ public class LinkApiIntegrationTest {
 		String invalidJson = """
 			{
 				"title": "테스트 링크",
-				"memo": "메모",
-				"isImportant": false
+				"memo": "메모"
 			}
 			""";
 
@@ -539,8 +503,7 @@ public class LinkApiIntegrationTest {
 		String invalidJson = """
 			{
 				"url": "https://example.com",
-				"memo": "메모",
-				"isImportant": false
+				"memo": "메모"
 			}
 			""";
 
@@ -564,10 +527,7 @@ public class LinkApiIntegrationTest {
 			"https://example.com",
 			longTitle,
 			null,
-			null,
-			null,
-			null,
-			false
+			null
 		);
 
 		// when & then
@@ -586,15 +546,7 @@ public class LinkApiIntegrationTest {
 	void shouldFailWhenUrlExceedsMaxLength() throws Exception {
 		// given
 		String longUrl = "https://example.com/" + "a".repeat(2048);
-		LinkCreateReq req = new LinkCreateReq(
-			longUrl,
-			"테스트 링크",
-			null,
-			null,
-			null,
-			null,
-			false
-		);
+		LinkCreateReq req = new LinkCreateReq(longUrl, "테스트 링크", null, null);
 
 		// when & then
 		mockMvc.perform(

--- a/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
@@ -49,10 +49,6 @@ class LinkRepositoryTest {
 			.url("https://example.com")
 			.title("테스트 링크")
 			.memo("테스트 메모")
-			.imageUrl("https://example.com/image.jpg")
-			.metadataJson("{\"key\":\"value\"}")
-			.tags("[\"tag1\",\"tag2\"]")
-			.isImportant(false)
 			.build();
 
 		// when

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
@@ -40,9 +40,6 @@ class LinkCommandServiceTest {
 			.title("테스트 링크")
 			.memo("메모")
 			.imageUrl("https://example.com/image.jpg")
-			.metadataJson("{}")
-			.tags("tag1,tag2")
-			.isImportant(false)
 			.build();
 
 		given(linkRepository.save(any(Link.class))).willReturn(link);
@@ -53,10 +50,7 @@ class LinkCommandServiceTest {
 			"https://example.com",
 			"테스트 링크",
 			"메모",
-			"https://example.com/image.jpg",
-			"{}",
-			"tag1,tag2",
-			false
+			"https://example.com/image.jpg"
 		);
 
 		// then
@@ -80,28 +74,19 @@ class LinkCommandServiceTest {
 			.title("원본 제목")
 			.memo("원본 메모")
 			.imageUrl("https://example.com/image.jpg")
-			.metadataJson("{}")
-			.tags("tag1")
-			.isImportant(false)
 			.build();
 
 		// when
 		Link result = linkCommandService.updateLink(
 			originalLink,
 			"수정된 제목",
-			"수정된 메모",
-			"{}",
-			"tag1,tag2",
-			true
+			"수정된 메모"
 		);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getTitle()).isEqualTo("수정된 제목");
 		assertThat(result.getMemo()).isEqualTo("수정된 메모");
-		assertThat(result.getMetadataJson()).isEqualTo("{}");
-		assertThat(result.getTags()).isEqualTo("tag1,tag2");
-		assertThat(result.isImportant()).isTrue();
 		verify(linkRepository, never()).save(any(Link.class));
 	}
 

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -53,7 +53,7 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.existsByUrl(member, "https://example.com")).willReturn(false);
-		given(linkCommandService.saveLink(any(), any(), any(), any(), any(), any(), any(), anyBoolean()))
+		given(linkCommandService.saveLink(any(), any(), any(), any(), any()))
 			.willReturn(link);
 
 		// when
@@ -62,17 +62,14 @@ class LinkServiceTest {
 			"https://example.com",
 			"테스트 링크",
 			"메모",
-			null,
-			null,
-			null,
-			false
+			null
 		);
 
 		// then
 		assertThat(createdLink).isNotNull();
 		assertThat(createdLink.url()).isEqualTo("https://example.com");
 		verify(linkQueryService, times(1)).existsByUrl(member, "https://example.com");
-		verify(linkCommandService, times(1)).saveLink(any(), any(), any(), any(), any(), any(), any(), anyBoolean());
+		verify(linkCommandService, times(1)).saveLink(any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -92,16 +89,13 @@ class LinkServiceTest {
 			"https://example.com",
 			"테스트 링크",
 			null,
-			null,
-			null,
-			null,
-			false
+			null
 		))
 			.isInstanceOf(BusinessException.class)
 			.hasFieldOrPropertyWithValue("errorCode", LinkErrorCode.DUPLICATE_URL);
 
 		verify(linkQueryService, times(1)).existsByUrl(member, "https://example.com");
-		verify(linkCommandService, never()).saveLink(any(), any(), any(), any(), any(), any(), any(), anyBoolean());
+		verify(linkCommandService, never()).saveLink(any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -126,16 +120,16 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), any(), any(), any(), any(), any())).willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), any(), any())).willReturn(updatedLink);
 
 		// when
-		LinkRes result = linkService.updateLink(1L, member, "수정된 제목", null, null, null, null);
+		LinkRes result = linkService.updateLink(1L, member, "수정된 제목", null);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.title()).isEqualTo("수정된 제목");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), any(), any(), any(), any(), any());
+		verify(linkCommandService, times(1)).updateLink(any(), any(), any());
 	}
 
 	@Test
@@ -162,7 +156,7 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("수정된 제목"), eq("원본 메모"), any(), any(), anyBoolean()))
+		given(linkCommandService.updateLink(any(), eq("수정된 제목"), eq("원본 메모")))
 			.willReturn(updatedLink);
 
 		// when
@@ -173,7 +167,7 @@ class LinkServiceTest {
 		assertThat(result.title()).isEqualTo("수정된 제목");
 		assertThat(result.memo()).isEqualTo("원본 메모");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), eq("수정된 제목"), eq("원본 메모"), any(), any(), anyBoolean());
+		verify(linkCommandService, times(1)).updateLink(any(), eq("수정된 제목"), eq("원본 메모"));
 	}
 
 	@Test
@@ -200,7 +194,7 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("원본 제목"), eq("수정된 메모"), any(), any(), anyBoolean()))
+		given(linkCommandService.updateLink(any(), eq("원본 제목"), eq("수정된 메모")))
 			.willReturn(updatedLink);
 
 		// when
@@ -211,7 +205,7 @@ class LinkServiceTest {
 		assertThat(result.title()).isEqualTo("원본 제목");
 		assertThat(result.memo()).isEqualTo("수정된 메모");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), eq("원본 제목"), eq("수정된 메모"), any(), any(), anyBoolean());
+		verify(linkCommandService, times(1)).updateLink(any(), eq("원본 제목"), eq("수정된 메모"));
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

- close #132 

## PR 설명
최신 ERD 수정 사항을 반영하여 Link 및 Summary 엔티티 구조를 변경해야 함.

 1. Link Entity 
  - `isImportant` 필드 삭제
  - `metadataJson` 필드 삭제
  - `tags `필드 삭제

  2. Summary Entity 
  - `version` 필드 삭제
  - `body` → `content`로 이름 변경
  - `select` 필드 추가 

  3. DTO 업데이트