### PR TITLE
로그아웃 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
@@ -3,10 +3,13 @@ package com.sofa.linkiving.domain.member.controller;
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.dto.response.TokenRes;
+import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Tag(name = "User")
 public interface MemberApi {
@@ -15,4 +18,7 @@ public interface MemberApi {
 
 	@Operation(summary = "로그인", description = "이메일, 비밀번호를 통해 로그인을 진행합니다.")
 	BaseResponse<TokenRes> login(LoginReq req);
+
+	@Operation(summary = "로그아웃", description = "리프레시 토큰을 무효화하고 로그아웃 처리합니다.")
+	BaseResponse<String> logout(Member member, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
@@ -12,6 +12,8 @@ import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
+import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class MemberService {
 	private final MemberCommandService memberCommandService;
 	private final MemberQueryService memberQueryService;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisService redisService;
 
 	public TokenRes signup(SignupReq req) {
 
@@ -58,5 +61,9 @@ public class MemberService {
 		String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
 		return TokenRes.of(accessToken, refreshToken);
+	}
+
+	public void logout(Member member) {
+		redisService.delete(RedisKeyRegistry.REFRESH_TOKEN, member.getEmail());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 		"/ws/chat/**",
 
 		/* temp */
-		"/v1/member/**", "/mock/**",
+		"/v1/member/signup", "/v1/member/login", "/mock/**",
 
 		/* oauth2 */
 		"/oauth2/**"

--- a/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
@@ -1,31 +1,39 @@
 package com.sofa.linkiving.domain.member.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
 import com.sofa.linkiving.infra.redis.RedisService;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -179,5 +187,97 @@ public class MemberApiIntegrationTest {
 			.andExpect(jsonPath("$.status").value(MemberErrorCode.INCORRECT_PASSWORD.getStatus().name()))
 			.andExpect(jsonPath("$.message").value(MemberErrorCode.INCORRECT_PASSWORD.getMessage()))
 			.andExpect(jsonPath("$.data").value(MemberErrorCode.INCORRECT_PASSWORD.getCode()));
+	}
+
+	@Test
+	@DisplayName("로그아웃 시 로컬 환경에서는 HttpOnly/Secure 없이 쿠키가 만료된다")
+	void shouldExpireCookiesWithoutSecureFlagsOnLocalhost() throws Exception {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.email("logout-local@test.com")
+			.password("password")
+			.build());
+		CustomMemberDetail userDetails = new CustomMemberDetail(member, Role.USER);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/logout")
+					.with(csrf())
+					.with(user(userDetails))
+					.with(request -> {
+						request.setServerName("localhost");
+						return request;
+					})
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("로그아웃에 성공하였습니다."))
+			.andReturn();
+
+		// then
+		verify(redisService).delete(RedisKeyRegistry.REFRESH_TOKEN, member.getEmail());
+
+		List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+		assertThat(setCookies).hasSize(2);
+
+		String accessTokenCookie = setCookies.stream()
+			.filter(cookie -> cookie.startsWith("accessToken="))
+			.findFirst()
+			.orElseThrow();
+		String refreshTokenCookie = setCookies.stream()
+			.filter(cookie -> cookie.startsWith("refreshToken="))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(accessTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
+		assertThat(refreshTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
+		assertThat(accessTokenCookie).doesNotContain("HttpOnly");
+		assertThat(accessTokenCookie).doesNotContain("Secure");
+		assertThat(refreshTokenCookie).doesNotContain("HttpOnly");
+		assertThat(refreshTokenCookie).doesNotContain("Secure");
+	}
+
+	@Test
+	@DisplayName("로그아웃 시 운영 환경에서는 HttpOnly/Secure 쿠키로 만료된다")
+	void shouldExpireCookiesWithSecureFlagsOnNonLocalhost() throws Exception {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.email("logout-prod@test.com")
+			.password("password")
+			.build());
+		CustomMemberDetail userDetails = new CustomMemberDetail(member, Role.USER);
+
+		// when
+		MvcResult result = mockMvc.perform(post(BASE_URL + "/logout")
+					.with(csrf())
+					.with(user(userDetails))
+					.with(request -> {
+						request.setServerName("example.com");
+						return request;
+					})
+					.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("로그아웃에 성공하였습니다."))
+			.andReturn();
+
+		// then
+		verify(redisService).delete(RedisKeyRegistry.REFRESH_TOKEN, member.getEmail());
+
+		List<String> setCookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+		assertThat(setCookies).hasSize(2);
+
+		String accessTokenCookie = setCookies.stream()
+			.filter(cookie -> cookie.startsWith("accessToken="))
+			.findFirst()
+			.orElseThrow();
+		String refreshTokenCookie = setCookies.stream()
+			.filter(cookie -> cookie.startsWith("refreshToken="))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(accessTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
+		assertThat(refreshTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
+		assertThat(accessTokenCookie).contains("HttpOnly");
+		assertThat(accessTokenCookie).contains("Secure");
+		assertThat(refreshTokenCookie).contains("HttpOnly");
+		assertThat(refreshTokenCookie).contains("Secure");
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -23,6 +23,7 @@ import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +33,8 @@ public class MemberServiceTest {
 	MemberCommandService memberCommandService;
 	@Mock
 	JwtTokenProvider jwtTokenProvider;
+	@Mock
+	RedisService redisService;
 	@InjectMocks
 	MemberService memberService;
 	@Mock
@@ -142,5 +145,18 @@ public class MemberServiceTest {
 			);
 
 		verify(memberQueryService, times(1)).getUser(email);
+	}
+
+	@Test
+	@DisplayName("로그아웃 시 Redis에 저장된 refresh token 삭제")
+	void shouldDeleteRefreshTokenOnLogout() {
+		// given
+		Member member = Member.builder().email("test@test.com").password("pw").build();
+
+		// when
+		memberService.logout(member);
+
+		// then
+		verify(redisService, times(1)).delete(any(), eq(member.getEmail()));
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #183

## PR 설명

**Overview**
- 로그아웃 엔드포인트 추가 및 Redis 리프레시 토큰 무효화
- 회원 API 중 `signup/login` 제외하고 인증 필요하도록 변경

**Changes**
- `POST /v1/member/logout` 추가 및 쿠키 만료 처리
- 로그아웃 시 refresh token 삭제
- 보안 설정에서 `/v1/member/signup`, `/v1/member/login`만 permit
- `MemberServiceTest`에 로그아웃 테스트 추가

**Testing**
- `./gradlew test --tests com.sofa.linkiving.domain.member.service.MemberServiceTest`

