### PR TITLE
Prometheus + Grafana 모니터링 구성 추가

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -78,29 +78,10 @@ jobs:
       - name: ✨ Checkout repository
         uses: actions/checkout@v5
 
-      - name: 🗂️ Make monitoring config
+      - name: 🗂️ Grafana 환경변수 설정
         run: |
-          # Prometheus 설정
-          mkdir -p ./docker
-          echo "$PROMETHEUS_YML" > ./docker/prometheus.yml
-
-          # Grafana provisioning 설정
-          mkdir -p ./docker/grafana/provisioning/datasources
-          mkdir -p ./docker/grafana/provisioning/dashboards
-          mkdir -p ./docker/grafana/dashboards
-
-          echo "$GRAFANA_DATASOURCE_YML" > ./docker/grafana/provisioning/datasources/prometheus.yml
-          echo "$GRAFANA_DASHBOARD_PROVIDER_YML" > ./docker/grafana/provisioning/dashboards/dashboards.yml
-          echo "$GRAFANA_DASHBOARD_JSON" > ./docker/grafana/dashboards/http-overview.json
-
-          # Grafana 환경변수
-          echo "$DOCKER_ENV" > ./docker/.env
-        env:
-          PROMETHEUS_YML: ${{ secrets.PROMETHEUS_YML }}
-          GRAFANA_DATASOURCE_YML: ${{ secrets.GRAFANA_DATASOURCE_YML }}
-          GRAFANA_DASHBOARD_PROVIDER_YML: ${{ secrets.GRAFANA_DASHBOARD_PROVIDER_YML }}
-          GRAFANA_DASHBOARD_JSON: ${{ secrets.GRAFANA_DASHBOARD_JSON }}
-          DOCKER_ENV: ${{ secrets.DOCKER_ENV }}
+          echo "GRAFANA_ADMIN_USER=admin" > ./docker/.env
+          echo "GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> ./docker/.env
         shell: bash
 
       - name: ✨ 배포 스크립트 실행

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -78,6 +78,31 @@ jobs:
       - name: ✨ Checkout repository
         uses: actions/checkout@v5
 
+      - name: 🗂️ Make monitoring config
+        run: |
+          # Prometheus 설정
+          mkdir -p ./docker
+          echo "$PROMETHEUS_YML" > ./docker/prometheus.yml
+
+          # Grafana provisioning 설정
+          mkdir -p ./docker/grafana/provisioning/datasources
+          mkdir -p ./docker/grafana/provisioning/dashboards
+          mkdir -p ./docker/grafana/dashboards
+
+          echo "$GRAFANA_DATASOURCE_YML" > ./docker/grafana/provisioning/datasources/prometheus.yml
+          echo "$GRAFANA_DASHBOARD_PROVIDER_YML" > ./docker/grafana/provisioning/dashboards/dashboards.yml
+          echo "$GRAFANA_DASHBOARD_JSON" > ./docker/grafana/dashboards/http-overview.json
+
+          # Grafana 환경변수
+          echo "$DOCKER_ENV" > ./docker/.env
+        env:
+          PROMETHEUS_YML: ${{ secrets.PROMETHEUS_YML }}
+          GRAFANA_DATASOURCE_YML: ${{ secrets.GRAFANA_DATASOURCE_YML }}
+          GRAFANA_DASHBOARD_PROVIDER_YML: ${{ secrets.GRAFANA_DASHBOARD_PROVIDER_YML }}
+          GRAFANA_DASHBOARD_JSON: ${{ secrets.GRAFANA_DASHBOARD_JSON }}
+          DOCKER_ENV: ${{ secrets.DOCKER_ENV }}
+        shell: bash
+
       - name: ✨ 배포 스크립트 실행
         run: |
           chmod +x deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,6 @@ out/
 
 ### Spring
 *.yml
+!docker/prometheus.yml
+!docker/grafana/**/*.yml
 .editorconfig
-
-### Environment
-.env
-docker/.env
-docker/prometheus.yml
-docker/grafana/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ out/
 ### Spring
 *.yml
 .editorconfig
+
+### Environment
+.env
+docker/.env
+docker/prometheus.yml
+docker/grafana/

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,19 @@ if ! ${COMPOSE} pull; then
 fi
 echo "✅ 새로운 이미지가 성공적으로 pull되었습니다."
 
+# Prometheus & Grafana 실행 (이미 실행 중이면 스킵)
+echo "모니터링 서비스 확인 중..."
+PROMETHEUS_RUNNING=$(sudo docker ps --filter "name=prometheus" --filter "status=running" -q)
+GRAFANA_RUNNING=$(sudo docker ps --filter "name=grafana" --filter "status=running" -q)
+
+if [ -z "$PROMETHEUS_RUNNING" ] || [ -z "$GRAFANA_RUNNING" ]; then
+    echo "모니터링 서비스 시작 중..."
+    ${COMPOSE} up -d prometheus grafana
+    echo "✅ Prometheus & Grafana가 시작되었습니다."
+else
+    echo "✅ 모니터링 서비스가 이미 실행 중입니다."
+fi
+
 echo "사용하지 않는 이미지 정리 중..."
 sudo docker image prune -f
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,18 +32,10 @@ if ! ${COMPOSE} pull; then
 fi
 echo "✅ 새로운 이미지가 성공적으로 pull되었습니다."
 
-# Prometheus & Grafana 실행 (이미 실행 중이면 스킵)
-echo "모니터링 서비스 확인 중..."
-PROMETHEUS_RUNNING=$(sudo docker ps --filter "name=prometheus" --filter "status=running" -q)
-GRAFANA_RUNNING=$(sudo docker ps --filter "name=grafana" --filter "status=running" -q)
-
-if [ -z "$PROMETHEUS_RUNNING" ] || [ -z "$GRAFANA_RUNNING" ]; then
-    echo "모니터링 서비스 시작 중..."
-    ${COMPOSE} up -d prometheus grafana
-    echo "✅ Prometheus & Grafana가 시작되었습니다."
-else
-    echo "✅ 모니터링 서비스가 이미 실행 중입니다."
-fi
+# Prometheus & Grafana 실행 (설정 변경 시 자동 반영)
+echo "모니터링 서비스 시작 중..."
+${COMPOSE} up -d prometheus grafana
+echo "✅ Prometheus & Grafana가 시작되었습니다."
 
 echo "사용하지 않는 이미지 정리 중..."
 sudo docker image prune -f

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,4 @@
 # docker-compose.yml
-version: '3.8'
-
 services:
   blue:
     image: linkivingsofa/core:latest
@@ -63,8 +61,6 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=3d'
       - '--web.enable-lifecycle'
-    ports:
-      - '9090:9090'
     restart: unless-stopped
     networks:
       - app-network

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,6 +52,64 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=3d'
+      - '--web.enable-lifecycle'
+    ports:
+      - '9090:9090'
+    restart: unless-stopped
+    networks:
+      - app-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - '3001:3000'
+    restart: unless-stopped
+    networks:
+      - app-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    depends_on:
+      - prometheus
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
 networks:
   app-network:
     driver: bridge

--- a/docker/grafana/dashboards/http-overview.json
+++ b/docker/grafana/dashboards/http-overview.json
@@ -1,0 +1,457 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m]))",
+          "legendFormat": "Total RPS",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\", status=~\"5..\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) * 100",
+          "legendFormat": "5xx Error Rate",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\", status=~\"4..\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) * 100",
+          "legendFormat": "4xx Error Rate",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Error Rate (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Response Time (Percentiles)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "2.."
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "4.."
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "5.."
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests by Status Code",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["http", "spring-boot"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "Linkiving HTTP Overview",
+  "uid": "linkiving-http-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/dashboards/http-overview.json
+++ b/docker/grafana/dashboards/http-overview.json
@@ -436,6 +436,184 @@
       ],
       "title": "HTTP Requests by Status Code",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, avg(rate(http_server_requests_seconds_sum{application=\"linkiving-core\"}[1m])) by (uri) / avg(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) by (uri))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Slowest Endpoints (Avg Response Time)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) by (uri))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Most Requested Endpoints",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/docker/grafana/dashboards/http-overview.json
+++ b/docker/grafana/dashboards/http-overview.json
@@ -11,7 +11,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -87,7 +87,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m]))",
           "legendFormat": "Total RPS",
@@ -100,7 +100,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -176,7 +176,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\", status=~\"5..\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) * 100",
           "legendFormat": "5xx Error Rate",
@@ -185,7 +185,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\", status=~\"4..\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) * 100",
           "legendFormat": "4xx Error Rate",
@@ -198,7 +198,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -274,7 +274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
           "legendFormat": "p50",
@@ -283,7 +283,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
           "legendFormat": "p95",
@@ -292,7 +292,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{application=\"linkiving-core\"}[1m])) by (le))",
           "legendFormat": "p99",
@@ -305,7 +305,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -427,7 +427,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(http_server_requests_seconds_count{application=\"linkiving-core\"}[1m])) by (status)",
           "legendFormat": "{{status}}",

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -5,5 +5,6 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+    uid: prometheus
     isDefault: true
     editable: false

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: 'linkiving-core'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets:
+          - 'blue:8080'
+          - 'green:8080'
+        labels:
+          application: 'linkiving-core'

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -6,7 +6,8 @@ public abstract class SecurityConstants {
 		"/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources", "/swagger-resources/**",
 
 		/* actuator */
-		"/actuator/prometheus", "/actuator/health",
+		"/actuator/health",
+		"/actuator/prometheus",
 
 		/* health check */
 		"/health-check",

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -5,6 +5,9 @@ public abstract class SecurityConstants {
 		/* swagger */
 		"/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources", "/swagger-resources/**",
 
+		/* actuator */
+		"/actuator/prometheus", "/actuator/health",
+
 		/* health check */
 		"/health-check",
 


### PR DESCRIPTION
## 관련 이슈

- close #226

## PR 설명
- Prometheus + Grafana 기반 HTTP 모니터링 시스템 구축
- EC2 리소스 절약을 위해 HTTP 메트릭만 수집 (JVM/시스템 메트릭 비활성화)

## 구현 내용

### 수집 메트릭
- HTTP Request Rate: 초당 요청 수 추이
- HTTP Error Rate: 4xx/5xx 에러율 (%)
- HTTP Response Time: 응답 시간 백분위수 (p50, p95, p99)
- Requests by Status Code: 상태 코드별 분포
- **Top 10 Slowest Endpoints: 가장 느린 API 10개**
- **Top 10 Most Requested Endpoints: 가장 많이 호출되는 API 10개**

### 리소스 설정
- Prometheus/Grafana 각 메모리 256MB 제한
- 메트릭 스크래핑 간격: 30초
- 데이터 보존 기간: 3일

### Grafana 대시보드
- HTTP Request Rate: 초당 요청 수 추이
- HTTP Error Rate: 4xx/5xx 에러율 (%)
- HTTP Response Time: 응답 시간 백분위수
- Requests by Status Code: 상태 코드별 분포

### 배포 준비 완료 작업
- GitHub Secrets에 GRAFANA_ADMIN_PASSWORD 추가
- GitHub Secrets의 APPLICATION에 management 설정 추가
- EC2 보안그룹에서 3001 포트 오픈

## 접속 방법
1. PR 머지 → CD 자동 실행 → 배포 완료
2. 접속 URL:
   - Grafana: http://(EC2-IP):3001
3. Grafana 로그인: admin / 노션 참조
4. 좌측 메뉴 → Dashboards → Linkiving HTTP Overview 선택

<img width="2336" height="1414" alt="image" src="https://github.com/user-attachments/assets/6c8ff8ca-7017-41d4-9e05-f827aec0f499" />