### PR TITLE
채팅 AI 서버 연동

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/MockAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/MockAnswerClient.java
@@ -2,7 +2,7 @@ package com.sofa.linkiving.domain.chat.ai;
 
 import java.util.List;
 
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@Primary
+@Profile("test")
 public class MockAnswerClient implements AnswerClient {
 
 	@Override

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
@@ -1,0 +1,33 @@
+package com.sofa.linkiving.domain.chat.ai;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
+import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class RagAnswerClient implements AnswerClient {
+
+	private final RagAnswerFeign ragAnswerFeign;
+
+	@Override
+	public RagAnswerRes generateAnswer(RagAnswerReq request) {
+		try {
+			List<RagAnswerRes> ragAnswerRes = ragAnswerFeign.generateAnswer(request);
+			log.info("RagAnswerClient generateAnswer ragAnswerRes={}", ragAnswerRes);
+			return ragAnswerRes.get(0);
+		} catch (Exception e) {
+			log.error("RagAnswerClient generateAnswer error", e);
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerFeign.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerFeign.java
@@ -1,0 +1,17 @@
+package com.sofa.linkiving.domain.chat.ai;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
+import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
+import com.sofa.linkiving.infra.feign.GlobalFeignConfig;
+
+@FeignClient(name = "ai-answer-client", url = "${ai.server.url}", configuration = GlobalFeignConfig.class)
+public interface RagAnswerFeign {
+	@PostMapping("/webhook/chat-answer")
+	List<RagAnswerRes> generateAnswer(@RequestBody RagAnswerReq request);
+}

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/RagAnswerReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/RagAnswerReq.java
@@ -2,12 +2,31 @@ package com.sofa.linkiving.domain.chat.dto.request;
 
 import java.util.List;
 
+import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.enums.Mode;
+import com.sofa.linkiving.domain.chat.enums.Type;
 
 public record RagAnswerReq(
 	Long userId,
 	String question,
-	List<String> history,
+	List<RagMessageReq> history,
 	Mode mode
 ) {
+	public static RagAnswerReq of(Long userId, String question, List<Message> messages, Mode mode) {
+		List<RagMessageReq> history = messages.stream()
+			.map(RagMessageReq::from)
+			.toList();
+
+		return new RagAnswerReq(userId, question, history, mode);
+	}
+
+	public record RagMessageReq(
+		String role,
+		String content
+	) {
+		public static RagMessageReq from(Message message) {
+			String role = (message.getType() == Type.AI) ? "system" : "user";
+			return new RagMessageReq(role, message.getContent());
+		}
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -76,13 +76,24 @@ public class ChatFacade {
 			taskManager.remove(chatId);
 
 			if (task.isCancelled() || ex != null) {
+
+				if (ex != null) {
+					log.error("AI 답변 생성 중 오류 발생 - chatId: {}, error: {}", chatId, ex.getMessage(), ex);
+				} else {
+					log.info("AI 답변 생성 작업 취소됨 - chatId: {}", chatId);
+				}
+
 				sendNotification(chatId, member, AnswerRes.error(chatId, message));
 				return;
 			}
 
 			if (result != null) {
 				sendNotification(chatId, member, result);
+				return;
 			}
+
+			log.error("AI 답변 생성 결과가 null 입니다 - chatId: {}", chatId);
+			sendNotification(chatId, member, AnswerRes.error(chatId, message));
 		});
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -1,6 +1,5 @@
 package com.sofa.linkiving.domain.chat.service;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -43,15 +42,11 @@ public class RagChatService {
 		Chat chat = chatQueryService.findChat(chatId, member);
 
 		Message question = messageCommandService.saveUserMessage(chat, userMessage);
-		List<Message> pastMessages = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
+		List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
 			question.getId(), chat);
-
-		List<String> history = new ArrayList<>(pastMessages.stream()
-			.map(Message::getContent)
-			.toList());
 		Collections.reverse(history);
 
-		RagAnswerReq request = new RagAnswerReq(
+		RagAnswerReq request = RagAnswerReq.of(
 			member.getId(),
 			userMessage,
 			history,

--- a/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
@@ -1,0 +1,59 @@
+package com.sofa.linkiving.domain.chat.ai;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
+import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RagAnswerClient 단위 테스트")
+class RagAnswerClientTest {
+
+	@InjectMocks
+	private RagAnswerClient ragAnswerClient;
+
+	@Mock
+	private RagAnswerFeign ragAnswerFeign;
+
+	@Test
+	@DisplayName("generateAnswer: Feign 응답이 정상일 경우 리스트의 첫 번째 요소를 반환한다")
+	void shouldReturnFirstElement_WhenGenerateAnswerSuccess() {
+		// given
+		RagAnswerReq req = mock(RagAnswerReq.class);
+		RagAnswerRes expectedRes = mock(RagAnswerRes.class);
+		given(ragAnswerFeign.generateAnswer(any(RagAnswerReq.class)))
+			.willReturn(List.of(expectedRes));
+
+		// when
+		RagAnswerRes actualRes = ragAnswerClient.generateAnswer(req);
+
+		// then
+		assertThat(actualRes).isEqualTo(expectedRes);
+	}
+
+	@Test
+	@DisplayName("generateAnswer: Feign 요청 중 예외가 발생하면 예외를 잡고 null을 반환한다")
+	void shouldCatchExceptionAndReturnNull_WhenGenerateAnswerThrowsException() {
+		// given
+		RagAnswerReq req = mock(RagAnswerReq.class);
+		given(ragAnswerFeign.generateAnswer(any(RagAnswerReq.class)))
+			.willThrow(new RuntimeException("AI Server Error"));
+
+		// when
+		RagAnswerRes actualRes = ragAnswerClient.generateAnswer(req);
+
+		// then
+		assertThat(actualRes).isNull();
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #178 

## PR 설명
* 외부 AI 서버와 연동하여 RAG 기반 채팅 답변을 생성하는 Feign Client 및 서비스 구현함.
* 답변 생성 과정의 상태 추적 및 모니터링 강화를 위해 로깅 추가함.

### 작업 내용
#### API 명세
* **AI 채팅 답변 요청 (`generateAnswer`)**
  * Endpoint: `POST /webhook/chat-answer`
  * 동작: 사용자 질문 및 대화 기록을 AI 서버로 전송하고, 분석된 답변 및 참조 링크, 추론 과정을 List 형태로 수신함.

### Rag Request DTO 수정
* "history" 요청 시 기존 질문 내용만 보내던 부분을 질문 내용 및 해당 질문의 role을 포함하여 요청하도록 수정
   * 기존
      ```json
        {
            "userId": 1,
            "question": "Gemini 관련 링크 찾아줘",
            "history": [
                         "네이버 링크는 naver.com입니다.",
                          "네이버 링크 알려줘"
             ]
            "mode": "detailed"
        }
      ```
   * 변경 후
      ```json
        {
            "userId": 1,
            "question": "Gemini 관련 링크 찾아줘",
            "history": [{
                       "role":"system",
                       "content":"네이버 링크는 naver.com입니다."
                  },
                  {
                       "role":"user",
                       "content":"네이버 링크 알려줘"
                  }]
            "mode": "detailed"
        }
      ```

#### 비즈니스 로직
* `RagAnswerFeign` 신규 작성: AI 서버(`ai.server.url`)와 통신하는 Feign Client 인터페이스 구현함.
* `AnswerClient` 구현체 프로파일 분리:
  * `RagAnswerClient` (`!test` 프로파일): 실제 Feign Client를 호출하며, 통신 예외 발생 시 트랜잭션 롤백 없이 에러 로그를 남기고 `null`을 반환하도록 Soft Fail 처리함. 응답받은 List 데이터 중 첫 번째 요소를 반환함.
  * `MockAnswerClient` (`test` 프로파일): 외부 API 호출 없이 더미 데이터를 반환하도록 구현함.
* `ChatFacade` 로깅 추가:
  * 작업 취소(`isCancelled`), 예외 발생(`ex != null`), 결과값 누락(`result == null`) 등 예외 상황별 상세 로그(info/error) 기록 로직 추가함.