### PR TITLE
메시지 피드백 등록 API 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
@@ -1,0 +1,15 @@
+package com.sofa.linkiving.domain.chat.controller;
+
+import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
+import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Feedback", description = "피드백 관리 API")
+public interface FeedbackApi {
+	@Operation(summary = "피드백 추가", description = "메세지에 피드백을 추가하고 생성된 피드백 ID를 반환합니다.")
+	BaseResponse<AddFeedbackRes> createFeedback(Long messageId, AddFeedbackReq createFeedbackReq, Member member);
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
@@ -1,0 +1,32 @@
+package com.sofa.linkiving.domain.chat.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
+import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.facade.FeedbackFacade;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.security.annotation.AuthMember;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/messages")
+@RequiredArgsConstructor
+public class FeedbackController implements FeedbackApi {
+	private final FeedbackFacade feedbackFacade;
+
+	@Override
+	@PostMapping("/{messageId}/feedback")
+	public BaseResponse<AddFeedbackRes> createFeedback(@PathVariable Long messageId,
+		@Valid @RequestBody AddFeedbackReq req, @AuthMember Member member) {
+		AddFeedbackRes res = feedbackFacade.createFeedback(member, messageId, req.sentiment(), req.text());
+		return BaseResponse.success(res, "피드백이 등록되었습니다.");
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AddFeedbackReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AddFeedbackReq.java
@@ -1,0 +1,17 @@
+package com.sofa.linkiving.domain.chat.dto.request;
+
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AddFeedbackReq(
+	@NotNull(message = "피드백 상태는 필수입니다.") // 필수 값 체크
+	@Schema(description = "피드백 상태 (LIKE, DISLIKE)", example = "LIKE")
+	Sentiment sentiment,
+	@Schema(description = "피드백 내용 (선택)", example = "도움이 되었습니다.")
+	@Size(max = 20, message = "피드백 내용은 20자를 넘을 수 없습니다.")
+	String text
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AddFeedbackRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AddFeedbackRes.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AddFeedbackRes(
+	@Schema(description = "피드백 ID")
+	Long id
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/error/MessageErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/error/MessageErrorCode.java
@@ -1,0 +1,18 @@
+package com.sofa.linkiving.domain.chat.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.sofa.linkiving.global.error.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MessageErrorCode implements ErrorCode {
+	MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MS-001", "메세지를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacade.java
@@ -1,0 +1,28 @@
+package com.sofa.linkiving.domain.chat.facade;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+import com.sofa.linkiving.domain.chat.service.FeedbackService;
+import com.sofa.linkiving.domain.chat.service.MessageService;
+import com.sofa.linkiving.domain.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedbackFacade {
+	private final FeedbackService feedbackService;
+	private final MessageService messageService;
+
+	public AddFeedbackRes createFeedback(Member member, Long messageId, Sentiment sentiment, String text) {
+
+		Message message = messageService.get(messageId, member);
+		Long id = feedbackService.create(message, sentiment, text);
+		return new AddFeedbackRes(id);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/MessageRepository.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.chat.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,9 +12,13 @@ import org.springframework.stereotype.Repository;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.member.entity.Member;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
+	@Query("SELECT m FROM Message m JOIN m.chat c WHERE m.id = :id AND c.member = :member")
+	Optional<Message> findByIdAndMember(@Param("id") Long id, @Param("member") Member member);
+
 	@Modifying(clearAutomatically = true)
 	@Query("DELETE FROM Message m WHERE m.chat = :chat")
 	void deleteAllByChat(Chat chat);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackCommandService.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.chat.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.entity.Feedback;
 import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FeedbackCommandService {
 	private final FeedbackRepository feedbackRepository;
+
+	public Feedback save(Feedback feedback) {
+		return feedbackRepository.save(feedback);
+	}
 
 	public void deleteFeedbacksByChat(Chat chat) {
 		feedbackRepository.deleteAllByChat(chat);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
@@ -3,6 +3,9 @@ package com.sofa.linkiving.domain.chat.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +14,15 @@ import lombok.RequiredArgsConstructor;
 public class FeedbackService {
 	private final FeedbackQueryService feedbackQueryService;
 	private final FeedbackCommandService feedbackCommandService;
+
+	public Long create(Message message, Sentiment sentiment, String text) {
+		Feedback feedback = Feedback.builder()
+			.message(message)
+			.sentiment(sentiment)
+			.text(text)
+			.build();
+		return feedbackCommandService.save(feedback).getId();
+	}
 
 	public void deleteAll(Chat chat) {
 		feedbackCommandService.deleteFeedbacksByChat(chat);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageQueryService.java
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.error.MessageErrorCode;
 import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +20,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MessageQueryService {
 	private final MessageRepository messageRepository;
+
+	public Message findByIdAndMember(Long messageId, Member member) {
+		return messageRepository.findByIdAndMember(messageId, member).orElseThrow(
+			() -> new BusinessException(MessageErrorCode.MESSAGE_NOT_FOUND)
+		);
+	}
 
 	public Slice<Message> findAllByChatAndCursor(Chat chat, Long lastId, int size) {
 		PageRequest pageRequest = PageRequest.of(0, size + 1);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageService.java
@@ -19,6 +19,7 @@ import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.service.SummaryQueryService;
+import com.sofa.linkiving.domain.member.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.Disposable;
@@ -93,6 +94,10 @@ public class MessageService {
 			.build();
 
 		messageCommandService.saveMessage(message);
+	}
+
+	public Message get(Long messageId, Member member) {
+		return messageQueryService.findByIdAndMember(messageId, member);
 	}
 
 	public void deleteAll(Chat chat) {

--- a/src/test/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacadeTest.java
@@ -1,0 +1,56 @@
+package com.sofa.linkiving.domain.chat.facade;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+import com.sofa.linkiving.domain.chat.service.FeedbackService;
+import com.sofa.linkiving.domain.chat.service.MessageService;
+import com.sofa.linkiving.domain.member.entity.Member;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedbackFacadeTest {
+	@InjectMocks
+	private FeedbackFacade feedbackFacade;
+
+	@Mock
+	private FeedbackService feedbackService;
+
+	@Mock
+	private MessageService messageService;
+
+	@Test
+	@DisplayName("피드백 생성 요청 시 Message 조회 후 Feedback을 생성하고 결과를 반환함")
+	void shouldCreateFeedbackAndReturnRes() {
+		// given
+		Long messageId = 1L;
+		Long feedbackId = 100L;
+		Sentiment sentiment = Sentiment.LIKE;
+		String text = "도움이 되었어요";
+
+		Message message = mock(Message.class);
+		Member member = mock(Member.class);
+
+		given(messageService.get(messageId, member)).willReturn(message);
+		given(feedbackService.create(message, sentiment, text)).willReturn(feedbackId);
+
+		// when
+		AddFeedbackRes result = feedbackFacade.createFeedback(member, messageId, sentiment, text);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.id()).isEqualTo(feedbackId);
+
+		verify(messageService).get(messageId, member);
+		verify(feedbackService).create(message, sentiment, text);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.sofa.linkiving.domain.chat.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
+import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
+import com.sofa.linkiving.domain.chat.enums.Type;
+import com.sofa.linkiving.domain.chat.repository.ChatRepository;
+import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
+import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.Role;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.infra.redis.RedisService;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedbackIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private ChatRepository chatRepository;
+
+	@Autowired
+	private MessageRepository messageRepository;
+
+	@Autowired
+	private FeedbackRepository feedbackRepository;
+
+	@MockitoBean
+	private RedisService redisService; // 통합 테스트 환경 구성상 필요하다면 유지
+
+	private UserDetails testUserDetails;
+	private Message testMessage;
+
+	@BeforeEach
+	void setUp() {
+		Member member = memberRepository.save(Member.builder()
+			.email("feedback_user@test.com")
+			.password("password")
+			.build());
+		testUserDetails = new CustomMemberDetail(member, Role.USER);
+
+		Chat chat = chatRepository.save(Chat.builder()
+			.member(member)
+			.title("Test Chat")
+			.build());
+
+		testMessage = messageRepository.save(Message.builder()
+			.chat(chat)
+			.type(Type.AI)
+			.content("AI Response")
+			.build());
+	}
+
+	@Test
+	@DisplayName("피드백 등록 요청 시 DB에 저장되고 200 OK를 반환함")
+	void shouldSaveFeedbackAndReturnOkWhenValidRequest() throws Exception {
+		// given
+		Long messageId = testMessage.getId();
+		AddFeedbackReq req = new AddFeedbackReq(Sentiment.LIKE, "매우 유용한 답변입니다.");
+
+		// when & then
+		mockMvc.perform(post("/v1/messages/{messageId}/feedback", messageId)
+				.with(csrf())
+				.with(user(testUserDetails))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").isNumber()); // 생성된 ID 반환 확인
+
+		Feedback savedFeedback = feedbackRepository.findAll().get(0);
+		assertThat(savedFeedback.getMessage().getId()).isEqualTo(messageId);
+		assertThat(savedFeedback.getSentiment()).isEqualTo(Sentiment.LIKE);
+		assertThat(savedFeedback.getText()).isEqualTo("매우 유용한 답변입니다.");
+	}
+
+	@Test
+	@DisplayName("피드백 상태(Sentiment) 누락 시 400 Bad Request를 반환함")
+	void shouldReturnBadRequestWhenSentimentIsNull() throws Exception {
+		// given
+		Long messageId = testMessage.getId();
+		AddFeedbackReq req = new AddFeedbackReq(null, "내용만 있음"); // @NotNull 위반
+
+		// when & then
+		mockMvc.perform(post("/v1/messages/{messageId}/feedback", messageId)
+				.with(csrf())
+				.with(user(testUserDetails))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 메시지에 피드백 등록 시 404 Not Found를 반환함")
+	void shouldReturnNotFoundWhenMessageDoesNotExist() throws Exception {
+		// given
+		Long invalidMessageId = 99999L;
+		AddFeedbackReq req = new AddFeedbackReq(Sentiment.DISLIKE, "별로예요");
+
+		// when & then
+		mockMvc.perform(post("/v1/messages/{messageId}/feedback", invalidMessageId)
+				.with(csrf())
+				.with(user(testUserDetails))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)))
+			.andDo(print())
+			.andExpect(status().isNotFound()) // MessageQueryService에서 예외 발생
+			.andExpect(jsonPath("$.success").value(false));
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackServiceTest.java
@@ -1,5 +1,6 @@
 package com.sofa.linkiving.domain.chat.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -10,9 +11,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.enums.Sentiment;
 
 @ExtendWith(MockitoExtension.class)
 public class FeedbackServiceTest {
+
 	@InjectMocks
 	private FeedbackService feedbackService;
 
@@ -21,6 +26,34 @@ public class FeedbackServiceTest {
 
 	@Mock
 	private FeedbackQueryService feedbackQueryService;
+
+	@Test
+	@DisplayName("피드백 생성 요청 시 엔티티를 생성하고 저장을 요청함")
+	void shouldCreateAndSaveFeedback() {
+		// given
+		Message message = mock(Message.class);
+		Sentiment sentiment = Sentiment.LIKE;
+		String text = "답변이 훌륭합니다.";
+
+		Feedback savedFeedback = mock(Feedback.class);
+		given(savedFeedback.getId()).willReturn(10L);
+
+		given(feedbackCommandService.save(any(Feedback.class))).willAnswer(invocation -> {
+			Feedback argument = invocation.getArgument(0);
+			assertThat(argument.getMessage()).isEqualTo(message);
+			assertThat(argument.getSentiment()).isEqualTo(sentiment);
+			assertThat(argument.getText()).isEqualTo(text);
+
+			return savedFeedback;
+		});
+
+		// when
+		Long resultId = feedbackService.create(message, sentiment, text);
+
+		// then
+		assertThat(resultId).isEqualTo(10L);
+		verify(feedbackCommandService).save(any(Feedback.class));
+	}
 
 	@Test
 	@DisplayName("FeedbackCommandService.deleteAllByMessageIn 호출 위임")
@@ -35,4 +68,3 @@ public class FeedbackServiceTest {
 		verify(feedbackCommandService).deleteFeedbacksByChat(chat);
 	}
 }
-

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/MessageQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/MessageQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,14 +18,18 @@ import org.springframework.data.domain.Slice;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.error.MessageErrorCode;
 import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
 public class MessageQueryServiceTest {
 
+	@Mock
+	Member member;
 	@InjectMocks
 	private MessageQueryService messageQueryService;
-
 	@Mock
 	private MessageRepository messageRepository;
 
@@ -76,4 +81,36 @@ public class MessageQueryServiceTest {
 		assertThat(result.hasNext()).isFalse();
 		assertThat(result.getContent()).hasSize(size);
 	}
+
+	@Test
+	@DisplayName("단일 메시지 조회 시 메시지가 존재하고 회원이 일치하면 메시지를 반환함")
+	void shouldReturnMessageWhenFound() {
+		// given
+		Long messageId = 1L;
+		Message message = mock(Message.class);
+
+		given(messageRepository.findByIdAndMember(messageId, member)).willReturn(Optional.of(message));
+
+		// when
+		Message result = messageQueryService.findByIdAndMember(messageId, member);
+
+		// then
+		assertThat(result).isEqualTo(message);
+	}
+
+	@Test
+	@DisplayName("단일 메시지 조회 시 메시지가 없거나 회원이 불일치하면 예외를 던짐")
+	void shouldThrowExceptionWhenNotFound() {
+		// given
+		Long messageId = 999L;
+
+		given(messageRepository.findByIdAndMember(messageId, member)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> messageQueryService.findByIdAndMember(messageId, member))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(MessageErrorCode.MESSAGE_NOT_FOUND);
+	}
 }
+


### PR DESCRIPTION
## 관련 이슈

- close #151 

## PR 설명
* 사용자가 AI의 답변(메시지)에 대해 좋아요/싫어요 및 의견을 남길 수 있는 **피드백 등록 API**(`POST`) 구현
* 유지보수성을 위해 **Controller를 분리**하고

## 작업 내용

### 1. API 구현 (`FeedbackController`)
* **Endpoint**: `POST /v1/messages/{messageId}/feedback`
* **Request**: `AddFeedbackReq` (감정 `sentiment`, 의견 `text`).
    * `text`는 `null` 입력을 허용함.
* **Response**: 생성된 `feedbackId` 반환.
    ```json
         {
           "success": true,
           "status": "OK",
           "message": "피드백이 등록되었습니다.",
           "data": {
             "id": 15
           }
         }
     ```
* **Swagger**: `FeedbackApi` 인터페이스를 통해 API 명세를 정의함.

### 2. 아키텍처 및 로직 (`FeedbackFacade`)
* **Facade 패턴 적용**:
    * `FeedbackFacade`가 트랜잭션을 관리하며 `MessageService`와 `FeedbackService`를 조율함.
    * **흐름**: 메시지 조회(존재 확인) -> 피드백 엔티티 생성 및 저장 -> 결과 반환.
* **Controller 분리**:
    * 기존 `ChatController`의 비대화를 방지하기 위해 `domain.chat.controller` 패키지 내에 `FeedbackController`를 별도로 생성함.

### 3. Service 로직 (CQS)
* **`MessageService`**:
    * `MessageQueryService`를 통해 `messageId`로 메시지를 조회하고, 존재하지 않을 경우 `CHAT_NOT_FOUND` 예외를 발생시킴.
* **`FeedbackService`**:
    * `FeedbackCommandService`를 통해 피드백 데이터를 DB에 저장함.

### 4. 에러 처리 (`MessageErrorCode`)
* **예외 정의**: 메시지가 존재하지 않을 경우를 대비해 `MessageErrorCode.CHAT_NOT_FOUND` 에러 코드를 정의

### 5. 테스트 작성 (Test Coverage)
* **Integration Test (`FeedbackIntegrationTest`)**:
    * **정상 흐름**: 유효한 요청 시 200 OK 응답 및 DB 저장 여부를 검증함.
    * **유효성 검사**: 필수 값(`sentiment`) 누락 시 `400 Bad Request` 반환을 확인함.
    * **예외 처리**: 존재하지 않는 메시지 ID로 요청 시 `404 Not Found`(`MessageErrorCode.CHAT_NOT_FOUND`) 반환을 확인함.
* **Unit Test**:
    * **`FeedbackFacadeTest`**: Mocking을 통해 메시지 조회 후 피드백 저장으로 이어지는 호출 순서를 검증함.
    * **`FeedbackServiceTest`**: 요청 데이터가 올바르게 엔티티로 변환되어 저장되는지 테스트함.