### PR TITLE
AI 요약 완료 후 링크 상태(COMPLETED) 업데이트 누락 버그 수정

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/facade/SummaryWorkerFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/SummaryWorkerFacade.java
@@ -42,7 +42,7 @@ public class SummaryWorkerFacade {
 
 		Summary savedSummary = summaryService.createInitialSummary(link, summaryContent);
 
-		link.updateSummaryStatus(SummaryStatus.COMPLETED);
+		linkService.updateSummaryStatus(linkId, SummaryStatus.COMPLETED);
 
 		return savedSummary;
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -104,7 +104,8 @@ public class SummaryWorker {
 			Summary summary = summaryWorkerFacade.createInitialSummaryAndUpdateStatus(link.getId(), res.summary());
 			if (summary != null) {
 				eventPublisher.publishEvent(new SummaryStatusEvent(
-					userEmail, SummaryStatusRes.completed(linkId, SummaryRes.from(summary))
+					userEmail,
+					SummaryStatusRes.completed(linkId, SummaryRes.from(summary))
 				));
 			}
 		} catch (Exception e) {

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/SummaryWorkerFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/SummaryWorkerFacadeTest.java
@@ -76,9 +76,9 @@ class SummaryWorkerFacadeTest {
 		Summary result = summaryWorkerFacade.createInitialSummaryAndUpdateStatus(linkId, summaryContent);
 
 		// then
-		assertThat(result).isEqualTo(mockSummary); // 정상 생성된 요약 반환 확인
+		assertThat(result).isEqualTo(mockSummary);
 		verify(summaryService, times(1)).createInitialSummary(mockLink, summaryContent);
-		verify(mockLink, times(1)).updateSummaryStatus(SummaryStatus.COMPLETED);
+		verify(linkService, times(1)).updateSummaryStatus(linkId, SummaryStatus.COMPLETED);
 	}
 
 	@Test
@@ -98,6 +98,5 @@ class SummaryWorkerFacadeTest {
 		// then
 		assertThat(result).isNull();
 		verify(summaryService, never()).createInitialSummary(any(), any());
-		verify(mockLink, never()).updateSummaryStatus(any());
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #216 

## PR 설명
* JPA 영속성 컨텍스트 생명주기 문제(준영속 상태)로 인한 변경 감지 누락 현상을 원인으로 파악하고, 명시적인 업데이트 로직으로 구조를 개선함.

### 원인 분석
* 요약 처리 과정 중 `Link` 객체가 영속성 컨텍스트에서 밀려나 **준영속 상태**로 전환됨.
* 이로 인해 `updateSummaryStatus(COMPLETED)`를 호출하여 엔티티 필드 값을 변경하더라도, 해당 객체가 JPA 관리 대상에서 벗어났기 때문에 트랜잭션 종료 시 UPDATE 쿼리가 발생하지 않는 문제가 있었음.

### 작업 내용
#### 비즈니스 로직 수정 (영속성 이슈 해결)
* **AS-IS**: 엔티티의 필드 값을 직접 변경하여 JPA 더티 체킹에 의존함.
  * `link.updateSummaryStatus(SummaryStatus.COMPLETED)`
* **TO-BE**: 영속성 컨텍스트의 상태(영속/준영속)에 영향을 받지 않고 데이터 정합성을 확실히 보장하기 위해, ID 기반의 명시적인 UPDATE 쿼리를 발생시키는 서비스 메서드를 호출하도록 리팩토링함.
  * `linkService.updateSummaryStatus(linkId, SummaryStatus.COMPLETED)`

#### 상세 수정 내역
* `SummaryWorkerFacade.java`: `createInitialSummaryAndUpdateStatus` 메서드 내 상태 업데이트 로직을 `linkService`를 통한 서비스 위임 방식으로 변경함.