### PR TITLE
링크 이미지 수정 기능 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -86,7 +86,8 @@ public class LinkController implements LinkApi {
 			id,
 			member,
 			request.title(),
-			request.memo()
+			request.memo(),
+			request.imageUrl()
 		);
 		return BaseResponse.success(response, "링크 수정 완료");
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkUpdateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkUpdateReq.java
@@ -9,6 +9,9 @@ public record LinkUpdateReq(
 	String title,
 
 	@Schema(description = "메모", example = "나중에 읽어볼 것")
-	String memo
+	String memo,
+
+	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
+	String imageUrl
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
@@ -53,12 +53,15 @@ public class Link extends BaseEntity {
 			.build();
 	}
 
-	public void updateDetails(String title, String memo) {
+	public void updateDetails(String title, String memo, String imageUrl) {
 		if (title != null) {
 			this.title = title;
 		}
 		if (memo != null) {
 			this.memo = memo;
+		}
+		if (imageUrl != null) {
+			this.imageUrl = imageUrl;
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -49,8 +49,12 @@ public class LinkFacade {
 		return LinkRes.from(link);
 	}
 
-	public LinkRes updateLink(Long linkId, Member member, String title, String memo) {
-		Link link = linkService.updateLink(linkId, member, title, memo);
+	public LinkRes updateLink(Long linkId, Member member, String title, String memo, String imageUrl) {
+		String storedImageUrl = null;
+		if (imageUrl != null) {
+			storedImageUrl = imageUploader.uploadFromUrl(imageUrl);
+		}
+		Link link = linkService.updateLink(linkId, member, title, memo, storedImageUrl);
 		return LinkRes.from(link);
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
@@ -19,8 +19,8 @@ public class LinkCommandService {
 		return linkRepository.save(link);
 	}
 
-	public Link updateLink(Link link, String title, String memo) {
-		link.updateDetails(title, memo);
+	public Link updateLink(Link link, String title, String memo, String imageUrl) {
+		link.updateDetails(title, memo, imageUrl);
 		return link;
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -33,9 +33,9 @@ public class LinkService {
 		return link;
 	}
 
-	public Link updateLink(Long linkId, Member member, String title, String memo) {
+	public Link updateLink(Long linkId, Member member, String title, String memo, String imageUrl) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(link, title, memo);
+		Link updatedLink = linkCommandService.updateLink(link, title, memo, imageUrl);
 
 		log.info("Link updated - id: {}, memberId: {}", linkId, member.getId());
 
@@ -44,7 +44,7 @@ public class LinkService {
 
 	public Link updateTitle(Long linkId, Member member, String title) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(link, title, link.getMemo());
+		Link updatedLink = linkCommandService.updateLink(link, title, link.getMemo(), link.getImageUrl());
 
 		log.info("Link title updated - id: {}, memberId: {}", linkId, member.getId());
 
@@ -53,7 +53,7 @@ public class LinkService {
 
 	public Link updateMemo(Long linkId, Member member, String memo) {
 		Link link = linkQueryService.findById(linkId, member);
-		Link updatedLink = linkCommandService.updateLink(link, link.getTitle(), memo);
+		Link updatedLink = linkCommandService.updateLink(link, link.getTitle(), memo, link.getImageUrl());
 
 		log.info("Link memo updated - id: {}, memberId: {}", linkId, member.getId());
 

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -236,10 +236,10 @@ public class LinkFacadeTest {
 		Link updatedLink = Link.builder().member(member).url("https://example.com").title("수정").build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), any(), any())).willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), any(), any(), any())).willReturn(updatedLink);
 
 		// when
-		Link result = linkService.updateLink(1L, member, "수정", null);
+		Link result = linkService.updateLink(1L, member, "수정", null, null);
 
 		// then
 		assertThat(result).isEqualTo(updatedLink);
@@ -251,11 +251,19 @@ public class LinkFacadeTest {
 	void shouldUpdateTitle() {
 		// given
 		Member member = Member.builder().email("test@example.com").build();
-		Link originalLink = Link.builder().member(member).title("원본").memo("메모").build();
-		Link updatedLink = Link.builder().member(member).title("수정").memo("메모").build();
+		Link originalLink = Link.builder()
+			.member(member)
+			.title("원본")
+			.memo("메모")
+			.build();
+		Link updatedLink = Link.builder()
+			.member(member)
+			.title("수정")
+			.memo("메모")
+			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("수정"), eq("메모"))).willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), eq("수정"), eq("메모"), isNull())).willReturn(updatedLink);
 
 		// when
 		Link result = linkService.updateTitle(1L, member, "수정");
@@ -273,7 +281,7 @@ public class LinkFacadeTest {
 		Link updatedLink = Link.builder().member(member).title("제목").memo("수정").build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("제목"), eq("수정"))).willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), eq("제목"), eq("수정"), isNull())).willReturn(updatedLink);
 
 		// when
 		Link result = linkService.updateMemo(1L, member, "수정");

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -365,6 +365,11 @@ public class LinkApiIntegrationTest {
 	@DisplayName("링크 전체 수정 성공 시 DB 업데이트 및 200 OK 응답")
 	void shouldUpdateLinkSuccessfully() throws Exception {
 		// given
+		String originalImageUrl = "https://original.com/image.jpg";
+		String uploadedS3Url = "https://s3.amazonaws.com/bucket/links/uuid.jpg";
+
+		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(uploadedS3Url);
+
 		Link link = linkRepository.save(Link.builder()
 			.member(testMember)
 			.url("https://example.com")
@@ -374,7 +379,8 @@ public class LinkApiIntegrationTest {
 
 		LinkUpdateReq req = new LinkUpdateReq(
 			"수정된 제목",
-			"수정된 메모"
+			"수정된 메모",
+			originalImageUrl
 		);
 
 		// when & then
@@ -390,7 +396,8 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.message").value("링크 수정 완료"))
 			.andExpect(jsonPath("$.data.title").value(req.title()))
-			.andExpect(jsonPath("$.data.memo").value(req.memo()));
+			.andExpect(jsonPath("$.data.memo").value(req.memo()))
+			.andExpect(jsonPath("$.data.imageUrl").value(uploadedS3Url));
 
 		// DB 검증
 		Link updated = linkRepository.findById(link.getId()).orElseThrow();

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
@@ -80,13 +80,15 @@ class LinkCommandServiceTest {
 		Link result = linkCommandService.updateLink(
 			originalLink,
 			"수정된 제목",
-			"수정된 메모"
+			"수정된 메모",
+			"https://edit.com/image.jpg"
 		);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getTitle()).isEqualTo("수정된 제목");
 		assertThat(result.getMemo()).isEqualTo("수정된 메모");
+		assertThat(result.getImageUrl()).isEqualTo("https://edit.com/image.jpg");
 		verify(linkRepository, never()).save(any(Link.class));
 	}
 

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -122,16 +122,16 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), any(), any())).willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), any(), any(), any())).willReturn(updatedLink);
 
 		// when
-		Link result = linkService.updateLink(1L, member, "수정된 제목", null);
+		Link result = linkService.updateLink(1L, member, "수정된 제목", null, null);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getTitle()).isEqualTo("수정된 제목");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), any(), any());
+		verify(linkCommandService, times(1)).updateLink(any(), any(), any(), any());
 	}
 
 	@Test
@@ -158,8 +158,7 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("수정된 제목"), eq("원본 메모")))
-			.willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), eq("수정된 제목"), eq("원본 메모"), isNull())).willReturn(updatedLink);
 
 		// when
 		Link result = linkService.updateTitle(1L, member, "수정된 제목");
@@ -169,7 +168,7 @@ class LinkServiceTest {
 		assertThat(result.getTitle()).isEqualTo("수정된 제목");
 		assertThat(result.getMemo()).isEqualTo("원본 메모");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), eq("수정된 제목"), eq("원본 메모"));
+		verify(linkCommandService, times(1)).updateLink(any(), eq("수정된 제목"), eq("원본 메모"), isNull());
 	}
 
 	@Test
@@ -196,8 +195,7 @@ class LinkServiceTest {
 			.build();
 
 		given(linkQueryService.findById(1L, member)).willReturn(originalLink);
-		given(linkCommandService.updateLink(any(), eq("원본 제목"), eq("수정된 메모")))
-			.willReturn(updatedLink);
+		given(linkCommandService.updateLink(any(), eq("원본 제목"), eq("수정된 메모"), isNull())).willReturn(updatedLink);
 
 		// when
 		Link result = linkService.updateMemo(1L, member, "수정된 메모");
@@ -207,7 +205,7 @@ class LinkServiceTest {
 		assertThat(result.getTitle()).isEqualTo("원본 제목");
 		assertThat(result.getMemo()).isEqualTo("수정된 메모");
 		verify(linkQueryService, times(1)).findById(1L, member);
-		verify(linkCommandService, times(1)).updateLink(any(), eq("원본 제목"), eq("수정된 메모"));
+		verify(linkCommandService, times(1)).updateLink(any(), eq("원본 제목"), eq("수정된 메모"), isNull());
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

- close #193

## PR 설명
* 링크 썸네일(이미지) 변경 요구사항에 대응하기 위해, 기존 링크 생성 및 통합 수정 API에 `imageUrl` 필드를 추가하고 관련 서비스 로직을 개선함.

### 작업 내용
#### API 명세
* **링크 생성 및 통합 수정 API (`POST /v1/links`, `PUT /v1/links/{id}`)**
  * `LinkUpdateReq` 요청 DTO에 `imageUrl` 필드를 추가하여 제목, 메모와 함께 이미지 정보도 동시 처리하도록 명세 변경함.
    ``` Json
      {
        "title": "유용한 개발 자료",
        "memo": "나중에 읽어볼 것",
        "imageUrl": "https://example.com/new-image.png"
      }
    ```
#### 비즈니스 로직
* `LinkController`: `createLink` 및 `updateLink` 컨트롤러 메서드에서 `request.imageUrl()`을 파라미터로 넘기도록 바인딩 로직 수정함.
* `LinkService`: 
  * `createLink`, `updateLink` 메서드 시그니처에 `imageUrl` 파라미터를 추가하여 갱신 로직 반영함.
  * 제목 전용 수정(`updateTitle`), 메모 전용 수정(`updateMemo`) 호출 시 기존 엔티티의 `imageUrl`을 그대로 전달하여 기존 이미지 데이터가 소실되지 않도록 보존 처리함.
* `LinkCommandService`: `saveLink` 및 `updateLink` 시 전달받은 `imageUrl`을 Entity의 `updateDetails` 메서드에 전달하여 최종 병합함.

