### PR TITLE
Summary 엔티티 내 예약어 충돌 필드명 수정

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
@@ -28,14 +28,14 @@ public class Summary extends BaseEntity {
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
-	@Column(name = "select", columnDefinition = "TEXT")
-	private String select;
+	@Column(name = "selected", columnDefinition = "TEXT")
+	private String selected;
 
 	@Builder
 	public Summary(Link link, Format format, String content, String select) {
 		this.link = link;
 		this.format = format;
 		this.content = content;
-		this.select = select;
+		this.selected = select;
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
@@ -67,6 +67,6 @@ public class SummaryTest {
 		assertThat(summary.getLink()).isEqualTo(link);
 		assertThat(summary.getContent()).isEqualTo(content);
 		assertThat(summary.getFormat()).isEqualTo(format);
-		assertThat(summary.getSelect()).isEqualTo(select);
+		assertThat(summary.getSelected()).isEqualTo(select);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #145 

## PR 설명
* `Summary` 엔티티의 `select` 필드가 PostgreSQL의 예약어(**SELECT**)와 충돌하여 발생하는 SQL `syntax error`를 해결함.
* 해당 필드명을 `selected`로 변경하여 예약어 이슈를 해소하고 데이터 저장이 정상적으로 이루어지도록 수정함.

## 작업 내용

### 1. Entity 수정 (`Summary`)
* **필드명 변경**: `select` ➝ `selected`
    * `@Column` 및 멤버 변수 이름을 변경하여 예약어 충돌을 방지함.

### 2. 테스트 수정 (`SummaryTest`)
* **빌더 및 검증 로직 수정**:
    * 변경된 필드명(`selected`)에 맞춰 빌더 패턴 설정 및 Getter 호출 코드를 수정함.
    * 엔티티 저장 및 조회 테스트가 정상 통과됨을 확인함.