### PR TITLE
Linkservice transactional 제거

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.facade;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
@@ -12,6 +13,7 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class LinkFacade {
 
@@ -37,14 +39,17 @@ public class LinkFacade {
 		linkService.deleteLink(linkId, member);
 	}
 
+	@Transactional(readOnly = true)
 	public LinkRes getLink(Long linkId, Member member) {
 		return linkService.getLink(linkId, member);
 	}
 
+	@Transactional(readOnly = true)
 	public Page<LinkRes> getLinkList(Member member, Pageable pageable) {
 		return linkService.getLinkList(member, pageable);
 	}
 
+	@Transactional(readOnly = true)
 	public LinkDuplicateCheckRes checkDuplicate(Member member, String url) {
 		return linkService.checkDuplicate(member, url);
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -3,7 +3,6 @@ package com.sofa.linkiving.domain.link.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
@@ -17,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class LinkService {
 
@@ -69,19 +67,16 @@ public class LinkService {
 		log.info("Link soft deleted - id: {}, memberId: {}", linkId, member.getId());
 	}
 
-	@Transactional(readOnly = true)
 	public LinkRes getLink(Long linkId, Member member) {
 		Link link = linkQueryService.findById(linkId, member);
 		return LinkRes.from(link);
 	}
 
-	@Transactional(readOnly = true)
 	public Page<LinkRes> getLinkList(Member member, Pageable pageable) {
 		Page<Link> links = linkQueryService.findAllByMember(member, pageable);
 		return links.map(LinkRes::from);
 	}
 
-	@Transactional(readOnly = true)
 	public LinkDuplicateCheckRes checkDuplicate(Member member, String url) {
 		return linkQueryService.findIdByUrl(member, url)
 			.map(LinkDuplicateCheckRes::exists)


### PR DESCRIPTION
## 관련 이슈

- close #136 

## PR 설명
기존 LinkService에 있던 @Transactional을 LinkFacade로 이동하여, 여러 서비스를 조합하는 Facade 계층에서 트랜잭션 단위가 보장되도록 개선.

## 작업 내용
### 1.  `LinkService`에서 모든 `@Transactional` 제거
- import 제거
- 클래스 레벨 `@Transactional` 제거
- 메서드 레벨 `@Transactional`(readOnly = true) 제거
    
### 2.  `LinkFacde`에 `@Transactional` 추가
- 클래스 레벨 `@Transactional` 추가
- 메서드 레벨 `@Transactional`(readOnly = true) 추가
    
