### PR TITLE
OG 이미지 캐싱 및 SSRF 보안 보완 

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/abstraction/ImageUploader.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/abstraction/ImageUploader.java
@@ -1,9 +1,17 @@
 package com.sofa.linkiving.domain.link.abstraction;
 
+import java.util.Optional;
+
 public interface ImageUploader {
 	/**
 	 * 외부 이미지 URL을 입력받아 스토리지에 저장하고, 접근 가능한 URL을 반환한다.
 	 * 실패 시 null 값을 반환한다 (Soft Fail).
 	 */
 	String uploadFromUrl(String originalUrl);
+
+	/**
+	 * 이미지 URL이 이미 스토리지에 저장되어 있다면 해당 URL을 반환한다.
+	 * 저장된 URL이 아니거나 확인할 수 없으면 null을 반환한다.
+	 */
+	Optional<String> resolveStoredUrl(String originalUrl);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -41,7 +41,7 @@ public class LinkFacade {
 	private final SummaryClient summaryClient;
 
 	public LinkRes createLink(Member member, String url, String title, String memo, String imageUrl) {
-		String storedImageUrl = imageUploader.uploadFromUrl(imageUrl);
+		String storedImageUrl = processImageUpload(imageUrl);
 		Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 
 		eventPublisher.publishEvent(new LinkCreatedEvent(link.getId()));
@@ -109,7 +109,16 @@ public class LinkFacade {
 	@Transactional(readOnly = true)
 	public MetaScrapeRes scrapeMetadata(String url) {
 		OgTagDto ogTag = ogTagCrawler.crawl(url);
-		return MetaScrapeRes.from(ogTag);
+		String imageUrl = ogTag.image();
+		String uploadedImageUrl = processImageUpload(ogTag.image());
+
+		String responseImageUrl = uploadedImageUrl != null ? uploadedImageUrl : imageUrl;
+		return new MetaScrapeRes(
+			ogTag.title(),
+			ogTag.description(),
+			responseImageUrl,
+			ogTag.url()
+		);
 	}
 
 	public SummaryRes updateSummary(Long id, Member member, String content, Format format) {
@@ -117,5 +126,12 @@ public class LinkFacade {
 		Summary summary = summaryService.createSummary(link, format, content);
 		summaryService.selectSummary(link.getId(), summary.getId());
 		return SummaryRes.from(summary);
+	}
+
+	private String processImageUpload(String imageUrl) {
+		if (imageUrl == null || imageUrl.isBlank()) {
+			return null;
+		}
+		return imageUploader.uploadFromUrl(imageUrl);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/infra/s3/DefaultUrlConnectionFactory.java
+++ b/src/main/java/com/sofa/linkiving/infra/s3/DefaultUrlConnectionFactory.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.infra.s3;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -12,5 +13,13 @@ public class DefaultUrlConnectionFactory implements UrlConnectionFactory {
 	@Override
 	public URLConnection createConnection(String url) throws IOException {
 		return new URL(url).openConnection();
+	}
+
+	@Override
+	public InputStream openStream(String url) throws IOException {
+		URLConnection connection = createConnection(url);
+		connection.setConnectTimeout(5000);
+		connection.setReadTimeout(5000);
+		return connection.getInputStream();
 	}
 }

--- a/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
+++ b/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
@@ -4,13 +4,17 @@ import java.io.InputStream;
 import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.link.abstraction.ImageUploader;
+import com.sofa.linkiving.domain.link.util.UrlValidator;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 
+import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +26,7 @@ public class S3ImageUploader implements ImageUploader {
 
 	private final S3Template s3Template;
 	private final UrlConnectionFactory urlConnectionFactory;
+	private final UrlValidator urlValidator;
 
 	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
@@ -29,20 +34,26 @@ public class S3ImageUploader implements ImageUploader {
 	@Value("${spring.cloud.aws.region.static}")
 	private String region;
 
+	@Value("${app.link.default-image-url:}")
+	private String defaultImageUrl;
+
 	@Override
 	public String uploadFromUrl(String originalUrl) {
 		if (originalUrl == null || originalUrl.isBlank()) {
 			return null;
 		}
 
-		try {
-			String s3Key = generateUniqueKeyFromUrl(originalUrl);
-			String s3Url = buildS3Url(s3Key);
+		return resolveStoredUrl(originalUrl)
+			.orElseGet(() -> uploadNewImage(originalUrl));
+	}
 
-			if (s3Template.objectExists(bucketName, s3Key)) {
-				log.info("Image already exists (Cache Hit): {} -> {}", originalUrl, s3Key);
-				return s3Url;
-			}
+	/**
+	 * 신규 이미지를 S3에 업로드하는 내부 로직
+	 */
+	private String uploadNewImage(String originalUrl) {
+		try {
+			urlValidator.validateSafeUrl(originalUrl);
+			String s3Key = generateUniqueKeyFromUrl(originalUrl);
 
 			URLConnection connection = urlConnectionFactory.createConnection(originalUrl);
 			connection.setConnectTimeout(3000);
@@ -57,45 +68,70 @@ public class S3ImageUploader implements ImageUploader {
 			String contentType = connection.getContentType();
 			if (contentType == null || !contentType.startsWith("image/")) {
 				log.warn("Not Image (ContentType: {}): {}", contentType, originalUrl);
-				return null;
+				return normalizedDefaultImageUrl();
 			}
 
-			try (InputStream inputStream = connection.getInputStream()) {
-				s3Template.upload(bucketName, s3Key, inputStream, null);
-				log.info("Image uploaded: {}", s3Key);
-				return s3Url;
-			}
+			try (InputStream is = connection.getInputStream()) {
+				s3Template.upload(bucketName, s3Key, is, ObjectMetadata.builder().contentType(contentType).build());
 
+				return buildS3Url(s3Key);
+			}
+		} catch (BusinessException e) {
+			log.warn("Invalid image URL skipping upload: {}", originalUrl);
+			return normalizedDefaultImageUrl();
 		} catch (Exception e) {
-			log.warn("Upload failed, falling back to original URL: {}", e.getMessage());
-			return null;
+			log.error("S3 upload failed for URL: {}", originalUrl, e);
+			return normalizedDefaultImageUrl();
 		}
+	}
+
+	/**
+	 * S3에 해당 파일이 이미 존재하는지 확인 (Optional 기반 캐시 체크)
+	 */
+	public Optional<String> resolveStoredUrl(String originalUrl) {
+		try {
+			String s3Key = generateUniqueKeyFromUrl(originalUrl);
+			if (s3Template.objectExists(bucketName, s3Key)) {
+				log.info("Image already exists (Cache Hit): {} -> {}", originalUrl, s3Key);
+				return Optional.of(buildS3Url(s3Key));
+			}
+		} catch (Exception e) {
+			log.warn("Image cache lookup failed: {}", e.getMessage());
+		}
+		return Optional.empty();
 	}
 
 	private String buildS3Url(String key) {
 		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
 	}
 
+	private String normalizedDefaultImageUrl() {
+		return (defaultImageUrl == null || defaultImageUrl.isBlank()) ? null : defaultImageUrl;
+	}
+
 	private String generateUniqueKeyFromUrl(String url) {
 		try {
 			String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
-			String extension = "jpg";
+			String extension = extractExtension(decodedUrl);
 
-			int lastDotIndex = decodedUrl.lastIndexOf('.');
-			if (lastDotIndex > 0 && lastDotIndex < decodedUrl.length() - 1) {
-				String ext = decodedUrl.substring(lastDotIndex + 1);
-				if (ext.contains("?")) {
-					ext = ext.substring(0, ext.indexOf("?"));
-				}
-				if (ext.length() <= 4 && ext.matches("[a-zA-Z]+")) {
-					extension = ext;
-				}
-			}
-
-			UUID uuid = UUID.nameUUIDFromBytes(url.getBytes(StandardCharsets.UTF_8));
-			return "links/" + uuid + "." + extension;
+			return "images/" + UUID.nameUUIDFromBytes(decodedUrl.getBytes()) + "." + extension;
 		} catch (Exception e) {
-			return "links/" + UUID.randomUUID() + ".jpg";
+			return "images/" + UUID.randomUUID() + ".jpg";
 		}
+	}
+
+	private String extractExtension(String url) {
+		String extension = "jpg";
+		int lastDotIndex = url.lastIndexOf('.');
+		if (lastDotIndex > 0 && lastDotIndex < url.length() - 1) {
+			String ext = url.substring(lastDotIndex + 1);
+			if (ext.contains("?")) {
+				ext = ext.substring(0, ext.indexOf("?"));
+			}
+			if (ext.length() <= 4) {
+				extension = ext.toLowerCase();
+			}
+		}
+		return extension;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/infra/s3/UrlConnectionFactory.java
+++ b/src/main/java/com/sofa/linkiving/infra/s3/UrlConnectionFactory.java
@@ -1,8 +1,11 @@
 package com.sofa.linkiving.infra.s3;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLConnection;
 
 public interface UrlConnectionFactory {
 	URLConnection createConnection(String url) throws IOException;
+
+	InputStream openStream(String url) throws IOException;
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -80,14 +80,17 @@ public class LinkFacadeTest {
 	void shouldReturnMetaScrapeResWhenCrawlSucceeds() {
 		// given
 		String url = "https://velog.io/@jjeongdong/%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%A0%9C%EC%96%B4";
+		String originalImageUrl = "https://velog.io/images/thumbnail.png";
+		String storedImageUrl = "https://s3-bucket.com/links/uuid.png";
 		OgTagDto mockOgTag = OgTagDto.builder()
 			.title("동시성 제어")
 			.description("동시성 제어에 대한 설명")
-			.image("https://velog.io/images/thumbnail.png")
+			.image(originalImageUrl)
 			.url(url)
 			.build();
 
 		given(ogTagCrawler.crawl(url)).willReturn(mockOgTag);
+		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(storedImageUrl);
 
 		// when
 		MetaScrapeRes result = linkFacade.scrapeMetadata(url);
@@ -96,9 +99,10 @@ public class LinkFacadeTest {
 		assertThat(result).isNotNull();
 		assertThat(result.title()).isEqualTo("동시성 제어");
 		assertThat(result.description()).isEqualTo("동시성 제어에 대한 설명");
-		assertThat(result.image()).isEqualTo("https://velog.io/images/thumbnail.png");
+		assertThat(result.image()).isEqualTo(storedImageUrl);
 		assertThat(result.url()).isEqualTo(url);
 		verify(ogTagCrawler, times(1)).crawl(url);
+		verify(imageUploader, times(1)).uploadFromUrl(originalImageUrl);
 	}
 
 	@Test
@@ -162,6 +166,8 @@ public class LinkFacadeTest {
 		assertThat(result.image()).isEmpty();
 		assertThat(result.url()).isEmpty();
 		verify(ogTagCrawler, times(1)).crawl(url);
+		verify(imageUploader, never()).uploadFromUrl(any());
+		verify(imageUploader, never()).resolveStoredUrl(any());
 	}
 
 	@Test
@@ -176,12 +182,12 @@ public class LinkFacadeTest {
 		String storedImageUrl = "https://s3-bucket.com/stored-image.jpg";
 
 		Member member = mock(Member.class);
-
-		// 1. 이미지 업로드 모킹
+		given(member.getId()).willReturn(100L);
+		given(linkQueryService.existsByUrl(eq(member), eq(url))).willReturn(false);
 		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(storedImageUrl);
 
-		// 2. 링크 저장 모킹 (LinkService 내부의 LinkCommandService 동작)
 		Link savedLink = Link.builder()
+			.member(member)
 			.url(url)
 			.title(title)
 			.memo(memo)
@@ -189,7 +195,7 @@ public class LinkFacadeTest {
 			.build();
 		ReflectionTestUtils.setField(savedLink, "id", linkId);
 
-		given(linkCommandService.saveLink(member, url, title, memo, storedImageUrl))
+		given(linkCommandService.saveLink(eq(member), eq(url), eq(title), eq(memo), eq(storedImageUrl)))
 			.willReturn(savedLink);
 
 		// when
@@ -197,17 +203,12 @@ public class LinkFacadeTest {
 
 		// then
 		assertThat(result).isNotNull();
+		assertThat(result.id()).isEqualTo(linkId);
 
-		// Verify: 기존 로직 정상 호출 확인
 		verify(imageUploader, times(1)).uploadFromUrl(originalImageUrl);
-		verify(linkCommandService, times(1)).saveLink(member, url, title, memo, storedImageUrl);
-
-		// Verify: 핵심 비즈니스 로직인 이벤트 발행이 정상적으로 수행되었는지 확인
-		verify(eventPublisher, atLeastOnce()).publishEvent(any(LinkCreatedEvent.class));
-
-		// Verify: 비동기로 전환되었으므로, 더 이상 파사드에서 요약 클라이언트나 서비스를 호출하지 않음을 확인
-		verifyNoInteractions(summaryClient);
-		verify(summaryService, never()).createSummary(any(), any(), any());
+		verify(linkQueryService, times(1)).existsByUrl(member, url);
+		verify(linkCommandService, times(1)).saveLink(any(), any(), any(), any(), any());
+		verify(eventPublisher, times(1)).publishEvent(any(LinkCreatedEvent.class));
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -98,6 +98,7 @@ public class LinkApiIntegrationTest {
 		String originalImageUrl = "https://original.com/image.jpg";
 		String uploadedS3Url = "https://s3.amazonaws.com/bucket/links/uuid.jpg";
 
+		given(imageUploader.resolveStoredUrl(originalImageUrl)).willReturn(null);
 		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(uploadedS3Url);
 
 		LinkCreateReq req = new LinkCreateReq(

--- a/src/test/java/com/sofa/linkiving/infra/s3/DefaultUrlConnectionFactoryTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/s3/DefaultUrlConnectionFactoryTest.java
@@ -1,0 +1,75 @@
+package com.sofa.linkiving.infra.s3;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URLConnection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DefaultUrlConnectionFactory 단위 테스트")
+class DefaultUrlConnectionFactoryTest {
+
+	@Spy
+	private DefaultUrlConnectionFactory factory;
+
+	@Mock
+	private URLConnection mockConnection;
+
+	@Test
+	@DisplayName("createConnection: 유효한 URL 문자열로 URLConnection 객체를 생성한다")
+	void shouldCreateConnectionForValidUrl() throws IOException {
+		// given
+		String url = "https://example.com";
+
+		// when
+		URLConnection connection = factory.createConnection(url);
+
+		// then
+		assertThat(connection).isNotNull();
+		assertThat(connection).isInstanceOf(HttpURLConnection.class);
+	}
+
+	@Test
+	@DisplayName("createConnection: 잘못된 형식의 URL인 경우 MalformedURLException이 발생한다")
+	void shouldThrowExceptionForInvalidUrlFormat() {
+		// given
+		String invalidUrl = "not-a-url";
+
+		// when & then
+		assertThatThrownBy(() -> factory.createConnection(invalidUrl))
+			.isInstanceOf(MalformedURLException.class);
+	}
+
+	@Test
+	@DisplayName("openStream: 연결 시 타임아웃(5000ms)을 설정하고 스트림을 반환한다")
+	void shouldSetTimeoutsAndReturnStream() throws IOException {
+		// given
+		String url = "https://example.com/image.jpg";
+		InputStream expectedStream = new ByteArrayInputStream("test-data".getBytes());
+
+		doReturn(mockConnection).when(factory).createConnection(url);
+		given(mockConnection.getInputStream()).willReturn(expectedStream);
+
+		// when
+		InputStream resultStream = factory.openStream(url);
+
+		// then
+		assertThat(resultStream).isEqualTo(expectedStream);
+
+		verify(mockConnection).setConnectTimeout(5000);
+		verify(mockConnection).setReadTimeout(5000);
+		verify(mockConnection).getInputStream();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/infra/s3/S3ImageUploaderTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/s3/S3ImageUploaderTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.sofa.linkiving.domain.link.error.LinkErrorCode;
+import com.sofa.linkiving.domain.link.util.UrlValidator;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
 import io.awspring.cloud.s3.S3Template;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,19 +31,25 @@ public class S3ImageUploaderTest {
 
 	private static final String BUCKET_NAME = "test-bucket";
 	private static final String REGION = "ap-northeast-2";
+	private static final String DEFAULT_IMAGE_URL = "https://example.com/default-image.jpg";
+
 	@InjectMocks
 	private S3ImageUploader s3ImageUploader;
+
 	@Mock
 	private S3Template s3Template;
+
 	@Mock
 	private UrlConnectionFactory urlConnectionFactory;
+
 	@Mock
-	private URLConnection mockConnection;
+	private UrlValidator urlValidator;
 
 	@BeforeEach
 	void setUp() {
 		ReflectionTestUtils.setField(s3ImageUploader, "bucketName", BUCKET_NAME);
 		ReflectionTestUtils.setField(s3ImageUploader, "region", REGION);
+		ReflectionTestUtils.setField(s3ImageUploader, "defaultImageUrl", DEFAULT_IMAGE_URL);
 	}
 
 	@Test
@@ -48,21 +59,49 @@ public class S3ImageUploaderTest {
 		String originalUrl = "https://example.com/image.jpg";
 
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
+		willDoNothing().given(urlValidator).validateSafeUrl(originalUrl);
 
+		// 변경된 로직에 맞춰 URLConnection을 모킹함
+		URLConnection mockConnection = mock(URLConnection.class);
 		given(urlConnectionFactory.createConnection(originalUrl)).willReturn(mockConnection);
 
+		// image/ 로 시작하는 ContentType 반환 모킹
 		given(mockConnection.getContentType()).willReturn("image/jpeg");
-		given(mockConnection.getInputStream()).willReturn(new ByteArrayInputStream("dummy-data".getBytes()));
+
+		InputStream inputStream = new ByteArrayInputStream("dummy-data".getBytes());
+		given(mockConnection.getInputStream()).willReturn(inputStream);
 
 		// when
 		String result = s3ImageUploader.uploadFromUrl(originalUrl);
 
 		// then
-		assertThat(result).startsWith("https://" + BUCKET_NAME + ".s3." + REGION + ".amazonaws.com/links/");
-		assertThat(result).endsWith(".jpg");
+		assertThat(result).contains("images/");
+		assertThat(result).contains(BUCKET_NAME + ".s3." + REGION);
+		verify(s3Template).upload(eq(BUCKET_NAME), anyString(), any(InputStream.class), any());
+	}
 
-		// 실제 업로드가 수행되었는지 검증
-		verify(s3Template).upload(eq(BUCKET_NAME), anyString(), any(InputStream.class), isNull());
+	@Test
+	@DisplayName("이미지가 아닌 URL(ContentType 불일치)일 경우 업로드를 건너뛰고 기본 이미지 URL을 반환한다")
+	void shouldReturnDefaultUrlWhenContentTypeIsNotImage() throws IOException {
+		// given
+		String originalUrl = "https://example.com/not-image.txt";
+
+		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
+		willDoNothing().given(urlValidator).validateSafeUrl(originalUrl);
+
+		URLConnection mockConnection = mock(URLConnection.class);
+		given(urlConnectionFactory.createConnection(originalUrl)).willReturn(mockConnection);
+
+		// 이미지가 아닌 Content-Type 반환 모킹
+		given(mockConnection.getContentType()).willReturn("text/html");
+
+		// when
+		String result = s3ImageUploader.uploadFromUrl(originalUrl);
+
+		// then
+		assertThat(result).isEqualTo(DEFAULT_IMAGE_URL);
+		// 업로드가 수행되지 않아야 함
+		verify(s3Template, never()).upload(anyString(), anyString(), any(InputStream.class), any());
 	}
 
 	@Test
@@ -70,56 +109,33 @@ public class S3ImageUploaderTest {
 	void shouldReturnS3UrlWhenImageExists() throws IOException {
 		// given
 		String originalUrl = "https://example.com/image.jpg";
-
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(true);
 
 		// when
 		String result = s3ImageUploader.uploadFromUrl(originalUrl);
 
 		// then
-		assertThat(result).contains(BUCKET_NAME, REGION, "links/");
-
-		// Factory 연결 생성 및 Upload가 호출되지 않아야 함
+		assertThat(result).contains("images/");
 		verify(urlConnectionFactory, never()).createConnection(anyString());
 		verify(s3Template, never()).upload(anyString(), anyString(), any(InputStream.class), any());
 	}
 
 	@Test
-	@DisplayName("ContentType이 이미지가 아닌 경우(예: HTML, PDF) Null을 반환한다")
-	void shouldReturnDefaultImageUrlWhenNotImage() throws IOException {
-		// given
-		String originalUrl = "https://example.com/document.pdf";
-
-		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
-		given(urlConnectionFactory.createConnection(originalUrl)).willReturn(mockConnection);
-
-		given(mockConnection.getContentType()).willReturn("application/pdf");
-
-		// when
-		String result = s3ImageUploader.uploadFromUrl(originalUrl);
-
-		// then
-		assertThat(result).isNull();
-
-		// Upload 호출 안 됨
-		verify(s3Template, never()).upload(anyString(), anyString(), any(InputStream.class), any());
-	}
-
-	@Test
-	@DisplayName("연결 실패나 업로드 중 예외 발생 시 Null을 반환한다 (Fallback)")
+	@DisplayName("업로드 중 예외 발생 시 기본 이미지 URL을 반환한다")
 	void shouldReturnDefaultImageUrlWhenExceptionOccurs() throws IOException {
 		// given
 		String originalUrl = "https://example.com/image.jpg";
-
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
+		willDoNothing().given(urlValidator).validateSafeUrl(originalUrl);
 
+		// 생성 단계에서 강제 예외 발생 유도
 		given(urlConnectionFactory.createConnection(originalUrl)).willThrow(new IOException("Connection Refused"));
 
 		// when
 		String result = s3ImageUploader.uploadFromUrl(originalUrl);
 
 		// then
-		assertThat(result).isNull();
+		assertThat(result).isEqualTo(DEFAULT_IMAGE_URL);
 	}
 
 	@Test
@@ -132,5 +148,36 @@ public class S3ImageUploaderTest {
 		// then
 		assertThat(resultNull).isNull();
 		assertThat(resultEmpty).isNull();
+	}
+
+	@Test
+	@DisplayName("검증 실패(BusinessException) 시 기본 이미지 URL을 반환한다")
+	void shouldReturnDefaultImageUrlWhenValidationFails() throws IOException {
+		// given
+		String originalUrl = "http://127.0.0.1/image.jpg";
+		willThrow(new BusinessException(LinkErrorCode.INVALID_URL_PRIVATE_IP))
+			.given(urlValidator).validateSafeUrl(originalUrl);
+
+		// when
+		String result = s3ImageUploader.uploadFromUrl(originalUrl);
+
+		// then
+		assertThat(result).isEqualTo(DEFAULT_IMAGE_URL);
+		verify(urlConnectionFactory, never()).createConnection(anyString());
+	}
+
+	@Test
+	@DisplayName("이미 존재하는 파일인지 확인하여 Optional URL을 반환한다")
+	void shouldResolveStoredUrl() {
+		// given
+		String originalUrl = "https://example.com/test.jpg";
+		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(true);
+
+		// when
+		Optional<String> result = s3ImageUploader.resolveStoredUrl(originalUrl);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get()).contains("images/");
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #169 

## PR 설명
- scrapeMetadata에서 OG 이미지 업로드를 선행하고 S3 URL을 반환하도록 변경
- createLink에서 캐시 히트 시 다운로드 없이 S3 URL 매핑
- 캐시 미스 시 UrlValidator로 SSRF 방어 후 업로드, 실패 시 기본 이미지 사용
