### PR TITLE
배포 환경 JWT 인증 실패 해결 및 쿠키 Fallback 로직 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
 
 import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
 import com.sofa.linkiving.infra.redis.RedisService;
@@ -25,11 +26,14 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtTokenProvider {
 	private final JwtProperties jwtProperties;
 	private final UserDetailsService userDetailsService;
@@ -100,6 +104,13 @@ public class JwtTokenProvider {
 		if (bearer != null && bearer.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
 			return bearer.substring(JwtKeys.Headers.BEARER_PREFIX.length());
 		}
+
+		Cookie cookie = WebUtils.getCookie(request, "accessToken");
+		if (cookie != null) {
+			return cookie.getValue();
+		}
+
+		log.warn("Token not found (missing in both header and cookie)");
 		return null;
 	}
 


### PR DESCRIPTION
## 관련 이슈

- close #196

## PR 설명
* 배포 환경에서 API 요청 시 `Authorization` 헤더를 통한 JWT 인증이 실패하여 서비스 접근이 차단되는 버그 수정함.
* 헤더 인증 실패 또는 토큰 누락 시, 쿠키(Cookie)에서 토큰을 읽어와 인증을 시도하는 예비(Fallback) 로직 추가함.
