### PR TITLE
`Report` Entity 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/report/cotroller/ReportApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/cotroller/ReportApi.java
@@ -1,0 +1,7 @@
+package com.sofa.linkiving.domain.report.cotroller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Report", description = "오류 및 버그 제보 관리 API")
+public interface ReportApi {
+}

--- a/src/main/java/com/sofa/linkiving/domain/report/cotroller/ReportController.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/cotroller/ReportController.java
@@ -1,0 +1,15 @@
+package com.sofa.linkiving.domain.report.cotroller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.report.service.ReportService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/report")
+@RequiredArgsConstructor
+public class ReportController implements ReportApi {
+	private final ReportService reportService;
+}

--- a/src/main/java/com/sofa/linkiving/domain/report/entity/Report.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/entity/Report.java
@@ -1,0 +1,34 @@
+package com.sofa.linkiving.domain.report.entity;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "reports")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseEntity {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	Member member;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	String content;
+
+	@Builder
+	public Report(Member member, String content) {
+		this.member = member;
+		this.content = content;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/repository/ReportRepository.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sofa.linkiving.domain.report.entity.Report;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/sofa/linkiving/domain/report/service/ReportCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/service/ReportCommandService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.report.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.report.repository.ReportRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReportCommandService {
+	private final ReportRepository reportRepository;
+}

--- a/src/main/java/com/sofa/linkiving/domain/report/service/ReportService.java
+++ b/src/main/java/com/sofa/linkiving/domain/report/service/ReportService.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.report.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportService {
+	private final ReportCommandService reportCommandService;
+}


### PR DESCRIPTION
## 관련 이슈

- close #160 

## PR 설명
1. `Report` Entitiy
* 테이블명: `reports`
* `BaseEntity` 사용

필드명 | 자바 타입 | DB 컬럼 타입 | 제약 조건
-- | -- | -- | --
id | Long | int | PK, auto increment
member_id | Member | uuid | not null
content | String | text | not null

2. Report 기본 CRUD 구조

ReportRepository: JPA Repository 인터페이스
ReportService, ReportCommandService: 비즈니스 로직 서비스 
ReportController: REST API 컨트롤러
ReportApi: Report 명세 작성 인터페이스