### PR TITLE
특정 CDN 이미지 URL 인식(다운로드) 차단 문제 해결

### DIFF
--- a/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
+++ b/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.infra.s3;
 
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
@@ -36,7 +37,6 @@ public class S3ImageUploader implements ImageUploader {
 
 		try {
 			String s3Key = generateUniqueKeyFromUrl(originalUrl);
-
 			String s3Url = buildS3Url(s3Key);
 
 			if (s3Template.objectExists(bucketName, s3Key)) {
@@ -48,9 +48,15 @@ public class S3ImageUploader implements ImageUploader {
 			connection.setConnectTimeout(3000);
 			connection.setReadTimeout(3000);
 
+			connection.setRequestProperty("User-Agent",
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+					+ "AppleWebKit/537.36 (KHTML, like Gecko) "
+					+ "Chrome/120.0.0.0 Safari/537.36");
+			connection.setRequestProperty("Accept", "image/*, */*;q=0.8");
+
 			String contentType = connection.getContentType();
 			if (contentType == null || !contentType.startsWith("image/")) {
-				log.warn("Not Image: {}", originalUrl);
+				log.warn("Not Image (ContentType: {}): {}", contentType, originalUrl);
 				return null;
 			}
 
@@ -72,10 +78,12 @@ public class S3ImageUploader implements ImageUploader {
 
 	private String generateUniqueKeyFromUrl(String url) {
 		try {
+			String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
 			String extension = "jpg";
-			int lastDotIndex = url.lastIndexOf('.');
-			if (lastDotIndex > 0 && lastDotIndex < url.length() - 1) {
-				String ext = url.substring(lastDotIndex + 1);
+
+			int lastDotIndex = decodedUrl.lastIndexOf('.');
+			if (lastDotIndex > 0 && lastDotIndex < decodedUrl.length() - 1) {
+				String ext = decodedUrl.substring(lastDotIndex + 1);
 				if (ext.contains("?")) {
 					ext = ext.substring(0, ext.indexOf("?"));
 				}
@@ -83,6 +91,7 @@ public class S3ImageUploader implements ImageUploader {
 					extension = ext;
 				}
 			}
+
 			UUID uuid = UUID.nameUUIDFromBytes(url.getBytes(StandardCharsets.UTF_8));
 			return "links/" + uuid + "." + extension;
 		} catch (Exception e) {

--- a/src/test/java/com/sofa/linkiving/infra/s3/S3ImageUploaderTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/s3/S3ImageUploaderTest.java
@@ -47,13 +47,10 @@ public class S3ImageUploaderTest {
 		// given
 		String originalUrl = "https://example.com/image.jpg";
 
-		// 1. 중복 검사 통과 (S3에 파일 없음)
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
 
-		// 2. Factory가 Mock Connection 반환
 		given(urlConnectionFactory.createConnection(originalUrl)).willReturn(mockConnection);
 
-		// 3. Connection 동작 설정 (이미지 타입, 스트림)
 		given(mockConnection.getContentType()).willReturn("image/jpeg");
 		given(mockConnection.getInputStream()).willReturn(new ByteArrayInputStream("dummy-data".getBytes()));
 
@@ -61,8 +58,6 @@ public class S3ImageUploaderTest {
 		String result = s3ImageUploader.uploadFromUrl(originalUrl);
 
 		// then
-		// 예상되는 S3 URL 포맷 확인
-		// UUID 생성이 내부 로직이라 정확한 키값 예측은 어려우나, bucket/region/경로 포함 여부 확인
 		assertThat(result).startsWith("https://" + BUCKET_NAME + ".s3." + REGION + ".amazonaws.com/links/");
 		assertThat(result).endsWith(".jpg");
 
@@ -76,7 +71,6 @@ public class S3ImageUploaderTest {
 		// given
 		String originalUrl = "https://example.com/image.jpg";
 
-		// 이미 파일이 존재한다고 설정 (Cache Hit)
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(true);
 
 		// when
@@ -99,7 +93,6 @@ public class S3ImageUploaderTest {
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
 		given(urlConnectionFactory.createConnection(originalUrl)).willReturn(mockConnection);
 
-		// ContentType을 이미지가 아닌 것으로 설정
 		given(mockConnection.getContentType()).willReturn("application/pdf");
 
 		// when
@@ -120,7 +113,6 @@ public class S3ImageUploaderTest {
 
 		given(s3Template.objectExists(eq(BUCKET_NAME), anyString())).willReturn(false);
 
-		// 연결 생성 시 예외 발생하도록 설정
 		given(urlConnectionFactory.createConnection(originalUrl)).willThrow(new IOException("Connection Refused"));
 
 		// when


### PR DESCRIPTION
## 관련 이슈

- close #195 

## PR 설명
* Daum, Kakao 등 특정 CDN의 복잡한 이미지 URL을 저장하지 못하던 문제를 해결함.
* 초기에는 URL 파싱 및 확장자 추출 문제로 예상했으나, 실제로는 해당 CDN 서버에서 프로그램(Bot)에 의한 비정상적인 접근을 차단하여 발생하는 문제로 확인됨.
* `URLConnection` 요청 시 일반 브라우저와 동일한 헤더 환경을 구성하여 정상적으로 이미지를 다운로드하도록 개선함.
 
### 작업 내용
#### 비즈니스 로직
* `S3ImageUploader`의 `URLConnection` 설정 로직 수정함.
  * CDN의 봇 접근 차단을 우회하기 위해 `User-Agent` 헤더 설정 추가함 (`Chrome/120...` 등 표준 브라우저 정보 명시).
  * 서버에서 이미지 데이터를 정상적으로 반환하도록 `Accept: image/*, */*;q=0.8` 헤더를 명시함.