### PR TITLE
로그인 버그 해결

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.domain.member.controller;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +17,7 @@ import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.service.MemberService;
 import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.config.CookieProperties;
 import com.sofa.linkiving.security.annotation.AuthMember;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController implements MemberApi {
 
 	private final MemberService memberService;
+	private final CookieProperties cookieProperties;
 
 	@Override
 	@PostMapping("/signup")
@@ -58,14 +61,22 @@ public class MemberController implements MemberApi {
 	private void expireCookie(HttpServletRequest request, HttpServletResponse response, String name) {
 		String domain = request.getServerName();
 		boolean isLocal = "localhost".equals(domain) || "127.0.0.1".equals(domain);
-
-		ResponseCookie cookie = ResponseCookie.from(name, "")
+		ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, "")
 			.path("/")
 			.maxAge(0)
 			.httpOnly(!isLocal)
 			.secure(!isLocal)
-			.sameSite("Lax")
-			.build();
+			// TODO: Review security implications of SameSite=None (CSRF risk) before finalizing.
+			.sameSite(isLocal ? "Lax" : "None");
+
+		if (!isLocal) {
+			String cookieDomain = cookieProperties.domain();
+			if (StringUtils.hasText(cookieDomain)) {
+				builder.domain(cookieDomain);
+			}
+		}
+
+		ResponseCookie cookie = builder.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 

--- a/src/main/java/com/sofa/linkiving/global/config/CookieProperties.java
+++ b/src/main/java/com/sofa/linkiving/global/config/CookieProperties.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cookie")
+public record CookieProperties(
+	String domain
+) {
+}

--- a/src/main/java/com/sofa/linkiving/global/config/CorsProperties.java
+++ b/src/main/java/com/sofa/linkiving/global/config/CorsProperties.java
@@ -1,0 +1,11 @@
+package com.sofa.linkiving.global.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+	List<String> allowedOrigins
+) {
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
@@ -8,7 +8,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
+import com.sofa.linkiving.global.config.CookieProperties;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 import com.sofa.linkiving.security.jwt.JwtProperties;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
@@ -24,6 +26,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final OAuth2Properties oauth2Properties;
 	private final JwtProperties jwtProperties;
+	private final CookieProperties cookieProperties;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -49,14 +52,22 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		int maxAge) {
 		String domain = request.getServerName();
 		boolean isLocal = "localhost".equals(domain) || "127.0.0.1".equals(domain);
-
-		ResponseCookie cookie = ResponseCookie.from(name, value)
+		ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
 			.path("/")
 			.maxAge(maxAge)
 			.httpOnly(!isLocal)
 			.secure(!isLocal)
-			.sameSite("Lax")
-			.build();
+			// TODO: Review security implications of SameSite=None (CSRF risk) before finalizing.
+			.sameSite(isLocal ? "Lax" : "None");
+
+		if (!isLocal) {
+			String cookieDomain = cookieProperties.domain();
+			if (StringUtils.hasText(cookieDomain)) {
+				builder.domain(cookieDomain);
+			}
+		}
+
+		ResponseCookie cookie = builder.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.sofa.linkiving.security.config;
 
+import java.util.List;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +13,12 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.sofa.linkiving.global.config.CookieProperties;
+import com.sofa.linkiving.global.config.CorsProperties;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 import com.sofa.linkiving.security.auth.handler.OAuth2FailureHandler;
 import com.sofa.linkiving.security.auth.handler.OAuth2SuccessHandler;
@@ -26,7 +33,12 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties({JwtProperties.class, OAuth2Properties.class})
+@EnableConfigurationProperties({
+	JwtProperties.class,
+	OAuth2Properties.class,
+	CorsProperties.class,
+	CookieProperties.class
+})
 public class SecurityConfig {
 
 	private static final String[] PERMIT_URLS = {
@@ -62,6 +74,7 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
+	private final CorsProperties corsProperties;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -92,5 +105,22 @@ public class SecurityConfig {
 			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+		List<String> allowedOrigins = corsProperties.allowedOrigins();
+		if (allowedOrigins == null || allowedOrigins.isEmpty()) {
+			allowedOrigins = List.of();
+		}
+		config.setAllowedOrigins(allowedOrigins);
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		config.setAllowedHeaders(List.of("*"));
+		config.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
@@ -32,28 +32,22 @@ import com.sofa.linkiving.domain.member.entity.Member;
 @DisplayName("RagChatService 단위 테스트")
 public class RagChatServiceTest {
 
-	@InjectMocks
-	private RagChatService ragChatService;
-
-	@Mock
-	private AnswerClient answerClient;
-
-	@Mock
-	private MessageCommandService messageCommandService;
-
-	@Mock
-	private MessageQueryService messageQueryService;
-
-	@Mock
-	private LinkQueryService linkQueryService;
-
-	@Mock
-	private ChatQueryService chatQueryService;
-
-	private Member member;
-	private Chat chat;
 	private final Long chatId = 1L;
 	private final String userMessage = "테스트 질문";
+	@InjectMocks
+	private RagChatService ragChatService;
+	@Mock
+	private AnswerClient answerClient;
+	@Mock
+	private MessageCommandService messageCommandService;
+	@Mock
+	private MessageQueryService messageQueryService;
+	@Mock
+	private LinkQueryService linkQueryService;
+	@Mock
+	private ChatQueryService chatQueryService;
+	private Member member;
+	private Chat chat;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
@@ -1,8 +1,7 @@
 package com.sofa.linkiving.domain.member.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -19,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -39,6 +39,7 @@ import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")
+@TestPropertySource(properties = "app.cookie.domain=linkiving.com")
 public class MemberApiIntegrationTest {
 
 	private static final String BASE_URL = "/v1/member";
@@ -201,13 +202,13 @@ public class MemberApiIntegrationTest {
 
 		// when
 		MvcResult result = mockMvc.perform(post(BASE_URL + "/logout")
-					.with(csrf())
-					.with(user(userDetails))
-					.with(request -> {
-						request.setServerName("localhost");
-						return request;
-					})
-					.accept(MediaType.APPLICATION_JSON))
+				.with(csrf())
+				.with(user(userDetails))
+				.with(request -> {
+					request.setServerName("localhost");
+					return request;
+				})
+				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("로그아웃에 성공하였습니다."))
 			.andReturn();
@@ -247,13 +248,13 @@ public class MemberApiIntegrationTest {
 
 		// when
 		MvcResult result = mockMvc.perform(post(BASE_URL + "/logout")
-					.with(csrf())
-					.with(user(userDetails))
-					.with(request -> {
-						request.setServerName("example.com");
-						return request;
-					})
-					.accept(MediaType.APPLICATION_JSON))
+				.with(csrf())
+				.with(user(userDetails))
+				.with(request -> {
+					request.setServerName("api.linkiving.com");
+					return request;
+				})
+				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("로그아웃에 성공하였습니다."))
 			.andReturn();
@@ -273,8 +274,8 @@ public class MemberApiIntegrationTest {
 			.findFirst()
 			.orElseThrow();
 
-		assertThat(accessTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
-		assertThat(refreshTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=Lax");
+		assertThat(accessTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=None", "Domain=linkiving.com");
+		assertThat(refreshTokenCookie).contains("Max-Age=0", "Path=/", "SameSite=None", "Domain=linkiving.com");
 		assertThat(accessTokenCookie).contains("HttpOnly");
 		assertThat(accessTokenCookie).contains("Secure");
 		assertThat(refreshTokenCookie).contains("HttpOnly");


### PR DESCRIPTION
## 관련 이슈

- close #190

## PR 설명

- 서브도메인 간 로그인 쿠키 공유를 위해 `Domain` 지정 및 `SameSite=None` 적용
- CORS 설정 추가 (`allowCredentials`, 허용 오리진)
- `SameSite=None` 보안 이슈 검토 필요 TODO 주석 추가
- 테스트: 미실행
