### PR TITLE
링크 조회 API 및 링크 목록 조회 API 응답 개선

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -1,13 +1,14 @@
 package com.sofa.linkiving.domain.link.controller;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.validation.annotation.Validated;
 
 import com.sofa.linkiving.domain.link.dto.request.LinkCreateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.MetaScrapeReq;
+import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
@@ -17,10 +18,14 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
+@Validated
 @Tag(name = "Link", description = "링크 관리 API")
 public interface LinkApi {
 
@@ -55,16 +60,21 @@ public interface LinkApi {
 		Member member
 	);
 
-	@Operation(summary = "링크 조회", description = "링크 상세 정보를 조회합니다")
-	BaseResponse<LinkRes> getLink(
+	@Operation(summary = "링크 상세 조회", description = "링크 상세 정보를 조회합니다")
+	BaseResponse<LinkDetailRes> getLink(
 		Long id,
 		Member member
 	);
 
-	@Operation(summary = "링크 목록 조회", description = "저장된 링크 목록을 페이징하여 조회합니다")
-	BaseResponse<Page<LinkRes>> getLinkList(
-		Pageable pageable,
-		Member member
+	@Operation(summary = "링크 카드 목록 조회", description = "저장된 링크 목록을 무한 스크롤 방식으로 조회합니다")
+	BaseResponse<LinkCardsRes> getLinkList(
+		Member member,
+		@Parameter(description = "페이징을 위한 마지막 메시지 ID, 첫 조회 시 null") Long lastId,
+
+		@Parameter(description = "한번에 조회할 데이터 갯수")
+		@Min(value = 1, message = "최소 1개 이상 조회해야 합니다.")
+		@Max(value = 50, message = "한 번에 최대 50개까지만 조회할 수 있습니다.")
+		int size
 	);
 
 	@Operation(summary = "링크 제목 수정", description = "링크 제목만 수정합니다")
@@ -84,7 +94,8 @@ public interface LinkApi {
 	@Operation(summary = "요약 재생성", description = "요약을 재생성 하고 신규 요약 기존 요약, 기존 및 신규 요약 비교 정보을 제공합니다.")
 	BaseResponse<RecreateSummaryResponse> recreateSummary(
 		Long id,
-		@Valid @Schema(description = "요청 형식(CONCISE: 간결하게, DETAILED:자세하게)") Format format,
+		@Schema(description = "요청 형식(CONCISE: 간결하게, DETAILED:자세하게)")
+		@Valid Format format,
 		Member member
 	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -1,8 +1,6 @@
 package com.sofa.linkiving.domain.link.controller;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -19,6 +17,8 @@ import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.MetaScrapeReq;
+import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
@@ -102,21 +102,22 @@ public class LinkController implements LinkApi {
 
 	@Override
 	@GetMapping("/{id}")
-	public BaseResponse<LinkRes> getLink(
+	public BaseResponse<LinkDetailRes> getLink(
 		@PathVariable Long id,
 		@AuthMember Member member
 	) {
-		LinkRes response = linkFacade.getLink(id, member);
+		LinkDetailRes response = linkFacade.getLinkDetail(id, member);
 		return BaseResponse.success(response, "링크 조회 완료");
 	}
 
 	@Override
 	@GetMapping
-	public BaseResponse<Page<LinkRes>> getLinkList(
-		@PageableDefault(size = 20) Pageable pageable,
-		@AuthMember Member member
+	public BaseResponse<LinkCardsRes> getLinkList(
+		@AuthMember Member member,
+		@RequestParam(required = false) Long lastId,
+		@RequestParam(defaultValue = "20") int size
 	) {
-		Page<LinkRes> response = linkFacade.getLinkList(member, pageable);
+		LinkCardsRes response = linkFacade.getLinkCards(member, lastId, size);
 		return BaseResponse.success(response, "링크 목록 조회 완료");
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/internal/LinkDto.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/internal/LinkDto.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.link.dto.internal;
+
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+
+public record LinkDto(
+	Link link,
+	Summary summary
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/internal/LinksDto.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/internal/LinksDto.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.link.dto.internal;
+
+import java.util.List;
+
+public record LinksDto(
+	List<LinkDto> linkDtos,
+	boolean hasNext
+) {
+}
+

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/internal/OgTagDto.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/internal/OgTagDto.java
@@ -1,4 +1,4 @@
-package com.sofa.linkiving.domain.link.dto;
+package com.sofa.linkiving.domain.link.dto.internal;
 
 import lombok.Builder;
 

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardsRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardsRes.java
@@ -1,0 +1,57 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import java.util.List;
+
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LinkCardsRes(
+	@Schema(description = "링크 목록")
+	List<LinkCardRes> links,
+	@Schema(description = "다음 페이지 존재 여부")
+	boolean hasNext,
+	@Schema(description = "마지막 메시지 ID (다음 요청 커서용)")
+	Long lastId
+) {
+	public static LinkCardsRes of(LinksDto linksDto) {
+		List<LinkCardRes> links = linksDto.linkDtos().stream().map(LinkCardRes::from).toList();
+		Long lastId = links.isEmpty() ? null : links.get(links.size() - 1).id();
+
+		return new LinkCardsRes(links, linksDto.hasNext(), lastId);
+	}
+
+	public record LinkCardRes(
+		@Schema(description = "링크 ID")
+		Long id,
+
+		@Schema(description = "링크 URL", example = "https://example.com")
+		String url,
+
+		@Schema(description = "링크 제목", example = "유용한 개발 자료")
+		String title,
+
+		@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+		String imageUrl,
+
+		@Schema(description = "요약 정보")
+		String summary
+	) {
+		public static LinkCardRes from(LinkDto dto) {
+			return of(dto.link(), dto.summary());
+		}
+
+		public static LinkCardRes of(Link link, Summary summary) {
+			return new LinkCardRes(
+				link.getId(),
+				link.getUrl(),
+				link.getTitle(),
+				link.getImageUrl(),
+				summary == null ? null : summary.getContent()
+			);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
@@ -1,0 +1,56 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LinkDetailRes(
+	@Schema(description = "링크 ID")
+	Long id,
+
+	@Schema(description = "링크 URL", example = "https://example.com")
+	String url,
+
+	@Schema(description = "링크 제목", example = "유용한 개발 자료")
+	String title,
+
+	@Schema(description = "메모", example = "나중에 읽어볼 것")
+	String memo,
+
+	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+	String imageUrl,
+
+	@Schema(description = "요약 정보")
+	SummaryRes summary
+) {
+	public static LinkDetailRes from(LinkDto dto) {
+		return of(dto.link(), dto.summary());
+	}
+
+	public static LinkDetailRes of(Link link, Summary summary) {
+		return new LinkDetailRes(
+			link.getId(),
+			link.getUrl(),
+			link.getTitle(),
+			link.getMemo(),
+			link.getImageUrl(),
+			SummaryRes.from(summary)
+		);
+	}
+
+	public record SummaryRes(
+		@Schema(description = "요약 ID")
+		Long id,
+		@Schema(description = "요약 내용", example = "이 링크는 예시 링크입니다.")
+		String content
+	) {
+		public static SummaryRes from(Summary summary) {
+			if (summary == null) {
+				return null;
+			}
+			return new SummaryRes(summary.getId(), summary.getContent());
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/MetaScrapeRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/MetaScrapeRes.java
@@ -1,6 +1,6 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
-import com.sofa.linkiving.domain.link.dto.OgTagDto;
+import com.sofa.linkiving.domain.link.dto.internal.OgTagDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Summary.java
@@ -28,11 +28,11 @@ public class Summary extends BaseEntity {
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
 
-	@Column(name = "selected", columnDefinition = "TEXT")
-	private String selected;
+	@Column(name = "selected")
+	private boolean selected;
 
 	@Builder
-	public Summary(Link link, Format format, String content, String select) {
+	public Summary(Link link, Format format, String content, boolean select) {
 		this.link = link;
 		this.format = format;
 		this.content = content;

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -1,11 +1,13 @@
 package com.sofa.linkiving.domain.link.facade;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.sofa.linkiving.domain.link.dto.OgTagDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
+import com.sofa.linkiving.domain.link.dto.internal.OgTagDto;
+import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
@@ -53,15 +55,15 @@ public class LinkFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public LinkRes getLink(Long linkId, Member member) {
-		Link link = linkService.getLink(linkId, member);
-		return LinkRes.from(link);
+	public LinkDetailRes getLinkDetail(Long linkId, Member member) {
+		LinkDto linkDto = linkService.getLinkWithSummary(linkId, member);
+		return LinkDetailRes.from(linkDto);
 	}
 
 	@Transactional(readOnly = true)
-	public Page<LinkRes> getLinkList(Member member, Pageable pageable) {
-		Page<Link> links = linkService.getLinkList(member, pageable);
-		return links.map(LinkRes::from);
+	public LinkCardsRes getLinkCards(Member member, Long lastId, int size) {
+		LinksDto linkDtos = linkService.getLinksWithSummary(member, lastId, size);
+		return LinkCardsRes.of(linkDtos);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
@@ -1,13 +1,14 @@
 package com.sofa.linkiving.domain.link.repository;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.member.entity.Member;
 
@@ -15,10 +16,40 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
 	Optional<Link> findByIdAndMember(Long id, Member member);
 
-	Page<Link> findByMemberAndIsDeleteFalse(Member member, Pageable pageable);
-
 	boolean existsByMemberAndUrlAndIsDeleteFalse(Member member, String url);
 
-	@Query("SELECT l.id FROM Link l WHERE l.member = :member AND l.url = :url AND l.isDelete = false")
+	@Query("""
+		SELECT l.id
+		FROM Link l
+		WHERE l.member = :member AND l.url = :url AND l.isDelete = false
+		""")
 	Optional<Long> findIdByMemberAndUrlAndIsDeleteFalse(@Param("member") Member member, @Param("url") String url);
+
+	@Query("""
+		SELECT new com.sofa.linkiving.domain.link.dto.internal.LinkDto(l, s)
+		FROM Link l
+		LEFT JOIN Summary s ON s.link = l AND s.selected = true
+		WHERE l.id = :id
+		AND l.member = :member
+		AND l.isDelete = false
+		""")
+	Optional<LinkDto> findByIdAndMemberWithSummaryAndIsDeleteFalse(
+		@Param("id") Long id,
+		@Param("member") Member member
+	);
+
+	@Query("""
+		SELECT new com.sofa.linkiving.domain.link.dto.internal.LinkDto(l, s)
+		FROM Link l
+		LEFT JOIN Summary s ON s.link = l AND s.selected = true
+		WHERE l.member = :member
+		AND l.isDelete = false
+		AND (:lastId IS NULL OR l.id < :lastId)
+		ORDER BY l.id DESC
+		""")
+	List<LinkDto> findAllByMemberWithSummaryAndCursorAndIsDeleteFalse(
+		@Param("member") Member member,
+		@Param("lastId") Long lastId,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
@@ -1,11 +1,13 @@
 package com.sofa.linkiving.domain.link.service;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.repository.LinkRepository;
@@ -28,8 +30,23 @@ public class LinkQueryService {
 			.orElseThrow(() -> new BusinessException(LinkErrorCode.LINK_NOT_FOUND));
 	}
 
-	public Page<Link> findAllByMember(Member member, Pageable pageable) {
-		return linkRepository.findByMemberAndIsDeleteFalse(member, pageable);
+	public LinkDto findByIdWithSummary(Long linkId, Member member) {
+		return linkRepository.findByIdAndMemberWithSummaryAndIsDeleteFalse(linkId, member)
+			.orElseThrow(() -> new BusinessException(LinkErrorCode.LINK_NOT_FOUND));
+	}
+
+	public LinksDto findAllByMemberWithSummaryAndCursor(Member member, Long lastId, int size) {
+		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		List<LinkDto> linkDtos = linkRepository.findAllByMemberWithSummaryAndCursorAndIsDeleteFalse(member, lastId,
+			pageRequest);
+
+		boolean hasNext = false;
+		if (linkDtos.size() > size) {
+			hasNext = true;
+			linkDtos.remove(size);
+		}
+
+		return new LinksDto(linkDtos, hasNext);
 	}
 
 	public boolean existsByUrl(Member member, String url) {

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -3,10 +3,10 @@ package com.sofa.linkiving.domain.link.service;
 import java.util.Optional;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.event.LinkCreatedEvent;
@@ -76,8 +76,12 @@ public class LinkService {
 		return linkQueryService.findById(linkId, member);
 	}
 
-	public Page<Link> getLinkList(Member member, Pageable pageable) {
-		return linkQueryService.findAllByMember(member, pageable);
+	public LinkDto getLinkWithSummary(Long linkId, Member member) {
+		return linkQueryService.findByIdWithSummary(linkId, member);
+	}
+
+	public LinksDto getLinksWithSummary(Member member, Long lastId, int size) {
+		return linkQueryService.findAllByMemberWithSummaryAndCursor(member, lastId, size);
 	}
 
 	public Optional<Long> findLinkIdByUrl(Member member, String url) {

--- a/src/main/java/com/sofa/linkiving/domain/link/util/OgTagCrawler.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/util/OgTagCrawler.java
@@ -6,7 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.stereotype.Component;
 
-import com.sofa.linkiving.domain.link.dto.OgTagDto;
+import com.sofa.linkiving.domain.link.dto.internal.OgTagDto;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/entity/SummaryTest.java
@@ -55,7 +55,7 @@ public class SummaryTest {
 
 		Format format = Format.DETAILED;
 		String content = "This is a detailed summary";
-		String select = "Selected text from the page";
+		boolean select = true;
 
 		Summary summary = Summary.builder()
 			.link(link)
@@ -67,6 +67,5 @@ public class SummaryTest {
 		assertThat(summary.getLink()).isEqualTo(link);
 		assertThat(summary.getContent()).isEqualTo(content);
 		assertThat(summary.getFormat()).isEqualTo(format);
-		assertThat(summary.getSelected()).isEqualTo(select);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,12 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
+import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
 import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.repository.LinkRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -77,41 +78,6 @@ class LinkQueryServiceTest {
 	}
 
 	@Test
-	@DisplayName("멤버의 모든 링크를 페이징 조회할 수 있다")
-	void shouldFindAllByMember() {
-		// given
-		Member member = Member.builder()
-			.email("test@example.com")
-			.password("password")
-			.build();
-
-		Link link1 = Link.builder()
-			.member(member)
-			.url("https://example1.com")
-			.title("링크 1")
-			.build();
-
-		Link link2 = Link.builder()
-			.member(member)
-			.url("https://example2.com")
-			.title("링크 2")
-			.build();
-
-		Pageable pageable = PageRequest.of(0, 10);
-		Page<Link> expectedPage = new PageImpl<>(List.of(link1, link2));
-
-		given(linkRepository.findByMemberAndIsDeleteFalse(member, pageable)).willReturn(expectedPage);
-
-		// when
-		Page<Link> result = linkQueryService.findAllByMember(member, pageable);
-
-		// then
-		assertThat(result).isNotNull();
-		assertThat(result.getContent()).hasSize(2);
-		verify(linkRepository, times(1)).findByMemberAndIsDeleteFalse(member, pageable);
-	}
-
-	@Test
 	@DisplayName("URL 중복 여부를 확인할 수 있다")
 	void shouldCheckUrlExists() {
 		// given
@@ -130,5 +96,95 @@ class LinkQueryServiceTest {
 		assertThat(exists).isTrue();
 		verify(linkRepository, times(1))
 			.existsByMemberAndUrlAndIsDeleteFalse(member, "https://example.com");
+	}
+
+	@Test
+	@DisplayName("커서 기반 목록 조회 시 요청 개수보다 데이터가 많으면 hasNext=true를 반환함")
+	void shouldFindAllByMemberWithSummaryAndCursor_HasNextTrue() {
+		// given
+		Member member = mock(Member.class);
+		Long lastId = 100L;
+		int size = 10;
+
+		// Repository가 size + 1 (11개) 데이터를 반환한다고 가정
+		List<LinkDto> dtos = new ArrayList<>();
+		for (int i = 0; i < size + 1; i++) {
+			dtos.add(mock(LinkDto.class));
+		}
+
+		// Pageable 검증 (size + 1 로 요청했는지)
+		given(linkRepository.findAllByMemberWithSummaryAndCursorAndIsDeleteFalse(
+			eq(member), eq(lastId), any(Pageable.class)))
+			.willReturn(dtos);
+
+		// when
+		LinksDto result = linkQueryService.findAllByMemberWithSummaryAndCursor(member, lastId, size);
+
+		// then
+		assertThat(result.hasNext()).isTrue();
+		assertThat(result.linkDtos()).hasSize(size); // 11개 -> 10개로 잘림
+	}
+
+	@Test
+	@DisplayName("커서 기반 목록 조회 시 데이터가 요청 개수 이하이면 hasNext=false를 반환함")
+	void shouldFindAllByMemberWithSummaryAndCursor_HasNextFalse() {
+		// given
+		Member member = mock(Member.class);
+		Long lastId = 100L;
+		int size = 10;
+
+		// Repository가 딱 size (10개) 데이터를 반환한다고 가정
+		List<LinkDto> dtos = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			dtos.add(mock(LinkDto.class));
+		}
+
+		given(linkRepository.findAllByMemberWithSummaryAndCursorAndIsDeleteFalse(
+			eq(member), eq(lastId), any(Pageable.class)))
+			.willReturn(dtos);
+
+		// when
+		LinksDto result = linkQueryService.findAllByMemberWithSummaryAndCursor(member, lastId, size);
+
+		// then
+		assertThat(result.hasNext()).isFalse();
+		assertThat(result.linkDtos()).hasSize(size); // 그대로 10개
+	}
+
+	@Test
+	@DisplayName("ID로 링크와 요약 정보(LinkDto)를 조회할 수 있다")
+	void shouldFindByIdWithSummary() {
+		// given
+		Member member = mock(Member.class);
+		Link link = mock(Link.class);
+		Summary summary = mock(Summary.class);
+
+		LinkDto expectedDto = new LinkDto(link, summary);
+
+		given(linkRepository.findByIdAndMemberWithSummaryAndIsDeleteFalse(1L, member))
+			.willReturn(Optional.of(expectedDto));
+
+		// when
+		LinkDto result = linkQueryService.findByIdWithSummary(1L, member);
+
+		// then
+		assertThat(result).isEqualTo(expectedDto);
+		verify(linkRepository).findByIdAndMemberWithSummaryAndIsDeleteFalse(1L, member);
+	}
+
+	@Test
+	@DisplayName("요약 포함 조회 시 존재하지 않거나 삭제된 링크면 예외가 발생한다")
+	void shouldThrowExceptionWhenLinkNotFoundInFindByIdWithSummary() {
+		// given
+		Member member = mock(Member.class);
+		Long linkId = 999L;
+
+		given(linkRepository.findByIdAndMemberWithSummaryAndIsDeleteFalse(linkId, member))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> linkQueryService.findByIdWithSummary(linkId, member))
+			.isInstanceOf(BusinessException.class)
+			.hasFieldOrPropertyWithValue("errorCode", LinkErrorCode.LINK_NOT_FOUND);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #157 

## PR 설명
* 기존 링크 조회 API 및 링크 목록 조회 API의 응답 구조를 `개선하여Summary` 정보를 포함하도록 변경 
* 링크 목록 조회 시 대용량 데이터 환경에서도 성능 저하 없는 무한 스크롤을 구현하기 위해 기존 Offset 기반 페이징을 Cursor 기반 페이징)으로 변경했습니다.

## 핵심 변경 사항
### 1. 커서 기반 페이징(Cursor Pagination) 도입 이유
* 무한 스크롤(Infinite Scroll) 환경에서 기존 `Pageable`(Offset) 방식 대신 `lastId`를 사용하는 커서 방식을 도입했습니다.

1.  **성능 최적화**:
    * Offset 방식(`LIMIT N OFFSET M`)은 페이지가 뒤로 갈수록 앞에서부터 모든 행을 읽고 버려야 하므로 데이터가 많아질수록 조회 속도가 급격히 느려집니다.
    * 반면, **Cursor 방식**(`WHERE id < lastId LIMIT size`)은 인덱스를 타고 조회 시작 위치를 바로 찾을 수 있어 데이터 양과 관계없이 **일정한 조회 성능**을 보장합니다.
2.  **데이터 정합성**:
    * 사용자가 스크롤을 내리는 동안 새로운 링크가 추가되거나 삭제될 경우, Offset 방식은 데이터가 밀려 중복 노출되거나 누락되는 문제가 발생할 수 있습니다.
    * Cursor 방식은 고유한 ID를 기준으로 다음 데이터를 가져오므로 이러한 문제 없이 안정적인 데이터 흐름을 제공합니다.

### 2. 검증 책임 이동 (Validation Refactoring)
* Spring Bean Validation(`@Min`, `@Max`, `@Valid`) 로직을 구현체(`LinkController`)에서 인터페이스(`LinkApi`)로 이동했습니다.
* 개발 과정에서 **"검증 책임은 어디에 있어야 하는가?"**에 대한 고민 끝에, 다음과 같은 이유로 인터페이스 레벨로 검증 로직을 이동하는 방식을 제안합니다.

1.  **제약 조건 선언의 중복 및 충돌 방지 (`ConstraintDeclarationException`)**:
    * Bean Validation 스펙(JSR-380)상, 인터페이스와 구현 클래스 양쪽에 제약 조건을 중복 선언하거나, 구현체에서 제약 조건을 강화/약화할 경우 런타임 에러가 발생합니다.
    * 이를 방지하기 위해 "`Interface`에만 제약 조건을 명시"하는 원칙을 적용했습니다.
2.  **계약에 의한 설계 (Design by Contract)**:
    * 인터페이스는 클라이언트와의 **약속(Spec)**입니다. "어떤 데이터가 유효한지"에 대한 정의는 구현 로직(`How`)이 아닌 명세(`What`) 단계에서 정의되는 것이 아키텍처 관점에서 더 명확하다고 판단했습니다.
3.  **AOP 프록시 동작 보장**:
    * `@Validated`는 Spring AOP 기반으로 동작합니다. 인터페이스에 제약 조건이 명시되어야 JDK Dynamic Proxy가 생성될 때 해당 메서드의 규약을 정확히 가로채어 검증할 수 있습니다.
4.  **어노테이션 역할 분리**:
    * **Interface (`LinkApi`)**: `@Valid`, `@Min`, `@Max` 등 **데이터 검증(Validation)** 관련 어노테이션 배치.
    * **Controller (`LinkController`)**: `@RequestBody`, `@PathVariable`, `@RequestParam` 등 **데이터 바인딩(Binding)** 관련 어노테이션 유지.

## 작업 내용

### 1. API 명세 변경 (`LinkController`)
* **단건 조회 (`GET /v1/links/{id}`)**:
    * 기존 `LinkRes` 대신 **요약 정보**가 포함된 `LinkCardRes`를 반환하도록 변경했습니다.
* **목록 조회 (`GET /v1/links`)**:
    * `Pageable` 파라미터를 제거하고 `lastId`(커서)와 `size`를 받도록 수정했습니다.
    * 응답 객체에 요약 정보를 포함하고, 다음 페이지 존재 여부(`hasNext`)를 반환합니다.

### 2. DTO 설계 (데이터 전송 객체 분리)
계층 간 결합도를 낮추기 위해 **내부 전달용 DTO**와 **외부 응답용 DTO**를 명확히 분리했습니다.
* **Internal DTO**: `LinkDto`(Link+Summary 엔티티 래핑), `LinksDto`(`hasNext` 포함) - Repository/Service 계층 간 이동.
* **Response DTO**: `LinkCardRes` 와 `LinkDetailRes` 분리
     * `LinkCardRes`: 링크 카드 정보 제공,
         * 링크ID, 제목, Url, 이미지, 요약 내용
    * `LinkDetailRes`: 링크 상세 정보 제공
         * 링크ID, 제목, Url, 이미지, 메모, 요약 정보(요약ID, 요약 정보)
         
### 3. Repository 최적화 (`LinkRepository`)
* **DTO 직접 조회 (Projection)**:
    * `new com.sofa...LinkDto(l, s)` 생성자 표현식을 사용하여 엔티티 전체를 로딩하는 대신 필요한 데이터만 DB 레벨에서 매핑했습니다.
* **LEFT JOIN 활용**:
    * `LEFT JOIN Summary s ON ... s.selected = true` 구문을 사용하여, 링크와 선택된 요약본을 **단 한 번의 쿼리**로 조회하도록 최적화했습니다 (N+1 문제 방지).

### 4. Service 계층 분리
* **`LinkQueryService` (조회 전담)**:
    * `findByIdWithSummary`: 요약 포함 단건 조회.
    * `findAllByMemberWithSummaryAndCursor`: `size + 1`개를 조회하여 `hasNext` 여부를 판단하고 목록을 반환하는 핵심 로직 구현.
* **`LinkService` (Facade 성격)**:
    * QueryService에서 받은 내부 DTO를 응답 DTO(`LinkCardRes`)로 변환하는 역할 수행.

### 5. 테스트 작성
* **`LinkRepositoryTest`**: 커서 페이징 쿼리(`WHERE id < lastId`) 동작 및 요약 데이터 조인(`LEFT JOIN`) 검증.
* **`LinkQueryServiceTest`**: 데이터 개수에 따른 `hasNext` 계산 로직 및 삭제된 링크 필터링 검증.
* **`LinkServiceTest`**: 내부 DTO -> 응답 DTO 변환 로직 검증.