### PR TITLE
링크 응답에 요약 상태를 노출하도록 정리

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -39,7 +39,9 @@ import jakarta.validation.constraints.Min;
 				```json
 				{
 					"linkId": 1,
-					"status": "PROCESSING"
+					"status": "PROCESSING",
+					"summary": null,
+					"errorMessage": null
 				}
 				```
 
@@ -48,11 +50,11 @@ import jakarta.validation.constraints.Min;
 				{
 					"linkId": 1,
 					"status": "COMPLETED",
-					"data": {
+					"summary": {
 						"id": 100,
-						"content": "생성된 AI 요약 내용입니다.",
-						"format": "CONCISE"
-					}
+						"content": "생성된 AI 요약 내용입니다."
+					},
+					"errorMessage": null
 				}
 				```
 		**CASE C: FAILED (요약 실패)**
@@ -60,7 +62,8 @@ import jakarta.validation.constraints.Min;
 				{
 					"linkId": 1,
 					"status": "FAILED",
-					"data": "AI 서버 응답이 없습니다."
+					"summary": null,
+					"errorMessage": "AI 서버 응답이 없습니다."
 				}
 				```
 		**흐름**: 링크 생성/재요약 API 호출 시 PENDING 상태 부여 -> 큐 진입 시 PROCESSING 알림 -> 완료 시 COMPLETED(데이터 포함) 알림

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardRes.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.dto.response;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -20,7 +21,10 @@ public record LinkCardRes(
 	String imageUrl,
 
 	@Schema(description = "요약 정보")
-	String summary
+	String summary,
+
+	@Schema(description = "요약 상태")
+	SummaryStatus summaryStatus
 ) {
 	public static LinkCardRes from(LinkDto dto) {
 		return of(dto.link(), dto.summary());
@@ -32,7 +36,8 @@ public record LinkCardRes(
 			link.getUrl(),
 			link.getTitle(),
 			link.getImageUrl(),
-			summary == null ? null : summary.getContent()
+			summary == null ? null : summary.getContent(),
+			link.getSummaryStatus()
 		);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.link.dto.response;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -23,7 +24,10 @@ public record LinkDetailRes(
 	String imageUrl,
 
 	@Schema(description = "요약 정보")
-	SummaryRes summary
+	SummaryRes summary,
+
+	@Schema(description = "요약 상태")
+	SummaryStatus summaryStatus
 ) {
 	public static LinkDetailRes from(LinkDto dto) {
 		return of(dto.link(), dto.summary());
@@ -36,7 +40,8 @@ public record LinkDetailRes(
 			link.getTitle(),
 			link.getMemo(),
 			link.getImageUrl(),
-			SummaryRes.from(summary)
+			SummaryRes.from(summary),
+			link.getSummaryStatus()
 		);
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
 import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -18,7 +19,10 @@ public record LinkRes(
 	String memo,
 
 	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
-	String imageUrl
+	String imageUrl,
+
+	@Schema(description = "요약 상태")
+	SummaryStatus summaryStatus
 ) {
 	public static LinkRes from(Link link) {
 		return new LinkRes(
@@ -26,7 +30,8 @@ public record LinkRes(
 			link.getUrl(),
 			link.getTitle(),
 			link.getMemo(),
-			link.getImageUrl()
+			link.getImageUrl(),
+			link.getSummaryStatus()
 		);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
@@ -6,35 +6,40 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record SummaryStatusRes<T>(
+public record SummaryStatusRes(
 	@Schema(description = "링크 ID")
 	Long linkId,
 	@Schema(description = "요약 진행 상태:PENDING(큐 대기 중), PROCESSING(요약 진행 중), COMPLETED(완료), FAILED(생성 실패)")
 	SummaryStatus status,
-	@Schema(description = "결과 데이터 (COMPLETED 상태일 때는 SummaryRes 객체, FAILED 상태일 때는 String 에러 메세지, 그 외는 null)")
-	T data
+	@Schema(description = "완료된 요약 데이터")
+	SummaryRes summary,
+	@Schema(description = "실패 에러 메세지")
+	String errorMessage
 ) {
-	public static SummaryStatusRes<Void> of(Long linkId, SummaryStatus status) {
-		return SummaryStatusRes.<Void>builder()
+	public static SummaryStatusRes of(Long linkId, SummaryStatus status) {
+		return SummaryStatusRes.builder()
 			.linkId(linkId)
 			.status(status)
-			.data(null)
+			.summary(null)
+			.errorMessage(null)
 			.build();
 	}
 
-	public static SummaryStatusRes<SummaryRes> completed(Long linkId, SummaryRes summary) {
-		return SummaryStatusRes.<SummaryRes>builder()
+	public static SummaryStatusRes completed(Long linkId, SummaryRes summary) {
+		return SummaryStatusRes.builder()
 			.linkId(linkId)
 			.status(SummaryStatus.COMPLETED)
-			.data(summary)
+			.summary(summary)
+			.errorMessage(null)
 			.build();
 	}
 
-	public static SummaryStatusRes<String> failed(Long linkId, String errorMessage) {
-		return SummaryStatusRes.<String>builder()
+	public static SummaryStatusRes failed(Long linkId, String errorMessage) {
+		return SummaryStatusRes.builder()
 			.linkId(linkId)
 			.status(SummaryStatus.FAILED)
-			.data(errorMessage)
+			.summary(null)
+			.errorMessage(errorMessage)
 			.build();
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -160,7 +160,17 @@ public class LinkFacade {
 
 	@Transactional(readOnly = true)
 	public SummaryStatusRes getSummaryStatus(Long id, Member member) {
-		SummaryStatus summaryStatus = linkService.getSummaryStatus(id, member);
+		LinkDto linkDto = linkService.getLinkWithSummary(id, member);
+		SummaryStatus summaryStatus = linkDto.link().getSummaryStatus();
+
+		if (summaryStatus == SummaryStatus.COMPLETED) {
+			return SummaryStatusRes.completed(id, SummaryRes.from(linkDto.summary()));
+		}
+
+		if (summaryStatus == SummaryStatus.FAILED) {
+			return SummaryStatusRes.failed(id, "요약 생성에 실패했습니다.");
+		}
+
 		return SummaryStatusRes.of(id, summaryStatus);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
@@ -135,7 +135,7 @@ class LinkEventListenerTest {
 		// 두 번째 이벤트 (FAILED)
 		assertThat(publishedEvents.get(1).email()).isEqualTo("fail@test.com");
 		assertThat(publishedEvents.get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(publishedEvents.get(1).response().data()).isEqualTo("요약 대기열 등록에 실패했습니다.");
+		assertThat(publishedEvents.get(1).response().errorMessage()).isEqualTo("요약 대기열 등록에 실패했습니다.");
 
 		// Facade를 통한 DB 상태 업데이트가 호출되었는지 검증
 		verify(summaryWorkerFacade, times(1)).updateSummaryStatus(2L, SummaryStatus.FAILED);

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -563,7 +563,12 @@ class LinkFacadeTest {
 		// given
 		Member member = mock(Member.class);
 		Long linkId = 123L;
-		given(linkService.getSummaryStatus(linkId, member)).willReturn(SummaryStatus.COMPLETED);
+		Link link = mock(Link.class);
+		Summary summary = mock(Summary.class);
+		given(link.getSummaryStatus()).willReturn(SummaryStatus.COMPLETED);
+		given(summary.getId()).willReturn(1L);
+		given(summary.getContent()).willReturn("요약 내용");
+		given(linkService.getLinkWithSummary(linkId, member)).willReturn(new LinkDto(link, summary));
 
 		// when
 		SummaryStatusRes result = linkFacade.getSummaryStatus(linkId, member);
@@ -572,6 +577,7 @@ class LinkFacadeTest {
 		assertThat(result).isNotNull();
 		assertThat(result.linkId()).isEqualTo(linkId);
 		assertThat(result.status()).isEqualTo(SummaryStatus.COMPLETED);
-		verify(linkService, times(1)).getSummaryStatus(linkId, member);
+		assertThat(result.summary()).isEqualTo(new SummaryRes(1L, "요약 내용"));
+		verify(linkService, times(1)).getLinkWithSummary(linkId, member);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -287,9 +287,7 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
-			.extracting(data -> (String)data)
-			.asString()
+		assertThat(captor.getAllValues().get(1).response().errorMessage())
 			.contains("Retry limit exceeded");
 	}
 
@@ -316,9 +314,7 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
-			.extracting(data -> (String)data)
-			.asString()
+		assertThat(captor.getAllValues().get(1).response().errorMessage())
 			.contains("Retry limit exceeded");
 	}
 
@@ -394,9 +390,7 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
-		assertThat(captor.getAllValues().get(1).response().data()).isInstanceOf(String.class)
-			.extracting(data -> (String)data)
-			.asString()
+		assertThat(captor.getAllValues().get(1).response().errorMessage())
 			.contains("Retry limit exceeded");
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #224

## PR 설명
- `link.summaryStatus`를 요약 상태의 기준값으로 사용하도록, 링크 관련 응답 계약을 정리했습니다.
- 프런트가 초기 렌더에서 failed/generating/ready 상태를 안정적으로 복원할 수 있도록 필요한 상태 정보를 응답에 포함합니다.

## Changes
- `LinkCardRes`, `LinkDetailRes`, `LinkRes`에 `summaryStatus` 추가
- `/summary-status` 응답을 `status + summary + errorMessage` 구조로 정리
- `COMPLETED`일 때는 summary 포함
- `FAILED`일 때는 error message 포함
- websocket payload 문서 예시를 새 응답 구조에 맞게 수정
- 관련 이벤트/워커 테스트를 새 필드 구조에 맞게 수정

## Notes
- 이 변경은 프런트의 summary 상태 렌더링 정리 PR과 짝으로 반영되어야 합니다.
- 목적은 `summary` 존재 여부가 아니라 `link.summaryStatus`를 상태 판단의 source of truth로 일관화하는 것입니다.

