### PR TITLE
링크 요약 수정 API 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -7,12 +7,14 @@ import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.MetaScrapeReq;
+import com.sofa.linkiving.domain.link.dto.request.SummaryUpdateReq;
 import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RecreateSummaryResponse;
+import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
 import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
@@ -96,6 +98,13 @@ public interface LinkApi {
 		Long id,
 		@Schema(description = "요청 형식(CONCISE: 간결하게, DETAILED:자세하게)")
 		@Valid Format format,
+		Member member
+	);
+
+	@Operation(summary = "새로운 요약 선택", description = "신규 요약으로 요약 내용을 수정합니다.")
+	BaseResponse<SummaryRes> updateSummary(
+		Long id,
+		@Valid SummaryUpdateReq request,
 		Member member
 	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -16,12 +16,14 @@ import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.MetaScrapeReq;
+import com.sofa.linkiving.domain.link.dto.request.SummaryUpdateReq;
 import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RecreateSummaryResponse;
+import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
 import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.link.facade.LinkFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -151,5 +153,16 @@ public class LinkController implements LinkApi {
 	) {
 		RecreateSummaryResponse response = linkFacade.recreateSummary(member, id, format);
 		return BaseResponse.success(response, "요약 재성성 완료");
+	}
+
+	@Override
+	@PatchMapping("/{id}/summary")
+	public BaseResponse<SummaryRes> updateSummary(
+		@PathVariable Long id,
+		@RequestBody SummaryUpdateReq request,
+		@AuthMember Member member
+	) {
+		SummaryRes response = linkFacade.updateSummary(id, member, request.summary(), request.format());
+		return BaseResponse.success(response, "요약 수정 완료");
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/SummaryUpdateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/SummaryUpdateReq.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.domain.link.dto.request;
+
+import com.sofa.linkiving.domain.link.enums.Format;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record SummaryUpdateReq(
+	@NotNull(message = "요약 내용은 필수입니다.")
+	@Schema(description = "요약 내용", example = "새롭게 선택한 요약 내용")
+	String summary,
+	@NotNull(message = "요약 포맷 정보는 필수입니다.")
+	@Schema(description = "요약 포맷 정보 (CONCISE, DETAILED)", example = "CONCISE")
+	Format format
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
@@ -40,17 +40,4 @@ public record LinkDetailRes(
 		);
 	}
 
-	public record SummaryRes(
-		@Schema(description = "요약 ID")
-		Long id,
-		@Schema(description = "요약 내용", example = "이 링크는 예시 링크입니다.")
-		String content
-	) {
-		public static SummaryRes from(Summary summary) {
-			if (summary == null) {
-				return null;
-			}
-			return new SummaryRes(summary.getId(), summary.getContent());
-		}
-	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryRes.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import com.sofa.linkiving.domain.link.entity.Summary;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SummaryRes(
+	@Schema(description = "요약 ID")
+	Long id,
+	@Schema(description = "요약 내용", example = "이 링크는 예시 링크입니다.")
+	String content
+) {
+	public static SummaryRes from(Summary summary) {
+		if (summary == null) {
+			return null;
+		}
+		return new SummaryRes(summary.getId(), summary.getContent());
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -13,7 +13,9 @@ import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RecreateSummaryResponse;
+import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
 import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
@@ -82,7 +84,7 @@ public class LinkFacade {
 		String url = linkService.getLink(linkId, member).getUrl();
 
 		String existingSummary = summaryService.getSummary(linkId).getContent();
-		String newSummary = summaryService.createSummary(linkId, url, format);
+		String newSummary = summaryService.initialSummary(linkId, url, format);
 
 		String comparison = summaryService.comparisonSummary(existingSummary, newSummary);
 
@@ -97,5 +99,12 @@ public class LinkFacade {
 	public MetaScrapeRes scrapeMetadata(String url) {
 		OgTagDto ogTag = ogTagCrawler.crawl(url);
 		return MetaScrapeRes.from(ogTag);
+	}
+
+	public SummaryRes updateSummary(Long id, Member member, String content, Format format) {
+		Link link = linkService.getLink(id, member);
+		Summary summary = summaryService.createSummary(link, format, content);
+		summaryService.selectSummary(link.getId(), summary.getId());
+		return SummaryRes.from(summary);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/SummaryCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/SummaryCommandService.java
@@ -2,6 +2,9 @@ package com.sofa.linkiving.domain.link.service;
 
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.repository.SummaryRepository;
 import com.sofa.linkiving.global.error.exception.BusinessException;
@@ -23,6 +26,16 @@ public class SummaryCommandService {
 		if (updated == 0) {
 			throw new BusinessException(LinkErrorCode.SUMMARY_NOT_FOUND);
 		}
+	}
+
+	public Summary save(Link link, Format format, String content) {
+		return summaryRepository.save(
+			Summary.builder()
+				.link(link)
+				.format(format)
+				.content(content)
+				.build()
+		);
 	}
 }
 

--- a/src/main/java/com/sofa/linkiving/domain/link/service/SummaryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/SummaryService.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.link.ai.AiSummaryClient;
+import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
 
@@ -12,9 +13,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SummaryService {
 	private final SummaryQueryService summaryQueryService;
+	private final SummaryCommandService summaryCommandService;
 	private final AiSummaryClient aiSummaryClient;
 
-	public String createSummary(Long linkId, String url, Format format) {
+	public String initialSummary(Long linkId, String url, Format format) {
 		return aiSummaryClient.generateSummary(linkId, url, format);
 	}
 
@@ -24,5 +26,13 @@ public class SummaryService {
 
 	public Summary getSummary(Long linkId) {
 		return summaryQueryService.getSummary(linkId);
+	}
+
+	public Summary createSummary(Link link, Format format, String content) {
+		return summaryCommandService.save(link, format, content);
+	}
+
+	public void selectSummary(Long linkId, Long summaryId) {
+		summaryCommandService.selectSummary(linkId, summaryId);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -116,7 +116,7 @@ public class LinkFacadeTest {
 		given(summaryService.getSummary(linkId)).willReturn(mockSummary);
 
 		// 3. SummaryService (새 요약 생성 및 비교)
-		given(summaryService.createSummary(linkId, url, format)).willReturn(newSummaryBody);
+		given(summaryService.initialSummary(linkId, url, format)).willReturn(newSummaryBody);
 		given(summaryService.comparisonSummary(existingSummaryBody, newSummaryBody)).willReturn(comparisonBody);
 
 		// when
@@ -130,7 +130,7 @@ public class LinkFacadeTest {
 
 		// verify
 		verify(summaryService).getSummary(linkId);
-		verify(summaryService).createSummary(linkId, url, format);
+		verify(summaryService).initialSummary(linkId, url, format);
 		verify(summaryService).comparisonSummary(existingSummaryBody, newSummaryBody);
 	}
 

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -28,6 +28,7 @@ import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.MetaScrapeReq;
+import com.sofa.linkiving.domain.link.dto.request.SummaryUpdateReq;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
@@ -723,5 +724,30 @@ public class LinkApiIntegrationTest {
 					.content(invalidJson)
 			)
 			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("updateSummary API: PATCH 요청 시 요약 정보를 수정하고 200 OK를 반환한다")
+	void updateSummaryApi_ShouldReturn200Ok() throws Exception {
+		// given
+		Link savedLink = linkRepository.save(Link.builder()
+			.member(testMember)
+			.url("https://example.com/article")
+			.title("테스트 링크")
+			.build());
+		Long linkId = savedLink.getId();
+
+		SummaryUpdateReq request = new SummaryUpdateReq("수정된 요약 텍스트", Format.DETAILED);
+
+		// when & then
+		mockMvc.perform(patch(BASE_URL + "/{id}/summary", linkId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request))
+				.with(csrf())
+				.with(user(testUserDetails))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("요약 수정 완료"))
+			.andExpect(jsonPath("$.data.content").value("수정된 요약 텍스트"));
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/SummaryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/SummaryServiceTest.java
@@ -26,8 +26,8 @@ public class SummaryServiceTest {
 	private AiSummaryClient aiSummaryClient;
 
 	@Test
-	@DisplayName("createSummary 호출 시 AiSummaryClient에게 위임한다")
-	void shouldCallGenerateSummaryWhenCreateSummary() {
+	@DisplayName("generateSummary 호출 시 SummaryClient에게 위임한다")
+	void shouldCallGenerateSummaryWhenInitialSummary() {
 		// given
 		Long linkId = 1L;
 		String url = "https://example.com";
@@ -37,7 +37,7 @@ public class SummaryServiceTest {
 		given(aiSummaryClient.generateSummary(linkId, url, format)).willReturn(expectedResult);
 
 		// when
-		String result = summaryService.createSummary(linkId, url, format);
+		String result = summaryService.initialSummary(linkId, url, format);
 
 		// then
 		assertThat(result).isEqualTo(expectedResult);


### PR DESCRIPTION
## 관련 이슈

- close #182 

## PR 설명
* 사용자가 최종적으로 선택하거나 수정한 텍스트를 새로운 요약으로 저장하고, 해당 링크의 대표(선택된) 요약으로 갱신하는 API 구현함.

### 작업 내용
#### API 명세
* **링크 요약 수정 API (`updateSummary`)**
  * Endpoint: `PATCH /v1/links/{id}/summary`
  * 동작: 요청받은 요약 텍스트와 포맷(CONCISE/DETAILED)으로 새로운 요약을 생성하고, 해당 링크의 대표 요약으로 설정함.

#### 비즈니스 로직
* `LinkController`, `LinkFacade`: 요약 수정 처리를 위한 파라미터 바인딩 및 서비스 위임 로직 추가함.
* `SummaryService`, `SummaryCommandService`:
  * 전달받은 텍스트와 포맷 정보로 신규 `Summary` 데이터를 DB에 저장함 (`save`).
  * 기존 링크에 연결된 요약들의 선택 상태(`selected`)를 모두 초기화한 뒤, 새로 생성한 요약을 선택 상태로 업데이트함 (`selectSummary`).
  * 업데이트 대상 요약이 없을 경우 `SUMMARY_NOT_FOUND` 비즈니스 예외 발생 처리함.
* `SummaryUpdateReq`, `SummaryRes`: 통신용 Request/Response DTO 정의함.

