### PR TITLE
RAG 서버 통합에 따른 Docker Compose 설정 업데이트

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - LANG=ko_KR.UTF-8
       - TZ=Asia/Seoul
+      - AI_SERVER_URL=http://n8n-app:5678
     ports:
       - '8080:8080'
     healthcheck:
@@ -19,6 +20,7 @@ services:
     restart: unless-stopped
     networks:
       - app-network
+      - linkiving-internal
     logging:
       driver: "json-file"
       options:
@@ -31,6 +33,7 @@ services:
     environment:
       - LANG=ko_KR.UTF-8
       - TZ=Asia/Seoul
+      - AI_SERVER_URL=http://n8n-app:5678
     ports:
       - '8081:8080'
     healthcheck:
@@ -42,6 +45,7 @@ services:
     restart: unless-stopped
     networks:
       - app-network
+      - linkiving-internal
     logging:
       driver: "json-file"
       options:
@@ -51,3 +55,5 @@ services:
 networks:
   app-network:
     driver: bridge
+  linkiving-internal:
+    external: true


### PR DESCRIPTION
## 관련 이슈

- close #217 

## PR 설명
RAG 서버를 메인 서버로 통합하고 t3.small로 업그레이드함에 따라
불필요해진 docker-compose.yml 설정을 추가한다.

## 변경 사항
AI_SERVER_URL 환경변수와 linkiving-internal external 네트워크를 추가했다.

## 확인 사항
- docker-compose 정상 실행 확인
