### PR TITLE
최초 요약 생성 실패 시 수동 재요청 API 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -146,6 +146,12 @@ public interface LinkApi {
 		Member member
 	);
 
+	@Operation(summary = "최초 요약 수동 재요청", description = "최초 요약 생성에 실패했을 경우 수동으로 최초 요약을 재요청합니다.")
+	BaseResponse<Void> retrySummary(
+		Long id,
+		Member member
+	);
+
 	@Operation(summary = "링크 전체 개수 조회", description = "저장된 전체 링크 개수를 조회합니다.")
 	BaseResponse<LinkTotalCountRes> getLinkTotalCount(
 		Member member

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -174,4 +174,14 @@ public class LinkController implements LinkApi {
 		LinkTotalCountRes res = linkFacade.getLinkTotalCount(member);
 		return BaseResponse.success(res, "링크 전체 개수 조회 완료");
 	}
+
+	@Override
+	@PostMapping("/{id}/retry-summary")
+	public BaseResponse<Void> retrySummary(
+		@PathVariable Long id,
+		@AuthMember Member member
+	) {
+		linkFacade.retrySummary(id, member);
+		return BaseResponse.noContent("요약 재시도");
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/error/LinkErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/error/LinkErrorCode.java
@@ -15,7 +15,8 @@ public enum LinkErrorCode implements ErrorCode {
 	DUPLICATE_URL(HttpStatus.BAD_REQUEST, "L-002", "이미 저장된 URL입니다."),
 	INVALID_URL(HttpStatus.BAD_REQUEST, "L-003", "유효하지 않은 URL 형식입니다."),
 	INVALID_URL_PROTOCOL(HttpStatus.BAD_REQUEST, "L-004", "허용되지 않은 프로토콜입니다. http 또는 https만 사용 가능합니다."),
-	INVALID_URL_PRIVATE_IP(HttpStatus.BAD_REQUEST, "L-005", "내부 네트워크 주소는 접근할 수 없습니다.");
+	INVALID_URL_PRIVATE_IP(HttpStatus.BAD_REQUEST, "L-005", "내부 네트워크 주소는 접근할 수 없습니다."),
+	INVALID_SUMMARY_STATUS_FOR_RETRY(HttpStatus.CONFLICT, "L-007", "요약 재시도는 요약 실패 상태에서만 가능합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -149,4 +149,9 @@ public class LinkFacade {
 	public LinkTotalCountRes getLinkTotalCount(Member member) {
 		return new LinkTotalCountRes(linkService.getLinkTotalCount(member));
 	}
+
+	public void retrySummary(Long id, Member member) {
+		linkService.resetSummaryStatusForRetry(id, member);
+		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getEmail()));
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
@@ -5,11 +5,13 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.member.entity.Member;
 
 public interface LinkRepository extends JpaRepository<Link, Long> {
@@ -67,6 +69,19 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 	List<LinkDto> findAllByMemberAndIdInWithSummaryAndIsDeleteFalse(
 		@Param("linkIds") List<Long> linkIds,
 		@Param("member") Member member
+	);
+
+	@Modifying(clearAutomatically = true)
+	@Query("""
+		UPDATE Link l SET l.summaryStatus = :newStatus
+		WHERE l.id = :linkId AND l.member = :member
+		AND l.summaryStatus = :oldStatus AND l.isDelete = false
+		""")
+	int updateSummaryStatusAtomically(
+		@Param("linkId") Long linkId,
+		@Param("member") Member member,
+		@Param("oldStatus") SummaryStatus oldStatus,
+		@Param("newStatus") SummaryStatus newStatus
 	);
 
 	Long countByMemberAndIsDeleteFalse(Member member);

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkCommandService.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.repository.LinkRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 
@@ -26,5 +27,10 @@ public class LinkCommandService {
 
 	public void deleteLink(Link link) {
 		link.markDeleted();
+	}
+
+	public int resetSummaryStatusForRetry(Long linkId, Member member) {
+		return linkRepository.updateSummaryStatusAtomically(linkId, member, SummaryStatus.FAILED,
+			SummaryStatus.PENDING);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -106,4 +106,17 @@ public class LinkService {
 		Link link = linkQueryService.findById(linkId);
 		link.updateSummaryStatus(status);
 	}
+
+	public void resetSummaryStatusForRetry(Long linkId, Member member) {
+		int updatedRows = linkCommandService.resetSummaryStatusForRetry(linkId, member);
+
+		if (updatedRows == 1) {
+			return;
+		}
+
+		linkQueryService.findById(linkId, member);
+
+		throw new BusinessException(LinkErrorCode.INVALID_SUMMARY_STATUS_FOR_RETRY);
+
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -416,7 +416,7 @@ class LinkFacadeTest {
 	}
 
 	@Test
-	@DisplayName("링크 카드 목록을 조회한다 (페이징 포함)")
+	@DisplayName("페이징된 링크 카드 목록을 조회한다")
 	void shouldGetLinkCards() {
 		// given
 		Member member = mock(Member.class);
@@ -536,5 +536,22 @@ class LinkFacadeTest {
 		assertThat(result).isNotNull();
 		assertThat(result.totalCount()).isEqualTo(15L);
 		verify(linkService, times(1)).getLinkTotalCount(member);
+	}
+
+	@Test
+	@DisplayName("요약 실패 상태인 링크를 초기화하고 LinkCreatedEvent를 다시 발행하여 큐에 적재한다")
+	void shouldRetrySummary() {
+		// given
+		Member member = mock(Member.class);
+		given(member.getEmail()).willReturn("test@test.com");
+
+		doNothing().when(linkService).resetSummaryStatusForRetry(1L, member);
+
+		// when
+		linkFacade.retrySummary(1L, member);
+
+		// then
+		verify(linkService, times(1)).resetSummaryStatusForRetry(1L, member);
+		verify(eventPublisher, times(1)).publishEvent(any(LinkCreatedEvent.class));
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -803,4 +803,45 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.data.totalCount").value(5))
 			.andExpect(jsonPath("$.message").value("링크 전체 개수 조회 완료"));
 	}
+
+	@Test
+	@DisplayName("SummaryStatus가 Failed인 링크에 대해 최초 요약 수동 재요청 API 성공 시 200 OK를 반환한다")
+	void shouldRetrySummaryWhenSummaryStatusFailed() throws Exception {
+		Link savedLink = linkRepository.save(Link.builder()
+			.member(testMember)
+			.url("https://example.com/article")
+			.title("테스트 링크")
+			.build());
+		savedLink.updateSummaryStatus(SummaryStatus.FAILED);
+		Long linkId = savedLink.getId();
+
+		// when & then
+		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", linkId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf())
+				.with(user(testUserDetails))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("요약 재시도"));
+	}
+
+	@Test
+	@DisplayName("SummaryStatus가 Failed가 아닌 링크에 대해 최초 요약 수동 재요청 API 요청 409 Conflict를 반환한다")
+	void shouldRetrySummaryFailWhenSummaryStatusNotFailed() throws Exception {
+		Link savedLink = linkRepository.save(Link.builder()
+			.member(testMember)
+			.url("https://example.com/article")
+			.title("테스트 링크")
+			.build());
+		savedLink.updateSummaryStatus(SummaryStatus.COMPLETED);
+		Long linkId = savedLink.getId();
+
+		// when & then
+		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", linkId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf())
+				.with(user(testUserDetails))
+			)
+			.andExpect(status().isConflict());
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
@@ -18,6 +18,7 @@ import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.Format;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.member.entity.Member;
 
 import jakarta.persistence.EntityManager;
@@ -312,5 +313,90 @@ class LinkRepositoryTest {
 
 		// then
 		assertThat(count).isEqualTo(4L);
+	}
+
+	@Test
+	@DisplayName("기존 상태(oldStatus)가 일치할 때 요약 상태를 원자적으로 업데이트한다 (1 반환)")
+	void updateSummaryStatusAtomically_Success() {
+		// given
+		Link testLink = Link.builder()
+			.member(testMember)
+			.url("https://example.com")
+			.title("테스트 링크")
+			.build();
+		ReflectionTestUtils.setField(testLink, "summaryStatus", SummaryStatus.FAILED);
+		entityManager.persist(testLink);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		int updatedCount = linkRepository.updateSummaryStatusAtomically(
+			testLink.getId(),
+			testMember,
+			SummaryStatus.FAILED,
+			SummaryStatus.PENDING
+		);
+
+		// then
+		assertThat(updatedCount).isEqualTo(1);
+
+		Link updatedLink = linkRepository.findById(testLink.getId()).get();
+		assertThat(updatedLink.getSummaryStatus()).isEqualTo(SummaryStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("기존 상태(oldStatus)가 일치하지 않으면 상태를 업데이트하지 않는다 (0 반환)")
+	void updateSummaryStatusAtomically_Fail_WhenOldStatusMismatch() {
+		// given
+		Link testLink = Link.builder()
+			.member(testMember)
+			.url("https://example.com")
+			.title("테스트 링크")
+			.build();
+		ReflectionTestUtils.setField(testLink, "summaryStatus", SummaryStatus.COMPLETED);
+		entityManager.persist(testLink);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		int updatedCount = linkRepository.updateSummaryStatusAtomically(
+			testLink.getId(),
+			testMember,
+			SummaryStatus.FAILED,
+			SummaryStatus.PENDING
+		);
+
+		// then
+		assertThat(updatedCount).isEqualTo(0);
+
+		Link notUpdatedLink = linkRepository.findById(testLink.getId()).orElseThrow();
+		assertThat(notUpdatedLink.getSummaryStatus()).isEqualTo(SummaryStatus.COMPLETED);
+	}
+
+	@Test
+	@DisplayName("삭제된 링크(isDelete=true)인 경우 상태를 업데이트하지 않는다 (0 반환)")
+	void updateSummaryStatusAtomically_Fail_WhenLinkIsDeleted() {
+		// given
+		Link testLink = Link.builder()
+			.member(testMember)
+			.url("https://example.com")
+			.title("테스트 링크")
+			.build();
+		ReflectionTestUtils.setField(testLink, "summaryStatus", SummaryStatus.FAILED);
+		ReflectionTestUtils.setField(testLink, "isDelete", true);
+		entityManager.persist(testLink);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		int updatedCount = linkRepository.updateSummaryStatusAtomically(
+			testLink.getId(),
+			testMember,
+			SummaryStatus.FAILED,
+			SummaryStatus.PENDING
+		);
+
+		// then
+		assertThat(updatedCount).isEqualTo(0);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkCommandServiceTest.java
@@ -113,4 +113,27 @@ class LinkCommandServiceTest {
 		// then
 		assertThat(link.isDeleted()).isTrue();
 	}
+
+	@Test
+	@DisplayName("요약 실패 상태를 PENDING으로 원자적 업데이트 한다")
+	void shouldResetSummaryStatusForRetry() {
+		// given
+		Long linkId = 1L;
+		Member member = mock(Member.class);
+
+		given(linkRepository.updateSummaryStatusAtomically(
+			eq(linkId), eq(member), eq(com.sofa.linkiving.domain.link.enums.SummaryStatus.FAILED),
+			eq(com.sofa.linkiving.domain.link.enums.SummaryStatus.PENDING)
+		)).willReturn(1);
+
+		// when
+		int updatedCount = linkCommandService.resetSummaryStatusForRetry(linkId, member);
+
+		// then
+		assertThat(updatedCount).isEqualTo(1);
+		verify(linkRepository, times(1)).updateSummaryStatusAtomically(
+			linkId, member, com.sofa.linkiving.domain.link.enums.SummaryStatus.FAILED,
+			com.sofa.linkiving.domain.link.enums.SummaryStatus.PENDING
+		);
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -446,6 +446,22 @@ class LinkServiceTest {
 	}
 
 	@Test
+	@DisplayName("요약 실패(FAILED) 상태인 링크의 상태를 PENDING으로 초기화한다")
+	void shouldRetrySummaryWhenSummaryStatusForRetry() {
+		// given
+		Long linkId = 1L;
+		Member member = mock(Member.class);
+
+		given(linkCommandService.resetSummaryStatusForRetry(linkId, member)).willReturn(1);
+
+		// when & then
+		assertThatCode(() -> linkService.resetSummaryStatusForRetry(linkId, member))
+			.doesNotThrowAnyException();
+
+		verify(linkCommandService, times(1)).resetSummaryStatusForRetry(linkId, member);
+	}
+
+	@Test
 	@DisplayName("사용자의 전체 링크 개수를 조회한다")
 	void getLinkTotalCount() {
 		// given


### PR DESCRIPTION
## 관련 이슈

- close #205

## PR 설명
* **Endpoint**: `POST /v1/links/{id}/retry-summary`

#### 비즈니스 로직
* `LinkService`: 
  * `getLinkWithFailedSummary`: 대상 링크의 상태가 실제로 `FAILED`인지 검증하는 방어 로직 추가함. `FAILED`가 아닐 경우 예외(`INVALID_SUMMARY_STATUS_FOR_RETRY`)를 발생시켜 중복/잘못된 요청을 차단함.
  * `resetSummaryStatusForRetry`: 요약 재시도를 위해 링크의 `SummaryStatus`를 다시 대기 상태(`PENDING`)로 롤백함.
* `LinkFacade`: 상태 갱신 후, AI 요약 큐에 작업을 다시 적재하기 위해 `LinkCreatedEvent`를 재발행(Publish)하는 로직 적용함.