### PR TITLE
익스텐션 개발 환경 API 요청 허용

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/config/CorsProperties.java
+++ b/src/main/java/com/sofa/linkiving/global/config/CorsProperties.java
@@ -6,6 +6,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.cors")
 public record CorsProperties(
-	List<String> allowedOrigins
+	List<String> allowedOrigins,
+	List<String> extensionAllowedOrigins
 ) {
+	public CorsProperties {
+		allowedOrigins = normalizeOrigins(allowedOrigins);
+		extensionAllowedOrigins = normalizeOrigins(extensionAllowedOrigins);
+	}
+
+	private static List<String> normalizeOrigins(List<String> origins) {
+		if (origins == null || origins.isEmpty()) {
+			return List.of();
+		}
+		return List.copyOf(origins);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sofa.linkiving.security.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -85,11 +86,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
-		List<String> allowedOrigins = corsProperties.allowedOrigins();
-		if (allowedOrigins == null || allowedOrigins.isEmpty()) {
-			allowedOrigins = List.of();
-		}
-		config.setAllowedOrigins(allowedOrigins);
+		config.setAllowedOrigins(resolveAllowedOrigins());
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true);
@@ -97,5 +94,13 @@ public class SecurityConfig {
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", config);
 		return source;
+	}
+
+	private List<String> resolveAllowedOrigins() {
+		List<String> allowedOrigins = new ArrayList<>(corsProperties.allowedOrigins());
+		allowedOrigins.addAll(corsProperties.extensionAllowedOrigins());
+		return allowedOrigins.stream()
+			.distinct()
+			.toList();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/sofa/linkiving/security/config/SecurityConfigTest.java
@@ -1,0 +1,88 @@
+package com.sofa.linkiving.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.cors.CorsConfiguration;
+
+import com.sofa.linkiving.global.config.CorsProperties;
+import com.sofa.linkiving.security.auth.handler.OAuth2FailureHandler;
+import com.sofa.linkiving.security.auth.handler.OAuth2SuccessHandler;
+import com.sofa.linkiving.security.auth.service.CustomOAuth2UserService;
+import com.sofa.linkiving.security.jwt.entrypoint.CustomAuthenticationEntryPoint;
+import com.sofa.linkiving.security.jwt.filter.JwtAuthenticationFilter;
+import com.sofa.linkiving.security.jwt.filter.JwtExceptionFilter;
+
+@DisplayName("SecurityConfig CORS 단위 테스트")
+class SecurityConfigTest {
+
+	private static final String WEB_ORIGIN = "http://localhost:3000";
+	private static final String EXTENSION_ORIGIN = "chrome-extension://dchepopfkpdcmpgpgbodmgblmnnagcdd";
+
+	@Test
+	@DisplayName("웹 origin과 익스텐션 origin을 모두 허용한다")
+	void shouldAllowWebAndExtensionOrigins() {
+		// given
+		SecurityConfig securityConfig = createSecurityConfig(
+			new CorsProperties(List.of(WEB_ORIGIN), List.of(EXTENSION_ORIGIN)));
+
+		// when
+		CorsConfiguration corsConfiguration = securityConfig.corsConfigurationSource()
+			.getCorsConfiguration(new MockHttpServletRequest());
+
+		// then
+		assertThat(corsConfiguration).isNotNull();
+		assertThat(corsConfiguration.getAllowedOrigins())
+			.containsExactly(WEB_ORIGIN, EXTENSION_ORIGIN);
+	}
+
+	@Test
+	@DisplayName("익스텐션 origin이 설정되지 않으면 웹 origin만 허용한다")
+	void shouldAllowOnlyWebOriginsWhenExtensionOriginsAreMissing() {
+		// given
+		SecurityConfig securityConfig = createSecurityConfig(
+			new CorsProperties(List.of(WEB_ORIGIN), null));
+
+		// when
+		CorsConfiguration corsConfiguration = securityConfig.corsConfigurationSource()
+			.getCorsConfiguration(new MockHttpServletRequest());
+
+		// then
+		assertThat(corsConfiguration).isNotNull();
+		assertThat(corsConfiguration.getAllowedOrigins()).containsExactly(WEB_ORIGIN);
+	}
+
+	@Test
+	@DisplayName("중복된 origin은 한 번만 허용한다")
+	void shouldDeduplicateAllowedOrigins() {
+		// given
+		SecurityConfig securityConfig = createSecurityConfig(
+			new CorsProperties(List.of(WEB_ORIGIN, EXTENSION_ORIGIN), List.of(EXTENSION_ORIGIN)));
+
+		// when
+		CorsConfiguration corsConfiguration = securityConfig.corsConfigurationSource()
+			.getCorsConfiguration(new MockHttpServletRequest());
+
+		// then
+		assertThat(corsConfiguration).isNotNull();
+		assertThat(corsConfiguration.getAllowedOrigins())
+			.containsExactly(WEB_ORIGIN, EXTENSION_ORIGIN);
+	}
+
+	private SecurityConfig createSecurityConfig(CorsProperties corsProperties) {
+		return new SecurityConfig(
+			mock(CustomAuthenticationEntryPoint.class),
+			mock(JwtAuthenticationFilter.class),
+			mock(JwtExceptionFilter.class),
+			mock(CustomOAuth2UserService.class),
+			mock(OAuth2SuccessHandler.class),
+			mock(OAuth2FailureHandler.class),
+			corsProperties
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #214

## PR 설명

- 익스텐션 origin을 기존 웹 origin과 분리된 설정으로 관리하도록 변경했습니다.
- `SecurityConfig`에서 웹 origin과 익스텐션 origin을 병합해 동일한 API 경로에 대한 CORS 허용 목록을 구성하도록 수정했습니다.
- 익스텐션 origin 값은 코드 기본값으로 고정하지 않고 `app.cors` 설정(yml/env)으로 주입받도록 정리했습니다.
- 보안 설정 테스트를 추가해 origin 병합, 중복 제거, 익스텐션 설정 누락 시 동작을 검증했습니다.

## 왜 이렇게 변경했는가

- 이번 이슈의 원인은 특정 endpoint의 부재가 아니라 브라우저의 CORS 검사였습니다.
- 익스텐션이 기존 API endpoint를 호출하면 요청의 `Origin`은 익스텐션 origin으로 전달됩니다.
- 서버의 CORS 허용 목록에 이 origin이 없으면 브라우저는 preflight `OPTIONS` 요청 단계 또는 실제 응답 처리 단계에서 요청을 차단합니다.
- 이 경우 요청은 컨트롤러 비즈니스 로직까지 도달하지 못하므로, endpoint를 새로 추가하는 것만으로는 해결되지 않습니다.
- 별도 endpoint를 만들더라도 그 endpoint 역시 동일한 origin을 허용하도록 CORS 설정이 필요합니다. 즉, 문제의 본질은 경로 부족이 아니라 허용 origin 부재입니다.
- 허용 origin 값은 환경별로 달라질 수 있으므로 코드 기본값보다 설정 주입이 더 보편적이고 운영 통제에 유리합니다.

## 설정 방식

- 웹 origin: `app.cors.allowed-origins`
- 익스텐션 origin: `app.cors.extension-allowed-origins`
- 실제 값은 환경별 yml 또는 env로 주입하는 것을 전제로 합니다.

예시:

```yml
app:
  cors:
    allowed-origins:
      - https://www.linkiving.com
      - http://localhost:3000
    extension-allowed-origins:
      - chrome-extension://dchepopfkpdcmpgpgbodmgblmnnagcdd
```

## 테스트

- bash ./gradlew test --tests com.sofa.linkiving.security.config.SecurityConfigTest checkstyleMain checkstyleTest
