### PR TITLE
단일 링크 요약 상태 조회 API 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -17,6 +17,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
+import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
@@ -143,6 +144,12 @@ public interface LinkApi {
 	BaseResponse<SummaryRes> updateSummary(
 		Long id,
 		@Valid SummaryUpdateReq request,
+		Member member
+	);
+
+	@Operation(summary = "요약 상태 조회", description = "링크 요약 상태를 조회합니다.")
+	BaseResponse<SummaryStatusRes> getSummaryStatus(
+		Long id,
 		Member member
 	);
 

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -39,9 +39,7 @@ import jakarta.validation.constraints.Min;
 				```json
 				{
 					"linkId": 1,
-					"status": "PROCESSING",
-					"summary": null,
-					"errorMessage": null
+					"status": "PROCESSING"
 				}
 				```
 
@@ -50,12 +48,11 @@ import jakarta.validation.constraints.Min;
 				{
 					"linkId": 1,
 					"status": "COMPLETED",
-					"summary": {
+					"data": {
 						"id": 100,
 						"content": "생성된 AI 요약 내용입니다.",
 						"format": "CONCISE"
-					},
-					"errorMessage": null
+					}
 				}
 				```
 		**CASE C: FAILED (요약 실패)**
@@ -63,8 +60,7 @@ import jakarta.validation.constraints.Min;
 				{
 					"linkId": 1,
 					"status": "FAILED",
-					"summary": null,
-					"errorMessage": "AI 서버 응답이 없습니다."
+					"data": "AI 서버 응답이 없습니다."
 				}
 				```
 		**흐름**: 링크 생성/재요약 API 호출 시 PENDING 상태 부여 -> 큐 진입 시 PROCESSING 알림 -> 완료 시 COMPLETED(데이터 포함) 알림

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -26,6 +26,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
+import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.facade.LinkFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
@@ -183,5 +184,15 @@ public class LinkController implements LinkApi {
 	) {
 		linkFacade.retrySummary(id, member);
 		return BaseResponse.noContent("요약 재시도");
+	}
+
+	@Override
+	@GetMapping("/{id}/summary-status")
+	public BaseResponse<SummaryStatusRes> getSummaryStatus(
+		@PathVariable Long id,
+		@AuthMember Member member
+	) {
+		SummaryStatusRes response = linkFacade.getSummaryStatus(id, member);
+		return BaseResponse.success(response, "요약 상태 조회 완료");
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
@@ -6,33 +6,35 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record SummaryStatusRes(
+public record SummaryStatusRes<T>(
 	@Schema(description = "링크 ID")
 	Long linkId,
 	@Schema(description = "요약 진행 상태:PENDING(큐 대기 중), PROCESSING(요약 진행 중), COMPLETED(완료), FAILED(생성 실패)")
 	SummaryStatus status,
-	@Schema(description = "요약 정보(COMPLETED 상태일 때만 존재)")
-	SummaryRes summary,
-	@Schema(description = "애러 메세지(FAILED 상태일 때만 존재)")
-	String errorMessage
+	@Schema(description = "결과 데이터 (COMPLETED 상태일 때는 SummaryRes 객체, FAILED 상태일 때는 String 에러 메세지, 그 외는 null)")
+	T data
 ) {
-	public static SummaryStatusRes of(Long linkId, SummaryStatus status) {
-		return SummaryStatusRes.builder().linkId(linkId).status(status).build();
-	}
-
-	public static SummaryStatusRes completed(Long linkId, SummaryRes summary) {
-		return SummaryStatusRes.builder()
+	public static SummaryStatusRes<Void> of(Long linkId, SummaryStatus status) {
+		return SummaryStatusRes.<Void>builder()
 			.linkId(linkId)
-			.status(SummaryStatus.COMPLETED)
-			.summary(summary)
+			.status(status)
+			.data(null)
 			.build();
 	}
 
-	public static SummaryStatusRes failed(Long linkId, String errorMessage) {
-		return SummaryStatusRes.builder()
+	public static SummaryStatusRes<SummaryRes> completed(Long linkId, SummaryRes summary) {
+		return SummaryStatusRes.<SummaryRes>builder()
+			.linkId(linkId)
+			.status(SummaryStatus.COMPLETED)
+			.data(summary)
+			.build();
+	}
+
+	public static SummaryStatusRes<String> failed(Long linkId, String errorMessage) {
+		return SummaryStatusRes.<String>builder()
 			.linkId(linkId)
 			.status(SummaryStatus.FAILED)
-			.errorMessage(errorMessage)
+			.data(errorMessage)
 			.build();
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/error/LinkErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/error/LinkErrorCode.java
@@ -16,7 +16,7 @@ public enum LinkErrorCode implements ErrorCode {
 	INVALID_URL(HttpStatus.BAD_REQUEST, "L-003", "유효하지 않은 URL 형식입니다."),
 	INVALID_URL_PROTOCOL(HttpStatus.BAD_REQUEST, "L-004", "허용되지 않은 프로토콜입니다. http 또는 https만 사용 가능합니다."),
 	INVALID_URL_PRIVATE_IP(HttpStatus.BAD_REQUEST, "L-005", "내부 네트워크 주소는 접근할 수 없습니다."),
-	INVALID_SUMMARY_STATUS_FOR_RETRY(HttpStatus.CONFLICT, "L-007", "요약 재시도는 요약 실패 상태에서만 가능합니다.");
+	INVALID_SUMMARY_STATUS_FOR_RETRY(HttpStatus.CONFLICT, "L-006", "요약 재시도는 요약 실패 상태에서만 가능합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -18,9 +18,11 @@ import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
+import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.LinkCreatedEvent;
 import com.sofa.linkiving.domain.link.event.LinkSyncEvent;
 import com.sofa.linkiving.domain.link.service.LinkService;
@@ -104,6 +106,7 @@ public class LinkFacade {
 	@Transactional(readOnly = true)
 	public RegenerateSummaryRes recreateSummary(Member member, Long linkId, Format format) {
 		Link link = linkService.getLinkForSummaryUpdate(linkId, member);
+
 		String url = link.getUrl();
 		String existingSummary = summaryService.getSummary(linkId).getContent();
 
@@ -153,5 +156,11 @@ public class LinkFacade {
 	public void retrySummary(Long id, Member member) {
 		linkService.resetSummaryStatusForRetry(id, member);
 		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getEmail()));
+	}
+
+	@Transactional(readOnly = true)
+	public SummaryStatusRes getSummaryStatus(Long id, Member member) {
+		SummaryStatus summaryStatus = linkService.getSummaryStatus(id, member);
+		return SummaryStatusRes.of(id, summaryStatus);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -96,9 +96,6 @@ public class LinkService {
 
 	public SummaryStatus getSummaryStatus(Long linkId, Member member) {
 		Link link = getLink(linkId, member);
-		if (link.getSummaryStatus() == null) {
-			throw new BusinessException(LinkErrorCode.SUMMARY_STATUS_MISSING);
-		}
 		return link.getSummaryStatus();
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -94,6 +94,14 @@ public class LinkService {
 		return link;
 	}
 
+	public SummaryStatus getSummaryStatus(Long linkId, Member member) {
+		Link link = getLink(linkId, member);
+		if (link.getSummaryStatus() == null) {
+			throw new BusinessException(LinkErrorCode.SUMMARY_STATUS_MISSING);
+		}
+		return link.getSummaryStatus();
+	}
+
 	public Long getLinkTotalCount(Member member) {
 		return linkQueryService.countByMemberAndIsDeleteFalse(member);
 	}

--- a/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
@@ -135,7 +135,7 @@ class LinkEventListenerTest {
 		// 두 번째 이벤트 (FAILED)
 		assertThat(publishedEvents.get(1).email()).isEqualTo("fail@test.com");
 		assertThat(publishedEvents.get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(publishedEvents.get(1).response().errorMessage()).isEqualTo("요약 대기열 등록에 실패했습니다.");
+		assertThat(publishedEvents.get(1).response().data()).isEqualTo("요약 대기열 등록에 실패했습니다.");
 
 		// Facade를 통한 DB 상태 업데이트가 호출되었는지 검증
 		verify(summaryWorkerFacade, times(1)).updateSummaryStatus(2L, SummaryStatus.FAILED);

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -30,9 +30,11 @@ import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
+import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.error.LinkErrorCode;
 import com.sofa.linkiving.domain.link.event.LinkCreatedEvent;
 import com.sofa.linkiving.domain.link.event.LinkSyncEvent;
@@ -553,5 +555,23 @@ class LinkFacadeTest {
 		// then
 		verify(linkService, times(1)).resetSummaryStatusForRetry(1L, member);
 		verify(eventPublisher, times(1)).publishEvent(any(LinkCreatedEvent.class));
+	}
+
+	@Test
+	@DisplayName("특정 링크의 요약 상태를 조회한다")
+	void shouldGetSummaryStatus() {
+		// given
+		Member member = mock(Member.class);
+		Long linkId = 123L;
+		given(linkService.getSummaryStatus(linkId, member)).willReturn(SummaryStatus.COMPLETED);
+
+		// when
+		SummaryStatusRes result = linkFacade.getSummaryStatus(linkId, member);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.linkId()).isEqualTo(linkId);
+		assertThat(result.status()).isEqualTo(SummaryStatus.COMPLETED);
+		verify(linkService, times(1)).getSummaryStatus(linkId, member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -760,6 +760,30 @@ public class LinkApiIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("요약 상태 조회 API 성공 시 200 OK와 상태 데이터를 반환한다")
+	void getSummaryStatus() throws Exception {
+		// given
+		Link link = Link.builder()
+			.member(testMember)
+			.url("https://example.com/article")
+			.title("테스트 링크")
+			.build();
+		link.updateSummaryStatus(SummaryStatus.COMPLETED);
+		Link savedlink = linkRepository.save(link);
+
+		// when & then
+		mockMvc.perform(get(BASE_URL + "/{id}/summary-status", savedlink.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf())
+				.with(user(testUserDetails))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.linkId").value(savedlink.getId()))
+			.andExpect(jsonPath("$.data.status").value(link.getSummaryStatus().toString()))
+			.andExpect(jsonPath("$.message").value("요약 상태 조회 완료"));
+	}
+
+	@Test
 	@DisplayName("전체 링크 개수 조회 API 성공 시 200 OK와 데이터(총 개수)를 반환한다")
 	void getLinkTotalCount() throws Exception {
 		// given

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -446,6 +446,22 @@ class LinkServiceTest {
 	}
 
 	@Test
+	@DisplayName("링크의 요약 상태를 정상적으로 조회한다")
+	void getSummaryStatus() {
+		// given
+		Member member = mock(Member.class);
+		Link mockLink = mock(Link.class);
+		given(linkQueryService.findById(1L, member)).willReturn(mockLink);
+		given(mockLink.getSummaryStatus()).willReturn(SummaryStatus.COMPLETED);
+
+		// when
+		SummaryStatus result = linkService.getSummaryStatus(1L, member);
+
+		// then
+		assertThat(result).isEqualTo(SummaryStatus.COMPLETED);
+	}
+
+	@Test
 	@DisplayName("요약 실패(FAILED) 상태인 링크의 상태를 PENDING으로 초기화한다")
 	void shouldRetrySummaryWhenSummaryStatusForRetry() {
 		// given

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -287,7 +287,10 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().errorMessage()).contains("Retry limit exceeded");
+		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
+			.extracting(data -> (String)data)
+			.asString()
+			.contains("Retry limit exceeded");
 	}
 
 	@Test
@@ -313,7 +316,10 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().errorMessage()).contains("Retry limit exceeded");
+		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
+			.extracting(data -> (String)data)
+			.asString()
+			.contains("Retry limit exceeded");
 	}
 
 	@Test
@@ -388,6 +394,9 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().errorMessage()).contains("Retry limit exceeded");
+		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
+			.extracting(data -> (String)data)
+			.asString()
+			.contains("Retry limit exceeded");
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #203

## PR 설명
### API 명세
* **Endpoint** : `GET /v1/links/{id}/summary-status`
* **Response**
    ```
        {
          "linkId": 105,
          "status": "PROCESSING",
          "summary": null,
          "errorMessage": null
        }
    ```

#### 비즈니스 로직
* `LinkFacade`: 컨트롤러의 요청을 받아 서비스 레이어에 위임하고, 반환된 도메인 상태를 응답 DTO(`SummaryStatusRes`)로 변환함.
* `LinkService`: 
  * 식별자(ID)와 사용자(`Member`) 정보를 기반으로 대상 링크의 소유권을 검증함.
  * 해당 링크 엔티티에서 `SummaryStatus` 필드만 가볍게 추출하여 반환함.
  * 상태값이 `null`일 경우를 대비해 `SUMMARY_STATUS_MISSING` 비즈니스 예외 처리 추가함.