### PR TITLE
AI 서버 링크 데이터 동기화 로직 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/ai/LinkSyncClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/LinkSyncClient.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+public interface LinkSyncClient {
+
+	void syncCreate(LinkSyncUpdateReq req);
+
+	void syncUpdate(LinkSyncUpdateReq req);
+
+	void syncDelete(Long linkId);
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/LinkSyncFeign.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/LinkSyncFeign.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncDeleteReq;
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+@FeignClient(name = "linkSyncClient", url = "${ai.server.url}")
+public interface LinkSyncFeign {
+
+	@PostMapping("/update-link")
+	void syncUpdate(@RequestBody LinkSyncUpdateReq req);
+
+	@DeleteMapping("/link-delete")
+	void syncDelete(@RequestBody LinkSyncDeleteReq req);
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClient.java
@@ -1,0 +1,25 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+@Component
+@Profile("test")
+public class MockLinkSyncClient implements LinkSyncClient {
+	@Override
+	public void syncCreate(LinkSyncUpdateReq req) {
+		return;
+	}
+
+	@Override
+	public void syncUpdate(LinkSyncUpdateReq req) {
+		return;
+	}
+
+	@Override
+	public void syncDelete(Long linkId) {
+		return;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClient.java
@@ -1,0 +1,37 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncDeleteReq;
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class RagLinkSyncClient implements LinkSyncClient {
+
+	private final LinkSyncFeign linkSyncFeign;
+
+	@Override
+	public void syncCreate(LinkSyncUpdateReq req) {
+		linkSyncFeign.syncUpdate(req);
+		log.info("AI 서버 동기화 완료 (CREATE) - linkId: {}", req.linkId());
+	}
+
+	@Override
+	public void syncUpdate(LinkSyncUpdateReq req) {
+		linkSyncFeign.syncUpdate(req);
+		log.info("AI 서버 동기화 완료 (UPDATE) - linkId: {}", req.linkId());
+	}
+
+	@Override
+	public void syncDelete(Long linkId) {
+		linkSyncFeign.syncDelete(new LinkSyncDeleteReq(linkId));
+		log.info("AI 서버 동기화 완료 (DELETE) - linkId: {}", linkId);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkSyncDeleteReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkSyncDeleteReq.java
@@ -1,0 +1,6 @@
+package com.sofa.linkiving.domain.link.dto.request;
+
+public record LinkSyncDeleteReq(
+	Long linkId
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkSyncUpdateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkSyncUpdateReq.java
@@ -1,0 +1,37 @@
+package com.sofa.linkiving.domain.link.dto.request;
+
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+
+import lombok.Builder;
+
+@Builder
+public record LinkSyncUpdateReq(
+	Long linkId,
+	Long userId,
+	String url,
+	String title,
+	String memo,
+	String summary
+) {
+	public static LinkSyncUpdateReq from(Link link) {
+		return LinkSyncUpdateReq.builder()
+			.linkId(link.getId())
+			.userId(link.getMember().getId())
+			.url(link.getUrl())
+			.title(link.getTitle())
+			.memo(link.getMemo())
+			.build();
+	}
+
+	public static LinkSyncUpdateReq of(Link link, Summary summary) {
+		return LinkSyncUpdateReq.builder()
+			.linkId(link.getId())
+			.userId(link.getMember().getId())
+			.url(link.getUrl())
+			.title(link.getTitle())
+			.memo(link.getMemo())
+			.summary(summary != null ? summary.getContent() : null)
+			.build();
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/enums/SyncAction.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/enums/SyncAction.java
@@ -1,0 +1,5 @@
+package com.sofa.linkiving.domain.link.enums;
+
+public enum SyncAction {
+	CREATE, UPDATE, DELETE
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEvent.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEvent.java
@@ -1,0 +1,28 @@
+package com.sofa.linkiving.domain.link.event;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.Summary;
+import com.sofa.linkiving.domain.link.enums.SyncAction;
+
+public record LinkSyncEvent(
+	LinkSyncUpdateReq req,
+	SyncAction action
+) {
+	public static LinkSyncEvent deleteEvent(Long linkId) {
+		LinkSyncUpdateReq req = LinkSyncUpdateReq.builder()
+			.linkId(linkId)
+			.build();
+		return new LinkSyncEvent(req, SyncAction.DELETE);
+	}
+
+	public static LinkSyncEvent createEvent(Link link) {
+		LinkSyncUpdateReq req = LinkSyncUpdateReq.from(link);
+		return new LinkSyncEvent(req, SyncAction.CREATE);
+	}
+
+	public static LinkSyncEvent updateEvent(Link link, Summary summary) {
+		LinkSyncUpdateReq req = LinkSyncUpdateReq.of(link, summary);
+		return new LinkSyncEvent(req, SyncAction.UPDATE);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
@@ -1,0 +1,45 @@
+package com.sofa.linkiving.domain.link.event;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.sofa.linkiving.domain.link.ai.LinkSyncClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LinkSyncEventListener {
+
+	private final LinkSyncClient linkSyncClient;
+
+	@Async
+	@Retryable(
+		retryFor = Exception.class,
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 1000, multiplier = 2)
+	)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleLinkSyncEvent(LinkSyncEvent event) {
+		log.info("AI 서버 동기화 비동기 실행 시도 - action: {}, linkId: {}", event.action(), event.req().linkId());
+
+		switch (event.action()) {
+			case CREATE -> linkSyncClient.syncCreate(event.req());
+			case UPDATE -> linkSyncClient.syncUpdate(event.req());
+			case DELETE -> linkSyncClient.syncDelete(event.req().linkId());
+		}
+	}
+
+	@Recover
+	public void recover(Exception exception, LinkSyncEvent event) {
+		log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
+			event.action(), event.req().linkId(), exception);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -21,6 +21,7 @@ import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.link.event.LinkCreatedEvent;
+import com.sofa.linkiving.domain.link.event.LinkSyncEvent;
 import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
@@ -45,6 +46,7 @@ public class LinkFacade {
 		Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 
 		eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail()));
+		eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
 
 		return LinkRes.from(link);
 	}
@@ -55,21 +57,28 @@ public class LinkFacade {
 			storedImageUrl = imageUploader.uploadFromUrl(imageUrl);
 		}
 		Link link = linkService.updateLink(linkId, member, title, memo, storedImageUrl);
+		Summary summary = summaryService.getSummaryOrElseNull(linkId);
+		eventPublisher.publishEvent(LinkSyncEvent.updateEvent(link, summary));
 		return LinkRes.from(link);
 	}
 
 	public LinkRes updateTitle(Long linkId, Member member, String title) {
 		Link link = linkService.updateTitle(linkId, member, title);
+		Summary summary = summaryService.getSummaryOrElseNull(linkId);
+		eventPublisher.publishEvent(LinkSyncEvent.updateEvent(link, summary));
 		return LinkRes.from(link);
 	}
 
 	public LinkRes updateMemo(Long linkId, Member member, String memo) {
 		Link link = linkService.updateMemo(linkId, member, memo);
+		Summary summary = summaryService.getSummaryOrElseNull(linkId);
+		eventPublisher.publishEvent(LinkSyncEvent.updateEvent(link, summary));
 		return LinkRes.from(link);
 	}
 
 	public void deleteLink(Long linkId, Member member) {
 		linkService.deleteLink(linkId, member);
+		eventPublisher.publishEvent(LinkSyncEvent.deleteEvent(linkId));
 	}
 
 	@Transactional(readOnly = true)
@@ -94,7 +103,6 @@ public class LinkFacade {
 	@Transactional(readOnly = true)
 	public RegenerateSummaryRes recreateSummary(Member member, Long linkId, Format format) {
 		Link link = linkService.getLinkForSummaryUpdate(linkId, member);
-
 		String url = link.getUrl();
 		String existingSummary = summaryService.getSummary(linkId).getContent();
 
@@ -124,7 +132,6 @@ public class LinkFacade {
 
 	public SummaryRes updateSummary(Long id, Member member, String content, Format format) {
 		Link link = linkService.getLinkForSummaryUpdate(id, member);
-
 		Summary summary = summaryService.createSummary(link, format, content);
 		summaryService.selectSummary(link.getId(), summary.getId());
 		return SummaryRes.from(summary);

--- a/src/main/java/com/sofa/linkiving/domain/link/service/SummaryQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/SummaryQueryService.java
@@ -26,6 +26,10 @@ public class SummaryQueryService {
 		);
 	}
 
+	public Summary getSummaryOrElseNull(Long linkId) {
+		return summaryRepository.findByLinkIdAndSelectedTrue(linkId).orElse(null);
+	}
+
 	public Map<Long, Summary> getSelectedSummariesByLinks(List<Link> links) {
 		if (links.isEmpty()) {
 			return Collections.emptyMap();

--- a/src/main/java/com/sofa/linkiving/domain/link/service/SummaryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/SummaryService.java
@@ -18,6 +18,10 @@ public class SummaryService {
 		return summaryQueryService.getSummary(linkId);
 	}
 
+	public Summary getSummaryOrElseNull(Long linkId) {
+		return summaryQueryService.getSummaryOrElseNull(linkId);
+	}
+
 	public Summary createSummary(Link link, Format format, String summary) {
 		return summaryCommandService.save(link, format, summary);
 	}

--- a/src/test/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClientTest.java
@@ -1,0 +1,48 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+@DisplayName("MockLinkSyncClient 단위 테스트")
+class MockLinkSyncClientTest {
+
+	private final MockLinkSyncClient mockLinkSyncClient = new MockLinkSyncClient();
+
+	@Test
+	@DisplayName("syncCreate 호출 시 아무 작업도 수행하지 않고 정상 종료된다")
+	void shouldNotThrowExceptionOnSyncCreate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+
+		// when & then
+		assertThatCode(() -> mockLinkSyncClient.syncCreate(req))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("syncUpdate 호출 시 아무 작업도 수행하지 않고 정상 종료된다")
+	void shouldNotThrowExceptionOnSyncUpdate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+
+		// when & then
+		assertThatCode(() -> mockLinkSyncClient.syncUpdate(req))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("syncDelete 호출 시 아무 작업도 수행하지 않고 정상 종료된다")
+	void shouldNotThrowExceptionOnSyncDelete() {
+		// given
+		Long linkId = 1L;
+
+		// when & then
+		assertThatCode(() -> mockLinkSyncClient.syncDelete(linkId))
+			.doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClientTest.java
@@ -1,0 +1,69 @@
+package com.sofa.linkiving.domain.link.ai;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncDeleteReq;
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LinkSyncClient 단위 테스트")
+class RagLinkSyncClientTest {
+
+	@InjectMocks
+	private RagLinkSyncClient ragLinkSyncClient;
+
+	@Mock
+	private LinkSyncFeign linkSyncFeign;
+
+	@Test
+	@DisplayName("CREATE 동기화 시 Feign Client의 syncUpdate를 호출한다")
+	void shouldCallSyncUpdateOnCreate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+
+		// when
+		ragLinkSyncClient.syncCreate(req);
+
+		// then
+		verify(linkSyncFeign, times(1)).syncUpdate(req);
+	}
+
+	@Test
+	@DisplayName("UPDATE 동기화 시 Feign Client의 syncUpdate를 호출한다")
+	void shouldCallSyncUpdateOnUpdate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+
+		// when
+		ragLinkSyncClient.syncUpdate(req);
+
+		// then
+		verify(linkSyncFeign, times(1)).syncUpdate(req);
+	}
+
+	@Test
+	@DisplayName("DELETE 동기화 시 LinkSyncDeleteReq를 생성하여 Feign Client의 syncDelete를 호출한다")
+	void shouldCallSyncDeleteOnDelete() {
+		// given
+		Long linkId = 10L;
+
+		// when
+		ragLinkSyncClient.syncDelete(linkId);
+
+		// then
+		ArgumentCaptor<LinkSyncDeleteReq> captor = ArgumentCaptor.forClass(LinkSyncDeleteReq.class);
+		verify(linkSyncFeign, times(1)).syncDelete(captor.capture());
+
+		LinkSyncDeleteReq capturedReq = captor.getValue();
+		assertThat(capturedReq.linkId()).isEqualTo(linkId);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListenerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListenerTest.java
@@ -1,0 +1,137 @@
+package com.sofa.linkiving.domain.link.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sofa.linkiving.domain.link.ai.RagLinkSyncClient;
+import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+import com.sofa.linkiving.domain.link.enums.SyncAction;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = LinkSyncEventListenerTest.RetryTestConfig.class)
+@DisplayName("LinkSyncEventListener 재시도(Retry) 및 복구(Recover) 단위 테스트")
+class LinkSyncEventListenerTest {
+
+	@Autowired
+	private LinkSyncEventListener linkSyncEventListener;
+
+	@Autowired
+	private RagLinkSyncClient linkSyncClient;
+
+	@BeforeEach
+	void setUp() {
+		reset(linkSyncClient);
+	}
+
+	@Test
+	@DisplayName("CREATE 액션 이벤트 수신 시 syncCreate를 호출한다")
+	void shouldCallSyncCreate_WhenActionIsCreate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+		LinkSyncEvent event = new LinkSyncEvent(req, SyncAction.CREATE);
+
+		// when
+		linkSyncEventListener.handleLinkSyncEvent(event);
+
+		// then
+		verify(linkSyncClient, times(1)).syncCreate(req);
+	}
+
+	@Test
+	@DisplayName("UPDATE 액션 이벤트 수신 시 syncUpdate를 호출한다")
+	void shouldCallSyncUpdate_WhenActionIsUpdate() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+		LinkSyncEvent event = new LinkSyncEvent(req, SyncAction.UPDATE);
+
+		// when
+		linkSyncEventListener.handleLinkSyncEvent(event);
+
+		// then
+		verify(linkSyncClient, times(1)).syncUpdate(req);
+	}
+
+	@Test
+	@DisplayName("DELETE 액션 이벤트 수신 시 syncDelete를 호출한다")
+	void shouldCallSyncDelete_WhenActionIsDelete() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+		when(req.linkId()).thenReturn(1L);
+		LinkSyncEvent event = new LinkSyncEvent(req, SyncAction.DELETE);
+
+		// when
+		linkSyncEventListener.handleLinkSyncEvent(event);
+
+		// then
+		verify(linkSyncClient, times(1)).syncDelete(1L);
+	}
+
+	@Test
+	@DisplayName("동기화 실패 시 설정된 횟수(최대 3번)만큼 재시도한다")
+	void shouldRetryUpTo3Times_WhenFails() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+		LinkSyncEvent event = new LinkSyncEvent(req, SyncAction.CREATE);
+
+		doThrow(new RuntimeException("AI Server Error")).when(linkSyncClient).syncCreate(any());
+
+		// when
+		assertThatCode(() -> linkSyncEventListener.handleLinkSyncEvent(event))
+			.doesNotThrowAnyException();
+
+		// then
+		verify(linkSyncClient, times(3)).syncCreate(req);
+	}
+
+	@Test
+	@DisplayName("3번 내에 성공하면 정상 종료된다 (2번 실패 후 3번째 성공)")
+	void shouldNotThrowError_WhenSucceedsWithin3Times() {
+		// given
+		LinkSyncUpdateReq req = mock(LinkSyncUpdateReq.class);
+		LinkSyncEvent event = new LinkSyncEvent(req, SyncAction.UPDATE);
+
+		doThrow(new RuntimeException("AI Server Error"))
+			.doThrow(new RuntimeException("AI Server Error"))
+			.doNothing()
+			.when(linkSyncClient).syncUpdate(any());
+
+		// when & then
+		assertThatCode(() -> linkSyncEventListener.handleLinkSyncEvent(event))
+			.doesNotThrowAnyException();
+
+		verify(linkSyncClient, times(3)).syncUpdate(req);
+	}
+
+	/**
+	 * 스프링의 @Retryable 동작을 테스트하기 위한 설정 클래스.
+	 * @Async를 비활성화하여 테스트 메서드 내에서 동기적으로 재시도 로직을 검증.
+	 */
+	@Configuration
+	@EnableRetry
+	@EnableAspectJAutoProxy(proxyTargetClass = true)
+	static class RetryTestConfig {
+
+		@Bean
+		public RagLinkSyncClient linkSyncClient() {
+			return mock(RagLinkSyncClient.class);
+		}
+
+		@Bean
+		public LinkSyncEventListener linkSyncEventListener(RagLinkSyncClient linkSyncClient) {
+			return new LinkSyncEventListener(linkSyncClient);
+		}
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -34,6 +34,7 @@ import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.event.LinkCreatedEvent;
+import com.sofa.linkiving.domain.link.event.LinkSyncEvent;
 import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
@@ -42,7 +43,7 @@ import com.sofa.linkiving.global.error.exception.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LinkFacade 단위 테스트")
-public class LinkFacadeTest {
+class LinkFacadeTest {
 
 	@InjectMocks
 	private LinkFacade linkFacade;
@@ -100,6 +101,27 @@ public class LinkFacadeTest {
 		assertThat(result.url()).isEqualTo(url);
 		verify(ogTagCrawler, times(1)).crawl(url);
 		verify(imageUploader, times(1)).uploadFromUrl(originalImageUrl);
+	}
+
+	@Test
+	@DisplayName("메타데이터 크롤링 실패 시 빈 값으로 MetaScrapeRes를 반환한다")
+	void shouldReturnEmptyMetaScrapeResWhenCrawlFails() {
+		// given
+		String url = "https://invalid-url.com";
+		given(ogTagCrawler.crawl(url)).willReturn(OgTagDto.EMPTY);
+
+		// when
+		MetaScrapeRes result = linkFacade.scrapeMetadata(url);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.title()).isEmpty();
+		assertThat(result.description()).isEmpty();
+		assertThat(result.image()).isEmpty();
+		assertThat(result.url()).isEmpty();
+		verify(ogTagCrawler, times(1)).crawl(url);
+		verify(imageUploader, never()).uploadFromUrl(any());
+		verify(imageUploader, never()).resolveStoredUrl(any());
 	}
 
 	@Test
@@ -175,31 +197,9 @@ public class LinkFacadeTest {
 		assertThat(result.id()).isEqualTo(summaryId);
 		assertThat(result.content()).isEqualTo(content);
 
-		// 호출 순서 및 횟수 검증 (검증 대상도 getLinkForSummaryUpdate 로 변경)
 		verify(linkService, times(1)).getLinkForSummaryUpdate(linkId, member);
 		verify(summaryService, times(1)).createSummary(link, format, content);
 		verify(summaryService, times(1)).selectSummary(linkId, summaryId);
-	}
-
-	@Test
-	@DisplayName("메타데이터 크롤링 실패 시 빈 값으로 MetaScrapeRes를 반환한다")
-	void shouldReturnEmptyMetaScrapeResWhenCrawlFails() {
-		// given
-		String url = "https://invalid-url.com";
-		given(ogTagCrawler.crawl(url)).willReturn(OgTagDto.EMPTY);
-
-		// when
-		MetaScrapeRes result = linkFacade.scrapeMetadata(url);
-
-		// then
-		assertThat(result).isNotNull();
-		assertThat(result.title()).isEmpty();
-		assertThat(result.description()).isEmpty();
-		assertThat(result.image()).isEmpty();
-		assertThat(result.url()).isEmpty();
-		verify(ogTagCrawler, times(1)).crawl(url);
-		verify(imageUploader, never()).uploadFromUrl(any());
-		verify(imageUploader, never()).resolveStoredUrl(any());
 	}
 
 	@Test
@@ -272,7 +272,7 @@ public class LinkFacadeTest {
 	}
 
 	@Test
-	@DisplayName("링크를 수정하고 LinkRes을 반환한다")
+	@DisplayName("링크를 수정하고 LinkSyncEvent를 발행한다")
 	void shouldUpdateLink() {
 		// given
 		Long linkId = 1L;
@@ -287,9 +287,11 @@ public class LinkFacadeTest {
 			.memo("메모수정")
 			.build();
 		ReflectionTestUtils.setField(updatedLink, "id", linkId);
+		Summary mockSummary = mock(Summary.class);
 
 		given(imageUploader.uploadFromUrl("https://example.com")).willReturn("https://example.com");
 		given(linkService.updateLink(linkId, member, "수정", "메모수정", "https://example.com")).willReturn(updatedLink);
+		given(summaryService.getSummaryOrElseNull(1L)).willReturn(mockSummary);
 
 		// when
 		LinkRes result = linkFacade.updateLink(linkId, member, "수정", "메모수정", "https://example.com");
@@ -299,10 +301,12 @@ public class LinkFacadeTest {
 		assertThat(result.title()).isEqualTo("수정");
 		assertThat(result.memo()).isEqualTo("메모수정");
 		verify(linkService, times(1)).updateLink(linkId, member, "수정", "메모수정", "https://example.com");
+		verify(summaryService).getSummaryOrElseNull(1L);
+		verify(eventPublisher).publishEvent(any(LinkSyncEvent.class));
 	}
 
 	@Test
-	@DisplayName("링크 제목만 수정할 수 있다")
+	@DisplayName("링크 제목을 수정하고 LinkSyncEvent를 발행한다")
 	void shouldUpdateTitle() {
 		// given
 		Long linkId = 1L;
@@ -325,10 +329,11 @@ public class LinkFacadeTest {
 		// then
 		assertThat(result.title()).isEqualTo("수정");
 		verify(linkService, times(1)).updateTitle(linkId, member, "수정");
+		verify(eventPublisher).publishEvent(any(LinkSyncEvent.class));
 	}
 
 	@Test
-	@DisplayName("링크 메모만 수정할 수 있다")
+	@DisplayName("링크 메모를 수정하고 LinkSyncEvent를 발행한다")
 	void shouldUpdateMemo() {
 		// given
 		Long linkId = 1L;
@@ -342,8 +347,10 @@ public class LinkFacadeTest {
 			.memo("수정")
 			.build();
 		ReflectionTestUtils.setField(updatedLink, "id", linkId);
+		Summary mockSummary = mock(Summary.class);
 
 		given(linkService.updateMemo(linkId, member, "수정")).willReturn(updatedLink);
+		given(summaryService.getSummaryOrElseNull(1L)).willReturn(mockSummary);
 
 		// when
 		LinkRes result = linkFacade.updateMemo(linkId, member, "수정");
@@ -351,10 +358,12 @@ public class LinkFacadeTest {
 		// then
 		assertThat(result.memo()).isEqualTo("수정");
 		verify(linkService, times(1)).updateMemo(linkId, member, "수정");
+		verify(summaryService).getSummaryOrElseNull(1L);
+		verify(eventPublisher).publishEvent(any(LinkSyncEvent.class));
 	}
 
 	@Test
-	@DisplayName("링크를 삭제할 수 있다")
+	@DisplayName("링크를 삭제하고 LinkSyncEvent(DELETE)를 발행한다")
 	void shouldDeleteLink() {
 		// given
 		Long linkId = 1L;
@@ -367,10 +376,11 @@ public class LinkFacadeTest {
 
 		// then
 		verify(linkService, times(1)).deleteLink(linkId, member);
+		verify(eventPublisher).publishEvent(any(LinkSyncEvent.class));
 	}
 
 	@Test
-	@DisplayName("단일 링크 상세 정보를 조회하고 LinkDetailRes로 변환한 후 반환한다")
+	@DisplayName("단일 링크 상세 조회를 수행한다")
 	void shouldGetLinkDetail() {
 		// given
 		Long linkId = 1L;
@@ -405,7 +415,7 @@ public class LinkFacadeTest {
 	}
 
 	@Test
-	@DisplayName("링크 카드 목록을 조회하고 Response DTO로 변환한다 (페이징 포함)")
+	@DisplayName("페이징된 링크 카드 목록을 조회한다")
 	void shouldGetLinkCards() {
 		// given
 		Member member = mock(Member.class);

--- a/src/test/java/com/sofa/linkiving/domain/link/service/SummaryQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/SummaryQueryServiceTest.java
@@ -105,4 +105,37 @@ public class SummaryQueryServiceTest {
 		assertThat(result.get(1L)).isEqualTo(summary1);
 		assertThat(result.get(2L)).isEqualTo(summary2);
 	}
+
+	@Test
+	@DisplayName("선택된 요약이 존재하면 해당 요약을 반환한다")
+	void shouldReturnExistingSummaryWhenSummaryExists() {
+		// given
+		Long linkId = 1L;
+		Summary expectedSummary = mock(Summary.class);
+		given(summaryRepository.findByLinkIdAndSelectedTrue(linkId))
+			.willReturn(Optional.of(expectedSummary));
+
+		// when
+		Summary result = summaryQueryService.getSummaryOrElseNull(linkId);
+
+		// then
+		assertThat(result).isEqualTo(expectedSummary);
+		verify(summaryRepository, times(1)).findByLinkIdAndSelectedTrue(linkId);
+	}
+
+	@Test
+	@DisplayName("선택된 요약이 없으면 null을 반환한다")
+	void shouldReturnDefaultSummaryWhenSummaryDoesNotExist() {
+		// given
+		Long linkId = 1L;
+		given(summaryRepository.findByLinkIdAndSelectedTrue(linkId))
+			.willReturn(Optional.empty());
+
+		// when
+		Summary result = summaryQueryService.getSummaryOrElseNull(linkId);
+
+		// then
+		assertThat(result).isNull();
+		verify(summaryRepository, times(1)).findByLinkIdAndSelectedTrue(linkId);
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/SummaryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/SummaryServiceTest.java
@@ -81,7 +81,7 @@ public class SummaryServiceTest {
 
 	@Test
 	@DisplayName("Format.CONCISE 형태로 초기 요약을 생성하고 저장한다")
-	void shouldCreateInitialSummaryAndUpdateStatusWithConciseFormat() {
+	void shouldCreateInitialSummaryWithConciseFormat() {
 		// given
 		Link link = mock(Link.class);
 		String content = "테스트 초기 요약 내용";
@@ -95,5 +95,21 @@ public class SummaryServiceTest {
 		// then
 		assertThat(actualSummary).isEqualTo(expectedSummary);
 		verify(summaryCommandService, times(1)).initialSave(link, Format.CONCISE, content);
+	}
+
+	@Test
+	@DisplayName("QueryService에 조회를 위임하고 결과를 반환한다")
+	void shouldDelegateToQueryServiceForSummaryOrElseDefault() {
+		// given
+		Long linkId = 1L;
+		Summary expectedSummary = mock(Summary.class);
+		given(summaryQueryService.getSummaryOrElseNull(linkId)).willReturn(expectedSummary);
+
+		// when
+		Summary result = summaryService.getSummaryOrElseNull(linkId);
+
+		// then
+		assertThat(result).isEqualTo(expectedSummary);
+		verify(summaryQueryService, times(1)).getSummaryOrElseNull(linkId);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #189 

### PR 설명
* 사용자가 링크를 추가, 수정, 삭제할 때 해당 변경사항을 AI 서버(RAG 컨텍스트)에 동기화하는 이벤트 기반 파이프라인을 구축함.
* 메인 비즈니스 로직의 응답 속도 및 트랜잭션 안정성에 영향을 주지 않도록 비동기(`@Async`) 및 `AFTER_COMMIT` 단계에서의 실행을 적용함.

### 작업 내용
#### 비즈니스 로직 및 이벤트 연동
* `LinkFacade`: 링크 생성(`createLink`), 수정(`updateLink`, `updateTitle`, `updateMemo`), 삭제(`deleteLink`) 수행 완료 시 `ApplicationEventPublisher`를 통해 `LinkSyncEvent` 발행 로직 추가함.
* `SummaryQueryService`, `SummaryService`: 동기화 페이로드에 포함될 요약 데이터를 예외 없이 안전하게 조회하기 위해 `getSummaryOrElseNull` 메서드 신규 추가함.
* `LinkSyncEventListener`: 
  * `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`를 적용하여 메인 DB 트랜잭션이 성공적으로 커밋된 이후에만 동기화 이벤트가 동작하도록 구현함.
  * `@Async`를 통해 별도 스레드에서 외부 API 통신을 수행하도록 분리함.

#### DTO 및 Event 정의
* 동기화 요청 데이터를 담는 `LinkSyncUpdateReq`(추가/수정용), `LinkSyncDeleteReq`(삭제용) DTO 정의함.
* 액션 타입(`CREATE`, `UPDATE`, `DELETE`)과 페이로드를 캡슐화한 `LinkSyncEvent` 레코드 생성함.

#### 예외 처리 (Fallback & Retry)
* `@Retryable`: AI 서버 통신 일시 장애에 대비하여 최대 3회 재시도 및 백오프(지연 시간 2배씩 증가) 로직 적용함.
* `@Recover`: 최종 동기화 실패 시 메인 트랜잭션에 영향을 주지 않고(Soft Fail), 수동 복구를 위한 에러 로그(`[CRITICAL]`)를 명확히 남기도록 구현함.

