### PR TITLE
채팅 피드백 수정 오류 해결 및 Upsert 로직 적용

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
@@ -1,7 +1,7 @@
 package com.sofa.linkiving.domain.chat.controller;
 
-import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
-import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.dto.request.UpsertFeedbackReq;
+import com.sofa.linkiving.domain.chat.dto.response.UpsertFeedbackRes;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
@@ -10,6 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Feedback", description = "피드백 관리 API")
 public interface FeedbackApi {
-	@Operation(summary = "피드백 추가", description = "메세지에 피드백을 추가하고 생성된 피드백 ID를 반환합니다.")
-	BaseResponse<AddFeedbackRes> createFeedback(Long messageId, AddFeedbackReq createFeedbackReq, Member member);
+	@Operation(summary = "피드백 추가 및 수정", description = "메세지에 피드백을 추가 및 수정하고 피드백 ID를 반환합니다.")
+	BaseResponse<UpsertFeedbackRes> upsertFeedback(Long messageId, UpsertFeedbackReq createFeedbackReq, Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
@@ -1,13 +1,13 @@
 package com.sofa.linkiving.domain.chat.controller;
 
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
-import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.dto.request.UpsertFeedbackReq;
+import com.sofa.linkiving.domain.chat.dto.response.UpsertFeedbackRes;
 import com.sofa.linkiving.domain.chat.facade.FeedbackFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
@@ -23,10 +23,13 @@ public class FeedbackController implements FeedbackApi {
 	private final FeedbackFacade feedbackFacade;
 
 	@Override
-	@PostMapping("/{messageId}/feedback")
-	public BaseResponse<AddFeedbackRes> createFeedback(@PathVariable Long messageId,
-		@Valid @RequestBody AddFeedbackReq req, @AuthMember Member member) {
-		AddFeedbackRes res = feedbackFacade.createFeedback(member, messageId, req.sentiment(), req.text());
+	@PutMapping("/{messageId}/feedback")
+	public BaseResponse<UpsertFeedbackRes> upsertFeedback(
+		@PathVariable Long messageId,
+		@Valid @RequestBody UpsertFeedbackReq req,
+		@AuthMember Member member
+	) {
+		UpsertFeedbackRes res = feedbackFacade.upsertFeedback(member, messageId, req.sentiment(), req.text());
 		return BaseResponse.success(res, "피드백이 등록되었습니다.");
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/UpsertFeedbackReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/UpsertFeedbackReq.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record AddFeedbackReq(
+public record UpsertFeedbackReq(
 	@NotNull(message = "피드백 상태는 필수입니다.") // 필수 값 체크
 	@Schema(description = "피드백 상태 (LIKE, DISLIKE)", example = "LIKE")
 	Sentiment sentiment,

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/UpsertFeedbackRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/UpsertFeedbackRes.java
@@ -2,7 +2,7 @@ package com.sofa.linkiving.domain.chat.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record AddFeedbackRes(
+public record UpsertFeedbackRes(
 	@Schema(description = "피드백 ID")
 	Long id
 ) {

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Feedback.java
@@ -35,4 +35,9 @@ public class Feedback extends BaseEntity {
 		this.text = text;
 		this.sentiment = sentiment;
 	}
+
+	public void update(String text, Sentiment sentiment) {
+		this.text = text;
+		this.sentiment = sentiment;
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacade.java
@@ -3,7 +3,7 @@ package com.sofa.linkiving.domain.chat.facade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.dto.response.UpsertFeedbackRes;
 import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.enums.Sentiment;
 import com.sofa.linkiving.domain.chat.service.FeedbackService;
@@ -19,10 +19,9 @@ public class FeedbackFacade {
 	private final FeedbackService feedbackService;
 	private final MessageService messageService;
 
-	public AddFeedbackRes createFeedback(Member member, Long messageId, Sentiment sentiment, String text) {
-
+	public UpsertFeedbackRes upsertFeedback(Member member, Long messageId, Sentiment sentiment, String text) {
 		Message message = messageService.get(messageId, member);
-		Long id = feedbackService.create(message, sentiment, text);
-		return new AddFeedbackRes(id);
+		Long id = feedbackService.upsertFeedback(message, sentiment, text).getId();
+		return new UpsertFeedbackRes(id);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/FeedbackRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/FeedbackRepository.java
@@ -1,5 +1,7 @@
 package com.sofa.linkiving.domain.chat.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,10 +10,13 @@ import org.springframework.stereotype.Repository;
 
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
 
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 	@Modifying(clearAutomatically = true)
 	@Query("DELETE FROM Feedback f WHERE f.message.id IN (SELECT m.id FROM Message m WHERE m.chat = :chat)")
 	void deleteAllByChat(@Param("chat") Chat chat);
+
+	Optional<Feedback> findByMessage(Message message);
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryService.java
@@ -1,7 +1,11 @@
 package com.sofa.linkiving.domain.chat.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +14,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FeedbackQueryService {
 	private final FeedbackRepository feedbackRepository;
+
+	public Optional<Feedback> findOptionalByMessage(Message message) {
+		return feedbackRepository.findByMessage(message);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/FeedbackService.java
@@ -15,13 +15,19 @@ public class FeedbackService {
 	private final FeedbackQueryService feedbackQueryService;
 	private final FeedbackCommandService feedbackCommandService;
 
-	public Long create(Message message, Sentiment sentiment, String text) {
-		Feedback feedback = Feedback.builder()
-			.message(message)
-			.sentiment(sentiment)
-			.text(text)
-			.build();
-		return feedbackCommandService.save(feedback).getId();
+	public Feedback upsertFeedback(Message message, Sentiment sentiment, String text) {
+		return feedbackQueryService.findOptionalByMessage(message)
+			.map(feedback -> {
+				feedback.update(text, sentiment);
+				return feedback;
+			}).orElseGet(() -> {
+				Feedback feedback = Feedback.builder()
+					.message(message)
+					.sentiment(sentiment)
+					.text(text)
+					.build();
+				return feedbackCommandService.save(feedback);
+			});
 	}
 
 	public void deleteAll(Chat chat) {

--- a/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/entity/FeedbackTest.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.chat.entity;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 
@@ -17,13 +18,14 @@ import com.sofa.linkiving.domain.member.entity.Member;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@DisplayName("Feedback 엔티티 테스트")
 public class FeedbackTest {
 
 	@Autowired
 	private TestEntityManager em;
 
 	@Test
-	@DisplayName("피드백 저장 시 메시지 연관관계 및 감정 상태 정상 저장")
+	@DisplayName("피드백 저장 시 메시지 및 상태 정상 저장")
 	void shouldSaveFeedbackWithSentiment() {
 		// given
 		Member member = Member
@@ -64,5 +66,24 @@ public class FeedbackTest {
 		assertThat(savedFeedback.getMessage().getId()).isEqualTo(message.getId());
 		assertThat(savedFeedback.getText()).isEqualTo(feedbackText);
 		assertThat(savedFeedback.getSentiment()).isEqualTo(sentiment);
+	}
+
+	@Test
+	@DisplayName("피드백 내용과 상태를 업데이트할 수 있다")
+	void shouldUpdateFeedback() {
+		// given
+		Message mockMessage = mock(Message.class);
+		Feedback feedback = Feedback.builder()
+			.message(mockMessage)
+			.text("기존 피드백 내용")
+			.sentiment(Sentiment.LIKE)
+			.build();
+
+		// when
+		feedback.update("수정된 피드백 내용", Sentiment.DISLIKE);
+
+		// then
+		assertThat(feedback.getText()).isEqualTo("수정된 피드백 내용");
+		assertThat(feedback.getSentiment()).isEqualTo(Sentiment.DISLIKE);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/facade/FeedbackFacadeTest.java
@@ -10,7 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sofa.linkiving.domain.chat.dto.response.AddFeedbackRes;
+import com.sofa.linkiving.domain.chat.dto.response.UpsertFeedbackRes;
+import com.sofa.linkiving.domain.chat.entity.Feedback;
 import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.enums.Sentiment;
 import com.sofa.linkiving.domain.chat.service.FeedbackService;
@@ -18,6 +19,7 @@ import com.sofa.linkiving.domain.chat.service.MessageService;
 import com.sofa.linkiving.domain.member.entity.Member;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("FeedbackFacade 단위 테스트")
 public class FeedbackFacadeTest {
 	@InjectMocks
 	private FeedbackFacade feedbackFacade;
@@ -29,28 +31,29 @@ public class FeedbackFacadeTest {
 	private MessageService messageService;
 
 	@Test
-	@DisplayName("피드백 생성 요청 시 Message 조회 후 Feedback을 생성하고 결과를 반환함")
-	void shouldCreateFeedbackAndReturnRes() {
+	@DisplayName("피드백을 생성하거나 수정하고 피드백 ID를 반환한다")
+	void upsertFeedback() {
 		// given
+		Member member = mock(Member.class);
 		Long messageId = 1L;
-		Long feedbackId = 100L;
 		Sentiment sentiment = Sentiment.LIKE;
-		String text = "도움이 되었어요";
+		String text = "유용한 답변입니다.";
 
 		Message message = mock(Message.class);
-		Member member = mock(Member.class);
-
 		given(messageService.get(messageId, member)).willReturn(message);
-		given(feedbackService.create(message, sentiment, text)).willReturn(feedbackId);
+
+		Feedback feedback = mock(Feedback.class);
+		given(feedback.getId()).willReturn(100L);
+		given(feedbackService.upsertFeedback(message, sentiment, text)).willReturn(feedback);
 
 		// when
-		AddFeedbackRes result = feedbackFacade.createFeedback(member, messageId, sentiment, text);
+		UpsertFeedbackRes result = feedbackFacade.upsertFeedback(member, messageId, sentiment, text);
 
 		// then
 		assertThat(result).isNotNull();
-		assertThat(result.id()).isEqualTo(feedbackId);
+		assertThat(result.id()).isEqualTo(100L);
 
-		verify(messageService).get(messageId, member);
-		verify(feedbackService).create(message, sentiment, text);
+		verify(messageService, times(1)).get(messageId, member);
+		verify(feedbackService, times(1)).upsertFeedback(message, sentiment, text);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sofa.linkiving.domain.chat.dto.request.AddFeedbackReq;
+import com.sofa.linkiving.domain.chat.dto.request.UpsertFeedbackReq;
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.entity.Feedback;
 import com.sofa.linkiving.domain.chat.entity.Message;
@@ -41,6 +41,8 @@ import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 @ActiveProfiles("test")
 class FeedbackIntegrationTest {
 
+	private static final String BASE_URL = "/v1/messages";
+
 	@Autowired
 	private MockMvc mockMvc;
 	@Autowired
@@ -59,7 +61,7 @@ class FeedbackIntegrationTest {
 	private FeedbackRepository feedbackRepository;
 
 	@MockitoBean
-	private RedisService redisService; // 통합 테스트 환경 구성상 필요하다면 유지
+	private RedisService redisService;
 
 	private UserDetails testUserDetails;
 	private Message testMessage;
@@ -85,14 +87,14 @@ class FeedbackIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("피드백 등록 요청 시 DB에 저장되고 200 OK를 반환함")
-	void shouldSaveFeedbackAndReturnOkWhenValidRequest() throws Exception {
+	@DisplayName("새로운 피드백 등록 요청 시 DB에 새로 저장되고 200 OK를 반환함")
+	void shouldCreateNewFeedbackAndReturnOkWhenNoExistingFeedback() throws Exception {
 		// given
 		Long messageId = testMessage.getId();
-		AddFeedbackReq req = new AddFeedbackReq(Sentiment.LIKE, "매우 유용한 답변입니다.");
+		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.LIKE, "매우 유용한 답변입니다.");
 
 		// when & then
-		mockMvc.perform(post("/v1/messages/{messageId}/feedback", messageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -100,8 +102,9 @@ class FeedbackIntegrationTest {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.id").isNumber()); // 생성된 ID 반환 확인
+			.andExpect(jsonPath("$.data.id").isNumber());
 
+		assertThat(feedbackRepository.count()).isEqualTo(1);
 		Feedback savedFeedback = feedbackRepository.findAll().get(0);
 		assertThat(savedFeedback.getMessage().getId()).isEqualTo(messageId);
 		assertThat(savedFeedback.getSentiment()).isEqualTo(Sentiment.LIKE);
@@ -109,14 +112,45 @@ class FeedbackIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("피드백 상태(Sentiment) 누락 시 400 Bad Request를 반환함")
+	@DisplayName("기존 피드백이 존재하는 상태에서 등록 요청 시 내용이 수정되고 200 OK를 반환함")
+	void shouldUpdateExistingFeedbackAndReturnOkWhenFeedbackExists() throws Exception {
+		// given
+		Feedback existingFeedback = feedbackRepository.save(Feedback.builder()
+			.message(testMessage)
+			.sentiment(Sentiment.LIKE)
+			.text("기존 피드백입니다.")
+			.build());
+
+		Long messageId = testMessage.getId();
+		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.DISLIKE, "내용이 수정되었습니다.");
+
+		// when & then
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
+				.with(csrf())
+				.with(user(testUserDetails))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(existingFeedback.getId()));
+
+		assertThat(feedbackRepository.count()).isEqualTo(1);
+		Feedback updatedFeedback = feedbackRepository.findAll().get(0);
+		assertThat(updatedFeedback.getId()).isEqualTo(existingFeedback.getId());
+		assertThat(updatedFeedback.getSentiment()).isEqualTo(Sentiment.DISLIKE);
+		assertThat(updatedFeedback.getText()).isEqualTo("내용이 수정되었습니다.");
+	}
+
+	@Test
+	@DisplayName("피드백 상태 누락 시 400 Bad Request를 반환함")
 	void shouldReturnBadRequestWhenSentimentIsNull() throws Exception {
 		// given
 		Long messageId = testMessage.getId();
-		AddFeedbackReq req = new AddFeedbackReq(null, "내용만 있음"); // @NotNull 위반
+		UpsertFeedbackReq req = new UpsertFeedbackReq(null, "내용만 있음");
 
 		// when & then
-		mockMvc.perform(post("/v1/messages/{messageId}/feedback", messageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -126,20 +160,20 @@ class FeedbackIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 메시지에 피드백 등록 시 404 Not Found를 반환함")
+	@DisplayName("존재하지 않는 메시지에 피드백 등록/수정 시 404 Not Found를 반환함")
 	void shouldReturnNotFoundWhenMessageDoesNotExist() throws Exception {
 		// given
 		Long invalidMessageId = 99999L;
-		AddFeedbackReq req = new AddFeedbackReq(Sentiment.DISLIKE, "별로예요");
+		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.DISLIKE, "별로예요");
 
 		// when & then
-		mockMvc.perform(post("/v1/messages/{messageId}/feedback", invalidMessageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", invalidMessageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(req)))
 			.andDo(print())
-			.andExpect(status().isNotFound()) // MessageQueryService에서 예외 발생
+			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.success").value(false));
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackQueryServiceTest.java
@@ -1,0 +1,58 @@
+package com.sofa.linkiving.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.chat.entity.Feedback;
+import com.sofa.linkiving.domain.chat.entity.Message;
+import com.sofa.linkiving.domain.chat.repository.FeedbackRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FeedbackQueryService 단위 테스트")
+public class FeedbackQueryServiceTest {
+	@InjectMocks
+	private FeedbackQueryService feedbackQueryService;
+
+	@Mock
+	private FeedbackRepository feedbackRepository;
+
+	@Test
+	@DisplayName("메시지로 피드백을 조회한다")
+	void findOptionalByMessage() {
+		// given
+		Message message = mock(Message.class);
+		Feedback feedback = mock(Feedback.class);
+		given(feedbackRepository.findByMessage(message)).willReturn(Optional.of(feedback));
+
+		// when
+		Optional<Feedback> result = feedbackQueryService.findOptionalByMessage(message);
+
+		// then
+		assertThat(result).isPresent().contains(feedback);
+		verify(feedbackRepository, times(1)).findByMessage(message);
+	}
+
+	@Test
+	@DisplayName("메시지에 해당하는 피드백이 없으면 빈 Optional을 반환한다")
+	void findOptionalByMessage_ReturnsEmpty() {
+		// given
+		Message message = mock(Message.class);
+		given(feedbackRepository.findByMessage(message)).willReturn(Optional.empty());
+
+		// when
+		Optional<Feedback> result = feedbackQueryService.findOptionalByMessage(message);
+
+		// then
+		assertThat(result).isEmpty();
+		verify(feedbackRepository, times(1)).findByMessage(message);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/FeedbackServiceTest.java
@@ -3,9 +3,12 @@ package com.sofa.linkiving.domain.chat.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,6 +19,7 @@ import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.enums.Sentiment;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("FeedbackService 단위 테스트")
 public class FeedbackServiceTest {
 
 	@InjectMocks
@@ -28,35 +32,55 @@ public class FeedbackServiceTest {
 	private FeedbackQueryService feedbackQueryService;
 
 	@Test
-	@DisplayName("피드백 생성 요청 시 엔티티를 생성하고 저장을 요청함")
-	void shouldCreateAndSaveFeedback() {
+	@DisplayName("기존 피드백이 존재하면 내용을 업데이트하고 반환한다")
+	void shouldUpdateExistingFeedback() {
 		// given
 		Message message = mock(Message.class);
 		Sentiment sentiment = Sentiment.LIKE;
-		String text = "답변이 훌륭합니다.";
+		String text = "수정된 피드백";
 
-		Feedback savedFeedback = mock(Feedback.class);
-		given(savedFeedback.getId()).willReturn(10L);
-
-		given(feedbackCommandService.save(any(Feedback.class))).willAnswer(invocation -> {
-			Feedback argument = invocation.getArgument(0);
-			assertThat(argument.getMessage()).isEqualTo(message);
-			assertThat(argument.getSentiment()).isEqualTo(sentiment);
-			assertThat(argument.getText()).isEqualTo(text);
-
-			return savedFeedback;
-		});
+		Feedback existingFeedback = mock(Feedback.class);
+		given(feedbackQueryService.findOptionalByMessage(message)).willReturn(Optional.of(existingFeedback));
 
 		// when
-		Long resultId = feedbackService.create(message, sentiment, text);
+		Feedback result = feedbackService.upsertFeedback(message, sentiment, text);
 
 		// then
-		assertThat(resultId).isEqualTo(10L);
-		verify(feedbackCommandService).save(any(Feedback.class));
+		assertThat(result).isEqualTo(existingFeedback);
+		verify(existingFeedback, times(1)).update(text, sentiment);
+		verify(feedbackCommandService, never()).save(any());
 	}
 
 	@Test
-	@DisplayName("FeedbackCommandService.deleteAllByMessageIn 호출 위임")
+	@DisplayName("기존 피드백이 없으면 새로 생성하여 저장을 요청한다")
+	void shouldCreateAndSaveNewFeedback() {
+		// given
+		Message message = mock(Message.class);
+		Sentiment sentiment = Sentiment.DISLIKE;
+		String text = "새로운 피드백";
+
+		given(feedbackQueryService.findOptionalByMessage(message)).willReturn(Optional.empty());
+
+		Feedback savedFeedback = mock(Feedback.class);
+		given(feedbackCommandService.save(any(Feedback.class))).willReturn(savedFeedback);
+
+		// when
+		Feedback result = feedbackService.upsertFeedback(message, sentiment, text);
+
+		// then
+		assertThat(result).isEqualTo(savedFeedback);
+
+		ArgumentCaptor<Feedback> captor = ArgumentCaptor.forClass(Feedback.class);
+		verify(feedbackCommandService, times(1)).save(captor.capture());
+
+		Feedback capturedFeedback = captor.getValue();
+		assertThat(capturedFeedback.getMessage()).isEqualTo(message);
+		assertThat(capturedFeedback.getSentiment()).isEqualTo(sentiment);
+		assertThat(capturedFeedback.getText()).isEqualTo(text);
+	}
+
+	@Test
+	@DisplayName("채팅에 속한 모든 피드백 삭제를 CommandService에 위임한다")
 	void shouldCallDeleteAllByMessageInWhenDeleteFeedbacks() {
 		// given
 		Chat chat = mock(Chat.class);


### PR DESCRIPTION
## 관련 이슈

- close #212 

## PR 설명
* 채팅 피드백(좋아요/싫어요) 변경 시 발생하는 500 에러를 해결하기 위해 기존 저장 로직을 Upsert 방식으로 수정함.
* 조회 결과에 따른 분기 처리를 안전하게 수행하기 위해 `Optional`을 도입하여 코드 가독성과 안정성을 높임.

#### 비즈니스 로직 수정
* **Upsert 방식 적용 (`FeedbackService`)**:
  * 기존 피드백 존재 여부를 확인하여, 이미 존재할 경우 JPA 변경 감지를 통해 상태를 업데이트하고, 없을 경우에만 신규 저장하도록 통합함.
  * 이를 통해 중복 데이터 등록으로 인한 DB 제약조건 위반(500 에러) 문제를 해결함.

* **Optional 사용 배경**:
  * `FeedbackQueryService`에서 피드백 조회 시 `Optional<Feedback>`을 반환하도록 하여, 데이터 부재 가능성을 명시적으로 표현함.
  * 파사드/서비스 계층에서 `map()`(업데이트)과 `orElseGet()`(신규 생성)을 활용한 함수형 스타일의 분기 처리를 통해, `null` 체크 없이 안전하고 직관적인 로직 구현이 가능해짐.