### PR TITLE
프로필 조회 API에 구글 계정 정보 반영

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberProfileRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberProfileRes.java
@@ -11,6 +11,10 @@ import lombok.Builder;
 public record MemberProfileRes(
 	@Schema(description = "회원 ID", example = "1")
 	Long id,
+	@Schema(description = "유저명", example = "Linkiving User")
+	String name,
+	@Schema(description = "프로필 이미지 URL", example = "https://lh3.googleusercontent.com/...")
+	String profileImageUrl,
 	@Schema(description = "이메일", example = "user@example.com")
 	String email,
 	@Schema(description = "가입일", example = "2026-03-01T12:34:56")
@@ -19,6 +23,8 @@ public record MemberProfileRes(
 	public static MemberProfileRes from(Member member) {
 		return MemberProfileRes.builder()
 			.id(member.getId())
+			.name(member.getName())
+			.profileImageUrl(member.getProfileImageUrl())
 			.email(member.getEmail())
 			.createdAt(member.getCreatedAt())
 			.build();

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -25,16 +25,22 @@ public class Member extends BaseEntity {
 	private String email;
 	@Column(nullable = false)
 	private String password;
+	@Column
+	private String name;
+	@Column(length = 2048)
+	private String profileImageUrl;
 	@Column(nullable = false)
 	private Role role;
 
 	@Builder
-	public Member(String email, String password) {
+	public Member(String email, String password, String name, String profileImageUrl) {
 		if (!isValidEmail(email)) {
 			throw new BusinessException(MemberErrorCode.INVALID_EMAIL_FORMAT);
 		}
 		this.email = email;
 		this.password = password;
+		this.name = name;
+		this.profileImageUrl = profileImageUrl;
 		this.role = Role.USER;
 	}
 
@@ -44,5 +50,14 @@ public class Member extends BaseEntity {
 
 	public boolean verifyPassword(String rawPassword) {
 		return this.password.equals(rawPassword);
+	}
+
+	public void updateProfile(String name, String profileImageUrl) {
+		if (name != null) {
+			this.name = name;
+		}
+		if (profileImageUrl != null) {
+			this.profileImageUrl = profileImageUrl;
+		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
@@ -22,11 +22,21 @@ public class MemberCommandService {
 	}
 
 	public Member createOrUpdate(String email) {
+		return createOrUpdate(email, null, null);
+	}
+
+	public Member createOrUpdate(String email, String name, String profileImageUrl) {
 		return memberRepository.findByEmail(email)
+			.map(member -> {
+				member.updateProfile(name, profileImageUrl);
+				return member;
+			})
 			.orElseGet(() -> {
 				Member newMember = Member.builder()
 					.email(email)
 					.password(email)
+					.name(name)
+					.profileImageUrl(profileImageUrl)
 					.build();
 
 				return memberRepository.save(newMember);

--- a/src/main/java/com/sofa/linkiving/security/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/service/CustomOAuth2UserService.java
@@ -32,7 +32,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 		GoogleOAuth2User googleUser = new GoogleOAuth2User(oAuth2User.getAttributes());
 
-		Member member = memberCommandService.createOrUpdate(googleUser.email());
+		Member member = memberCommandService.createOrUpdate(
+			googleUser.email(),
+			googleUser.name(),
+			googleUser.picture()
+		);
 
 		return new DefaultOAuth2User(
 			Collections.singleton(new SimpleGrantedAuthority("ROLE_" + member.getRole().name())),

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberCommandServiceTest.java
@@ -3,6 +3,8 @@ package com.sofa.linkiving.domain.member.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,5 +57,62 @@ class MemberCommandServiceTest {
 		Member captured = captor.getValue();
 		assertThat(captured.getEmail()).isEqualTo(email);
 		assertThat(captured.getPassword()).isEqualTo(password);
+	}
+
+	@Test
+	@DisplayName("OAuth 회원이 이미 존재하면 name, profileImageUrl을 갱신한다")
+	void shouldUpdateExistingOAuthMemberProfile() {
+		// given
+		String email = "oauth@test.com";
+		Member existing = Member.builder()
+			.email(email)
+			.password("encoded-password")
+			.name("old-name")
+			.profileImageUrl("https://old.example.com/profile.png")
+			.build();
+
+		when(memberRepository.findByEmail(email)).thenReturn(Optional.of(existing));
+
+		// when
+		Member result = memberCommandService.createOrUpdate(
+			email,
+			"new-name",
+			"https://new.example.com/profile.png"
+		);
+
+		// then
+		assertThat(result).isSameAs(existing);
+		assertThat(result.getName()).isEqualTo("new-name");
+		assertThat(result.getProfileImageUrl()).isEqualTo("https://new.example.com/profile.png");
+
+		verify(memberRepository, times(1)).findByEmail(email);
+		verify(memberRepository, never()).save(any(Member.class));
+		verifyNoMoreInteractions(memberRepository);
+	}
+
+	@Test
+	@DisplayName("OAuth 신규 회원이면 name, profileImageUrl을 저장한다")
+	void shouldCreateOAuthMemberWithProfile() {
+		// given
+		String email = "oauth-new@test.com";
+		when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+		when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		Member result = memberCommandService.createOrUpdate(
+			email,
+			"google-name",
+			"https://googleusercontent.com/profile.png"
+		);
+
+		// then
+		assertThat(result.getEmail()).isEqualTo(email);
+		assertThat(result.getPassword()).isEqualTo(email);
+		assertThat(result.getName()).isEqualTo("google-name");
+		assertThat(result.getProfileImageUrl()).isEqualTo("https://googleusercontent.com/profile.png");
+
+		verify(memberRepository, times(1)).findByEmail(email);
+		verify(memberRepository, times(1)).save(any(Member.class));
+		verifyNoMoreInteractions(memberRepository);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -169,6 +169,8 @@ public class MemberServiceTest {
 		Member member = mock(Member.class);
 		LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 12, 34, 56);
 		given(member.getId()).willReturn(1L);
+		given(member.getName()).willReturn("Linkiving User");
+		given(member.getProfileImageUrl()).willReturn("https://lh3.googleusercontent.com/sample");
 		given(member.getEmail()).willReturn("user@example.com");
 		given(member.getCreatedAt()).willReturn(createdAt);
 
@@ -177,6 +179,8 @@ public class MemberServiceTest {
 
 		// then
 		assertThat(res.id()).isEqualTo(1L);
+		assertThat(res.name()).isEqualTo("Linkiving User");
+		assertThat(res.profileImageUrl()).isEqualTo("https://lh3.googleusercontent.com/sample");
 		assertThat(res.email()).isEqualTo("user@example.com");
 		assertThat(res.createdAt()).isEqualTo(createdAt);
 	}


### PR DESCRIPTION
## 관련 이슈
- close #210

## PR 설명
- 프로필 조회 응답에 구글 계정 유저명(`name`)과 프로필 이미지(`profileImageUrl`)를 추가했습니다.
- OAuth2 로그인 시 구글 계정의 유저명/프로필 이미지를 회원 정보에 저장하도록 수정했습니다.
- 기존 회원이 재로그인하는 경우에도 최신 프로필 정보가 갱신되도록 처리했습니다.
- 관련 단위 테스트(`MemberCommandServiceTest`, `MemberServiceTest`)를 보강했습니다.