### PR TITLE
저장된 전체 링크 개수 조회 API 구현

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -13,6 +13,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
@@ -142,6 +143,11 @@ public interface LinkApi {
 	BaseResponse<SummaryRes> updateSummary(
 		Long id,
 		@Valid SummaryUpdateReq request,
+		Member member
+	);
+
+	@Operation(summary = "링크 전체 개수 조회", description = "저장된 전체 링크 개수를 조회합니다.")
+	BaseResponse<LinkTotalCountRes> getLinkTotalCount(
 		Member member
 	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -22,6 +22,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
@@ -165,5 +166,12 @@ public class LinkController implements LinkApi {
 	) {
 		SummaryRes response = linkFacade.updateSummary(id, member, request.summary(), request.format());
 		return BaseResponse.success(response, "요약 수정 완료");
+	}
+
+	@Override
+	@GetMapping("/count")
+	public BaseResponse<LinkTotalCountRes> getLinkTotalCount(@AuthMember Member member) {
+		LinkTotalCountRes res = linkFacade.getLinkTotalCount(member);
+		return BaseResponse.success(res, "링크 전체 개수 조회 완료");
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkTotalCountRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkTotalCountRes.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LinkTotalCountRes(
+	@Schema(description = "링크 전체 개수")
+	int totalCount
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkTotalCountRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkTotalCountRes.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LinkTotalCountRes(
 	@Schema(description = "링크 전체 개수")
-	int totalCount
+	Long totalCount
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/Link.java
@@ -9,8 +9,10 @@ import com.sofa.linkiving.global.error.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +21,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "link", indexes = {
+	@Index(name = "idx_link_member_is_delete", columnList = "member_id, is_delete")
+})
 public class Link extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -13,6 +13,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
@@ -142,5 +143,10 @@ public class LinkFacade {
 			return null;
 		}
 		return imageUploader.uploadFromUrl(imageUrl);
+	}
+
+	@Transactional(readOnly = true)
+	public LinkTotalCountRes getLinkTotalCount(Member member) {
+		return new LinkTotalCountRes(linkService.getLinkTotalCount(member));
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
@@ -69,5 +69,5 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 		@Param("member") Member member
 	);
 
-	int countByMemberAndIsDeleteFalse(Member member);
+	Long countByMemberAndIsDeleteFalse(Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/LinkRepository.java
@@ -68,4 +68,6 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 		@Param("linkIds") List<Long> linkIds,
 		@Param("member") Member member
 	);
+
+	int countByMemberAndIsDeleteFalse(Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
@@ -71,4 +71,8 @@ public class LinkQueryService {
 	public Optional<Long> findIdByUrl(Member member, String url) {
 		return linkRepository.findIdByMemberAndUrlAndIsDeleteFalse(member, url);
 	}
+
+	public int countByMemberAndIsDeleteFalse(Member member) {
+		return linkRepository.countByMemberAndIsDeleteFalse(member);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkQueryService.java
@@ -72,7 +72,7 @@ public class LinkQueryService {
 		return linkRepository.findIdByMemberAndUrlAndIsDeleteFalse(member, url);
 	}
 
-	public int countByMemberAndIsDeleteFalse(Member member) {
+	public Long countByMemberAndIsDeleteFalse(Member member) {
 		return linkRepository.countByMemberAndIsDeleteFalse(member);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -94,6 +94,10 @@ public class LinkService {
 		return link;
 	}
 
+	public int getLinkTotalCount(Member member) {
+		return linkQueryService.countByMemberAndIsDeleteFalse(member);
+	}
+
 	public Optional<Long> findLinkIdByUrl(Member member, String url) {
 		return linkQueryService.findIdByUrl(member, url);
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -94,7 +94,7 @@ public class LinkService {
 		return link;
 	}
 
-	public int getLinkTotalCount(Member member) {
+	public Long getLinkTotalCount(Member member) {
 		return linkQueryService.countByMemberAndIsDeleteFalse(member);
 	}
 

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -527,14 +527,14 @@ class LinkFacadeTest {
 			.email("test@example.com")
 			.password("password")
 			.build();
-		given(linkService.getLinkTotalCount(member)).willReturn(15);
+		given(linkService.getLinkTotalCount(member)).willReturn(15L);
 
 		// when
 		LinkTotalCountRes result = linkFacade.getLinkTotalCount(member);
 
 		// then
 		assertThat(result).isNotNull();
-		assertThat(result.totalCount()).isEqualTo(15);
+		assertThat(result.totalCount()).isEqualTo(15L);
 		verify(linkService, times(1)).getLinkTotalCount(member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -25,6 +25,7 @@ import com.sofa.linkiving.domain.link.dto.response.LinkCardsRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDetailRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkDuplicateCheckRes;
 import com.sofa.linkiving.domain.link.dto.response.LinkRes;
+import com.sofa.linkiving.domain.link.dto.response.LinkTotalCountRes;
 import com.sofa.linkiving.domain.link.dto.response.MetaScrapeRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RegenerateSummaryRes;
@@ -415,7 +416,7 @@ class LinkFacadeTest {
 	}
 
 	@Test
-	@DisplayName("페이징된 링크 카드 목록을 조회한다")
+	@DisplayName("링크 카드 목록을 조회한다 (페이징 포함)")
 	void shouldGetLinkCards() {
 		// given
 		Member member = mock(Member.class);
@@ -515,5 +516,25 @@ class LinkFacadeTest {
 		// then
 		assertThat(result).isNotNull();
 		verify(linkService, times(1)).findLinkIdByUrl(member, url);
+	}
+
+	@Test
+	@DisplayName("사용자의 전체 링크 개수를 조회하여 응답 객체(DTO)로 반환한다")
+	void shouldGetLinkTotalCount() {
+		// given
+		Member member = Member
+			.builder()
+			.email("test@example.com")
+			.password("password")
+			.build();
+		given(linkService.getLinkTotalCount(member)).willReturn(15);
+
+		// when
+		LinkTotalCountRes result = linkFacade.getLinkTotalCount(member);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.totalCount()).isEqualTo(15);
+		verify(linkService, times(1)).getLinkTotalCount(member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -758,4 +758,49 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.message").value("요약 수정 완료"))
 			.andExpect(jsonPath("$.data.content").value("수정된 요약 텍스트"));
 	}
+
+	@Test
+	@DisplayName("전체 링크 개수 조회 API 성공 시 200 OK와 데이터(총 개수)를 반환한다")
+	void getLinkTotalCount() throws Exception {
+		// given
+		Link link1 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link1")
+			.url("http://url1.com")
+			.build());
+
+		Link link2 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link2")
+			.url("http://url2.com")
+			.build());
+
+		Link link3 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link3")
+			.url("http://url3.com")
+			.build());
+
+		Link link4 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link4")
+			.url("http://url4.com")
+			.build());
+
+		Link link5 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link5")
+			.url("http://url5.com")
+			.build());
+
+		// when & then
+		mockMvc.perform(get(BASE_URL + "/count")
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf())
+				.with(user(testUserDetails))
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalCount").value(5))
+			.andExpect(jsonPath("$.message").value("링크 전체 개수 조회 완료"));
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
@@ -308,9 +308,9 @@ class LinkRepositoryTest {
 		ReflectionTestUtils.setField(deletedLink, "isDelete", true);
 
 		// when
-		int count = linkRepository.countByMemberAndIsDeleteFalse(testMember);
+		Long count = linkRepository.countByMemberAndIsDeleteFalse(testMember);
 
 		// then
-		assertThat(count).isEqualTo(4);
+		assertThat(count).isEqualTo(4L);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/repository/LinkRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
@@ -269,5 +270,47 @@ class LinkRepositoryTest {
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("특정 사용자 기준으로 isDelete가 false인 전체 링크 개수를 조회한다")
+	void countByMemberAndIsDeleteFalse() {
+		// given
+		Link link1 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link1")
+			.url("http://url1.com")
+			.build());
+
+		Link link2 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link2")
+			.url("http://url2.com")
+			.build());
+
+		Link link3 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link3")
+			.url("http://url3.com")
+			.build());
+
+		Link link4 = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link4")
+			.url("http://url4.com")
+			.build());
+
+		Link deletedLink = linkRepository.save(Link.builder()
+			.member(testMember)
+			.title("link4")
+			.url("http://url4.com")
+			.build());
+		ReflectionTestUtils.setField(deletedLink, "isDelete", true);
+
+		// when
+		int count = linkRepository.countByMemberAndIsDeleteFalse(testMember);
+
+		// then
+		assertThat(count).isEqualTo(4);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
@@ -301,13 +301,13 @@ class LinkQueryServiceTest {
 	void countByMemberAndIsDeleteFalse() {
 		// given
 		Member member = mock(Member.class);
-		given(linkRepository.countByMemberAndIsDeleteFalse(member)).willReturn(5);
+		given(linkRepository.countByMemberAndIsDeleteFalse(member)).willReturn(5L);
 
 		// when
-		int result = linkQueryService.countByMemberAndIsDeleteFalse(member);
+		Long result = linkQueryService.countByMemberAndIsDeleteFalse(member);
 
 		// then
-		assertThat(result).isEqualTo(5);
+		assertThat(result).isEqualTo(5L);
 		verify(linkRepository, times(1)).countByMemberAndIsDeleteFalse(member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkQueryServiceTest.java
@@ -295,4 +295,19 @@ class LinkQueryServiceTest {
 		assertThat(resultId).isPresent().contains(expectedId);
 		verify(linkRepository, times(1)).findIdByMemberAndUrlAndIsDeleteFalse(member, url);
 	}
+
+	@Test
+	@DisplayName("사용자의 삭제되지 않은 전체 링크 개수를 조회한다")
+	void countByMemberAndIsDeleteFalse() {
+		// given
+		Member member = mock(Member.class);
+		given(linkRepository.countByMemberAndIsDeleteFalse(member)).willReturn(5);
+
+		// when
+		int result = linkQueryService.countByMemberAndIsDeleteFalse(member);
+
+		// then
+		assertThat(result).isEqualTo(5);
+		verify(linkRepository, times(1)).countByMemberAndIsDeleteFalse(member);
+	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -450,13 +450,13 @@ class LinkServiceTest {
 	void getLinkTotalCount() {
 		// given
 		Member member = mock(Member.class);
-		given(linkQueryService.countByMemberAndIsDeleteFalse(member)).willReturn(10);
+		given(linkQueryService.countByMemberAndIsDeleteFalse(member)).willReturn(10L);
 
 		// when
-		int result = linkService.getLinkTotalCount(member);
+		Long result = linkService.getLinkTotalCount(member);
 
 		// then
-		assertThat(result).isEqualTo(10);
+		assertThat(result).isEqualTo(10L);
 		verify(linkQueryService, times(1)).countByMemberAndIsDeleteFalse(member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/LinkServiceTest.java
@@ -444,4 +444,19 @@ class LinkServiceTest {
 		verify(linkQueryService, times(1)).findById(linkId);
 		verify(link, times(1)).updateSummaryStatus(newStatus);
 	}
+
+	@Test
+	@DisplayName("사용자의 전체 링크 개수를 조회한다")
+	void getLinkTotalCount() {
+		// given
+		Member member = mock(Member.class);
+		given(linkQueryService.countByMemberAndIsDeleteFalse(member)).willReturn(10);
+
+		// when
+		int result = linkService.getLinkTotalCount(member);
+
+		// then
+		assertThat(result).isEqualTo(10);
+		verify(linkQueryService, times(1)).countByMemberAndIsDeleteFalse(member);
+	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #202

## PR 설명
* **Endpoint**: `GET /v1/links/count`
* **Response** 
   ```
      {
        "totalCount": 42
      }
   ```

### 비즈니스 로직 및 Repository
* `LinkFacade` -> `LinkService` -> `LinkQueryService`로 이어지는 읽기 전용 서비스 계층 파이프라인을 구축함.
* `LinkRepository`: 메모리 낭비와 쿼리 부하를 방지하기 위해 엔티티를 직접 조회하지 않고, 데이터베이스 레벨에서 카운트를 수행하는 `countByMemberAndIsDeleteFalse` 쿼리 메서드를 선언 및 적용함.