### PR TITLE
API 식별자 난독화를 위한 Hashids 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
     //Event
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'
+
+    //Encryption
+    implementation 'org.hashids:hashids:1.0.3'
 }
 
 dependencyManagement {

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatApi.java
@@ -66,9 +66,10 @@ public interface ChatApi {
 	@Operation(summary = "채팅 기록 조회", description = "채팅 기록을 최신순으로 조회합니다. 무한 스크롤 방식으로 제공됩니다.")
 	BaseResponse<MessagesRes> getMessages(
 		Member member,
-		@Parameter(description = "채팅방 ID") Long chatId,
-		@Parameter(description = "페이징을 위한 마지막 메시지 ID, 첫 조회 시 null") Long lastId,
-
+		@Parameter(description = "채팅방 ID")
+		Long chatId,
+		@Parameter(description = "페이징을 위한 마지막 메시지 ID, 첫 조회 시 null")
+		Long lastId,
 		@Parameter(description = "페이지 크기")
 		@Min(value = 1, message = "최소 1개 이상 조회해야 합니다.")
 		@Max(value = 50, message = "한 번에 최대 50개까지만 조회할 수 있습니다.")
@@ -85,7 +86,7 @@ public interface ChatApi {
 	);
 
 	@Operation(summary = "링크 삭제", description = "해당 링크방과 채팅 기록을 전부 Hard Delete 진행합니다.")
-	BaseResponse<String> deleteChat(Member member, Long chatId);
+	BaseResponse<String> deleteChat(Member member, @Parameter(description = "채팅방 ID") Long chatId);
 
 	void sendMessage(AnswerReq req, Member member);
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
@@ -20,6 +20,7 @@ import com.sofa.linkiving.domain.chat.dto.response.MessagesRes;
 import com.sofa.linkiving.domain.chat.facade.ChatFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
 import com.sofa.linkiving.security.annotation.AuthMember;
 
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class ChatController implements ChatApi {
 
 	@Override
 	@DeleteMapping("/{chatId}")
-	public BaseResponse<String> deleteChat(@AuthMember Member member, @PathVariable Long chatId) {
+	public BaseResponse<String> deleteChat(@AuthMember Member member, @PathVariable @DecodeHash Long chatId) {
 		chatFacade.deleteChat(member, chatId);
 		return BaseResponse.noContent("성공적으로 삭제했습니다.");
 	}
@@ -67,8 +68,8 @@ public class ChatController implements ChatApi {
 	@GetMapping("/{chatId}")
 	public BaseResponse<MessagesRes> getMessages(
 		@AuthMember Member member,
-		@PathVariable Long chatId,
-		@RequestParam(required = false) Long lastId,
+		@PathVariable @DecodeHash Long chatId,
+		@RequestParam(required = false) @DecodeHash Long lastId,
 		@RequestParam(defaultValue = "20") int size
 	) {
 		MessagesRes res = chatFacade.getMessages(member, chatId, lastId, size);

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackApi.java
@@ -6,10 +6,13 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Feedback", description = "피드백 관리 API")
 public interface FeedbackApi {
 	@Operation(summary = "피드백 추가 및 수정", description = "메세지에 피드백을 추가 및 수정하고 피드백 ID를 반환합니다.")
-	BaseResponse<UpsertFeedbackRes> upsertFeedback(Long messageId, UpsertFeedbackReq createFeedbackReq, Member member);
+	BaseResponse<UpsertFeedbackRes> upsertFeedback(@Parameter(description = "메세지 ID") Long messageId,
+		UpsertFeedbackReq createFeedbackReq,
+		Member member);
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/FeedbackController.java
@@ -11,6 +11,7 @@ import com.sofa.linkiving.domain.chat.dto.response.UpsertFeedbackRes;
 import com.sofa.linkiving.domain.chat.facade.FeedbackFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
 import com.sofa.linkiving.security.annotation.AuthMember;
 
 import jakarta.validation.Valid;
@@ -25,7 +26,7 @@ public class FeedbackController implements FeedbackApi {
 	@Override
 	@PutMapping("/{messageId}/feedback")
 	public BaseResponse<UpsertFeedbackRes> upsertFeedback(
-		@PathVariable Long messageId,
+		@PathVariable @DecodeHash Long messageId,
 		@Valid @RequestBody UpsertFeedbackReq req,
 		@AuthMember Member member
 	) {

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerCancelReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerCancelReq.java
@@ -1,9 +1,13 @@
 package com.sofa.linkiving.domain.chat.dto.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sofa.linkiving.global.config.jackson.HashidsDeserializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AnswerCancelReq(
 	@Schema(description = "채팅방 ID")
+	@JsonDeserialize(using = HashidsDeserializer.class)
 	Long chatId
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
@@ -1,9 +1,13 @@
 package com.sofa.linkiving.domain.chat.dto.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sofa.linkiving.global.config.jackson.HashidsDeserializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AnswerReq(
 	@Schema(description = "채팅방 ID")
+	@JsonDeserialize(using = HashidsDeserializer.class)
 	Long chatId,
 	@Schema(description = "유저 질문 내용")
 	String message

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
@@ -2,9 +2,11 @@ package com.sofa.linkiving.domain.chat.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.dto.response.LinkCardRes;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,8 +14,10 @@ public record AnswerRes(
 	@Schema(description = "성공 여부")
 	Boolean success,
 	@Schema(description = "채팅방 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long chatId,
 	@Schema(description = "메세지 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long messageId,
 	@Schema(description = "답변 내용")
 	String content,

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/ChatsRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/ChatsRes.java
@@ -2,7 +2,9 @@ package com.sofa.linkiving.domain.chat.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -20,6 +22,7 @@ public record ChatsRes(
 
 	public record ChatSummary(
 		@Schema(description = "채팅방 Id")
+		@JsonSerialize(using = HashidsSerializer.class)
 		Long id,
 		@Schema(description = "채팅방 제목")
 		String title

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/CreateChatRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/CreateChatRes.java
@@ -1,6 +1,8 @@
 package com.sofa.linkiving.domain.chat.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.entity.Chat;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -8,6 +10,7 @@ import lombok.Builder;
 @Builder
 public record CreateChatRes(
 	@Schema(description = "채팅방 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 	@Schema(description = "채팅방 제목")
 	String title,

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessageRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessageRes.java
@@ -5,16 +5,19 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.dto.internal.MessageDto;
 import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.chat.enums.Sentiment;
 import com.sofa.linkiving.domain.chat.enums.Type;
 import com.sofa.linkiving.domain.link.dto.response.LinkCardRes;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MessageRes(
 	@Schema(description = "메시지 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 
 	@Schema(description = "메시지 내용")

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessagesRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessagesRes.java
@@ -3,7 +3,9 @@ package com.sofa.linkiving.domain.chat.dto.response;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.dto.internal.MessageDto;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -15,6 +17,7 @@ public record MessagesRes(
 	boolean hasNext,
 
 	@Schema(description = "마지막 메시지 ID (다음 요청 커서용)")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long lastId
 ) {
 	public static MessagesRes of(List<MessageDto> messageDtos, boolean hasNext) {

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/UpsertFeedbackRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/UpsertFeedbackRes.java
@@ -1,9 +1,13 @@
 package com.sofa.linkiving.domain.chat.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UpsertFeedbackRes(
 	@Schema(description = "피드백 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkApi.java
@@ -38,6 +38,8 @@ import jakarta.validation.constraints.Min;
 			**CASE A: PROCESSING (처리 중)**
 				```json
 				{
+					"linkId": aB9x2K8R,
+					"status": "PROCESSING"
 					"linkId": 1,
 					"status": "PROCESSING",
 					"summary": null,
@@ -48,10 +50,10 @@ import jakarta.validation.constraints.Min;
 		**CASE B: COMPLETED (요약 완료)**
 				```json
 				{
-					"linkId": 1,
+					"linkId": aB9x2K8R,
 					"status": "COMPLETED",
 					"summary": {
-						"id": 100,
+						"id": aB9x2K8S,
 						"content": "생성된 AI 요약 내용입니다."
 					},
 					"errorMessage": null
@@ -60,7 +62,7 @@ import jakarta.validation.constraints.Min;
 		**CASE C: FAILED (요약 실패)**
 				```json
 				{
-					"linkId": 1,
+					"linkId": aB9x2K8R,
 					"status": "FAILED",
 					"summary": null,
 					"errorMessage": "AI 서버 응답이 없습니다."

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -30,6 +30,7 @@ import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.facade.LinkFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
 import com.sofa.linkiving.security.annotation.AuthMember;
 
 import lombok.RequiredArgsConstructor;
@@ -80,7 +81,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PutMapping("/{id}")
 	public BaseResponse<LinkRes> updateLink(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@RequestBody LinkUpdateReq request,
 		@AuthMember Member member
 	) {
@@ -97,7 +98,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@DeleteMapping("/{id}")
 	public BaseResponse<Void> deleteLink(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@AuthMember Member member
 	) {
 		linkFacade.deleteLink(id, member);
@@ -107,7 +108,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@GetMapping("/{id}")
 	public BaseResponse<LinkDetailRes> getLink(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@AuthMember Member member
 	) {
 		LinkDetailRes response = linkFacade.getLinkDetail(id, member);
@@ -118,7 +119,7 @@ public class LinkController implements LinkApi {
 	@GetMapping
 	public BaseResponse<LinkCardsRes> getLinkList(
 		@AuthMember Member member,
-		@RequestParam(required = false) Long lastId,
+		@RequestParam(required = false) @DecodeHash Long lastId,
 		@RequestParam(defaultValue = "20") int size
 	) {
 		LinkCardsRes response = linkFacade.getLinkCards(member, lastId, size);
@@ -128,7 +129,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PatchMapping("/{id}/title")
 	public BaseResponse<LinkRes> updateTitle(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@RequestBody LinkTitleUpdateReq request,
 		@AuthMember Member member
 	) {
@@ -139,7 +140,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PatchMapping("/{id}/memo")
 	public BaseResponse<LinkRes> updateMemo(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@RequestBody LinkMemoUpdateReq request,
 		@AuthMember Member member
 	) {
@@ -150,7 +151,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PostMapping("/{id}/summary")
 	public BaseResponse<RegenerateSummaryRes> recreateSummary(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@RequestBody RegenerateSummaryReq req,
 		@AuthMember Member member
 	) {
@@ -161,7 +162,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PatchMapping("/{id}/summary")
 	public BaseResponse<SummaryRes> updateSummary(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@RequestBody SummaryUpdateReq request,
 		@AuthMember Member member
 	) {
@@ -179,7 +180,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@PostMapping("/{id}/retry-summary")
 	public BaseResponse<Void> retrySummary(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@AuthMember Member member
 	) {
 		linkFacade.retrySummary(id, member);
@@ -189,7 +190,7 @@ public class LinkController implements LinkApi {
 	@Override
 	@GetMapping("/{id}/summary-status")
 	public BaseResponse<SummaryStatusRes> getSummaryStatus(
-		@PathVariable Long id,
+		@PathVariable @DecodeHash Long id,
 		@AuthMember Member member
 	) {
 		SummaryStatusRes response = linkFacade.getSummaryStatus(id, member);

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardRes.java
@@ -1,14 +1,17 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LinkCardRes(
 	@Schema(description = "링크 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 
 	@Schema(description = "링크 URL", example = "https://example.com")

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardsRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkCardsRes.java
@@ -2,7 +2,9 @@ package com.sofa.linkiving.domain.link.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.dto.internal.LinksDto;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,6 +14,7 @@ public record LinkCardsRes(
 	@Schema(description = "다음 페이지 존재 여부")
 	boolean hasNext,
 	@Schema(description = "마지막 메시지 ID (다음 요청 커서용)")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long lastId
 ) {
 	public static LinkCardsRes of(LinksDto linksDto) {

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDetailRes.java
@@ -1,14 +1,17 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LinkDetailRes(
 	@Schema(description = "링크 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 
 	@Schema(description = "링크 URL", example = "https://example.com")

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDuplicateCheckRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkDuplicateCheckRes.java
@@ -1,12 +1,16 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LinkDuplicateCheckRes(
 	@Schema(description = "URL 중복 여부", example = "true")
 	boolean exists,
 
-	@Schema(description = "중복된 링크 ID (exists가 true일 때만 반환)", example = "123")
+	@Schema(description = "중복된 링크 ID (exists가 true일 때만 반환)")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long linkId
 ) {
 	public static LinkDuplicateCheckRes notExists() {

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/LinkRes.java
@@ -1,12 +1,15 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LinkRes(
 	@Schema(description = "링크 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 
 	@Schema(description = "링크 URL", example = "https://example.com")

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryRes.java
@@ -1,11 +1,14 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.entity.Summary;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SummaryRes(
 	@Schema(description = "요약 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 	@Schema(description = "요약 내용", example = "이 링크는 예시 링크입니다.")
 	String content

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryStatusRes.java
@@ -1,6 +1,8 @@
 package com.sofa.linkiving.domain.link.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -8,6 +10,7 @@ import lombok.Builder;
 @Builder
 public record SummaryStatusRes(
 	@Schema(description = "링크 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long linkId,
 	@Schema(description = "요약 진행 상태:PENDING(큐 대기 중), PROCESSING(요약 진행 중), COMPLETED(완료), FAILED(생성 실패)")
 	SummaryStatus status,

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberProfileRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/response/MemberProfileRes.java
@@ -2,14 +2,17 @@ package com.sofa.linkiving.domain.member.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.config.jackson.HashidsSerializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record MemberProfileRes(
-	@Schema(description = "회원 ID", example = "1")
+	@Schema(description = "회원 ID")
+	@JsonSerialize(using = HashidsSerializer.class)
 	Long id,
 	@Schema(description = "유저명", example = "Linkiving User")
 	String name,

--- a/src/main/java/com/sofa/linkiving/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/SwaggerConfig.java
@@ -1,0 +1,70 @@
+package com.sofa.linkiving.global.config;
+
+import org.springdoc.core.customizers.ParameterCustomizer;
+import org.springdoc.core.customizers.PropertyCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
+
+import io.swagger.v3.oas.models.media.StringSchema;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public ParameterCustomizer hashidParameterCustomizer() {
+		return (parameterModel, methodParameter) -> {
+			if (methodParameter.hasParameterAnnotation(DecodeHash.class)) {
+				parameterModel.setSchema(new StringSchema());
+				parameterModel.setExample("aB9x2K8R");
+				String currentDesc = parameterModel.getDescription() != null ? parameterModel.getDescription() : "";
+				if (!currentDesc.contains("해시")) {
+					parameterModel.setDescription(currentDesc + " (해시 문자열)");
+				}
+			}
+			return parameterModel;
+		};
+	}
+
+	@Bean
+	public PropertyCustomizer hashidPropertyCustomizer() {
+		return (property, type) -> {
+			if (type.getCtxAnnotations() == null) {
+				return property;
+			}
+
+			boolean isHashidField = false;
+
+			for (java.lang.annotation.Annotation annotation : type.getCtxAnnotations()) {
+
+				if (annotation instanceof JsonSerialize serialize) {
+					if (serialize.using().getSimpleName().contains("Hashids")) {
+						isHashidField = true;
+						break;
+					}
+				} else if (annotation instanceof JsonDeserialize deserialize) {
+					if (deserialize.using().getSimpleName().contains("Hashids")) {
+						isHashidField = true;
+						break;
+					}
+				}
+			}
+
+			if (isHashidField) {
+				property.setType("string");
+				property.setFormat(null);
+				property.setExample("aB9x2K8R");
+
+				String desc = property.getDescription() != null ? property.getDescription() : "";
+				if (!desc.contains("해시")) {
+					property.setDescription(desc + " (해시된 문자열)");
+				}
+			}
+
+			return property;
+		};
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/annotation/DecodeHash.java
+++ b/src/main/java/com/sofa/linkiving/global/config/annotation/DecodeHash.java
@@ -1,0 +1,11 @@
+package com.sofa.linkiving.global.config.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DecodeHash {
+}

--- a/src/main/java/com/sofa/linkiving/global/config/jackson/HashidsDeserializer.java
+++ b/src/main/java/com/sofa/linkiving/global/config/jackson/HashidsDeserializer.java
@@ -1,0 +1,31 @@
+package com.sofa.linkiving.global.config.jackson;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+@Component
+public class HashidsDeserializer extends JsonDeserializer<Long> {
+
+	private static HashidsUtils hashidsUtils;
+
+	@Autowired
+	public void setHashidsUtils(HashidsUtils hashidsUtils) {
+		HashidsDeserializer.hashidsUtils = hashidsUtils;
+	}
+
+	@Override
+	public Long deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+		String hash = parser.getValueAsString();
+		if (hash == null || hash.isBlank()) {
+			return null;
+		}
+		return hashidsUtils.decode(hash);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/jackson/HashidsSerializer.java
+++ b/src/main/java/com/sofa/linkiving/global/config/jackson/HashidsSerializer.java
@@ -1,0 +1,30 @@
+package com.sofa.linkiving.global.config.jackson;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+@Component
+public class HashidsSerializer extends JsonSerializer<Long> {
+	private static HashidsUtils hashidsUtils;
+
+	@Autowired
+	public void setHashidsUtils(HashidsUtils hashidsUtils) {
+		HashidsSerializer.hashidsUtils = hashidsUtils;
+	}
+
+	@Override
+	public void serialize(Long value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		if (value == null) {
+			gen.writeNull();
+		} else {
+			gen.writeString(hashidsUtils.encode(value));
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/web/DecodeHashInterceptor.java
+++ b/src/main/java/com/sofa/linkiving/global/config/web/DecodeHashInterceptor.java
@@ -1,0 +1,88 @@
+package com.sofa.linkiving.global.config.web;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DecodeHashInterceptor implements HandlerInterceptor {
+
+	private final HashidsUtils hashidsUtils;
+
+	@Override
+	public boolean preHandle(@Nonnull HttpServletRequest request, @Nonnull HttpServletResponse response,
+		@Nonnull Object handler) {
+		if (!(handler instanceof HandlerMethod handlerMethod)) {
+			return true;
+		}
+
+		Object attribute = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+		Map<String, String> pathVars = new HashMap<>();
+
+		if (attribute instanceof Map<?, ?> map) {
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				if (entry.getKey() instanceof String key && entry.getValue() instanceof String value) {
+					pathVars.put(key, value);
+				}
+			}
+		}
+
+		Method specificMethod = ClassUtils.getMostSpecificMethod(handlerMethod.getMethod(),
+			handlerMethod.getBeanType());
+
+		for (Parameter param : specificMethod.getParameters()) {
+
+			if (param.isAnnotationPresent(DecodeHash.class)) {
+				String rawValue = null;
+
+				if (param.isAnnotationPresent(PathVariable.class)) {
+					PathVariable pv = param.getAnnotation(PathVariable.class);
+					String name = StringUtils.hasText(pv.value()) ? pv.value() : pv.name();
+					if (!StringUtils.hasText(name)) {
+						name = param.getName();
+					}
+
+					if (name != null) {
+						rawValue = pathVars.get(name);
+					}
+				} else if (param.isAnnotationPresent(RequestParam.class)) {
+					RequestParam rp = param.getAnnotation(RequestParam.class);
+					String name = StringUtils.hasText(rp.value()) ? rp.value() : rp.name();
+					if (!StringUtils.hasText(name)) {
+						name = param.getName();
+					}
+
+					if (name != null) {
+						rawValue = request.getParameter(name);
+					}
+				}
+
+				if (StringUtils.hasText(rawValue)) {
+					hashidsUtils.decode(rawValue);
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/web/HashidsFormatterFactory.java
+++ b/src/main/java/com/sofa/linkiving/global/config/web/HashidsFormatterFactory.java
@@ -1,0 +1,39 @@
+package com.sofa.linkiving.global.config.web;
+
+import java.util.Set;
+
+import org.springframework.format.AnnotationFormatterFactory;
+import org.springframework.format.Parser;
+import org.springframework.format.Printer;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class HashidsFormatterFactory implements AnnotationFormatterFactory<DecodeHash> {
+
+	private final HashidsUtils hashidsUtils;
+
+	@Nonnull
+	@Override
+	public Set<Class<?>> getFieldTypes() {
+		return Set.of(Long.class);
+	}
+
+	@Nonnull
+	@Override
+	public Parser<?> getParser(@Nonnull DecodeHash annotation, @Nonnull Class<?> fieldType) {
+		return (Parser<Long>)(text, locale) -> hashidsUtils.decode(text);
+	}
+
+	@Nonnull
+	@Override
+	public Printer<?> getPrinter(@Nonnull DecodeHash annotation, @Nonnull Class<?> fieldType) {
+		return (Printer<Long>)(object, locale) -> hashidsUtils.encode(object);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/web/WebMvcConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/web/WebMvcConfig.java
@@ -1,12 +1,14 @@
-package com.sofa.linkiving.global.config;
+package com.sofa.linkiving.global.config.web;
 
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.sofa.linkiving.security.resolver.AuthMemberArgumentResolver;
@@ -18,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class WebMvcConfig implements WebMvcConfigurer {
 
 	private final AuthMemberArgumentResolver authMemberArgumentResolver;
+	private final HashidsFormatterFactory hashidsFormatterFactory;
+	private final DecodeHashInterceptor decodeHashInterceptor;
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -37,5 +41,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		executor.setThreadNamePrefix("mvc-async-");
 		executor.initialize();
 		return executor;
+	}
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addFormatterForFieldAnnotation(hashidsFormatterFactory);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(decodeHashInterceptor);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/web/WebSocketConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/web/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package com.sofa.linkiving.global.config;
+package com.sofa.linkiving.global.config.web;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/sofa/linkiving/global/error/code/CommonErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/global/error/code/CommonErrorCode.java
@@ -19,7 +19,8 @@ public enum CommonErrorCode implements ErrorCode {
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C-007", "허용되지 않은 HTTP 메소드입니다."),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "C-008", "접근이 허용되지 않았습니다."),
 	NULL_POINTER(HttpStatus.INTERNAL_SERVER_ERROR, "C-009", "NullPointerException이 발생했습니다."),
-	HTTP_MEDIA_NOT_SUPPORT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "C-010", "지원하지 않는 미디어입니다.");
+	HTTP_MEDIA_NOT_SUPPORT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "C-010", "지원하지 않는 미디어입니다."),
+	INVALID_IDENTIFIER(HttpStatus.BAD_REQUEST, "C-011", "유효하지 않은 식별자입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/global/util/HashidsUtils.java
+++ b/src/main/java/com/sofa/linkiving/global/util/HashidsUtils.java
@@ -1,0 +1,40 @@
+package com.sofa.linkiving.global.util;
+
+import org.hashids.Hashids;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.global.error.code.CommonErrorCode;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+@Component
+public class HashidsUtils {
+	private final Hashids hashids;
+
+	public HashidsUtils(
+		@Value("${hashids.salt}") String salt,
+		@Value("${hashids.min-length:8}") int minLength) {
+		this.hashids = new Hashids(salt, minLength);
+	}
+
+	public String encode(Long id) {
+		if (id == null) {
+			return null;
+		}
+
+		return hashids.encode(id);
+	}
+
+	public Long decode(String hash) {
+		if (hash == null || hash.isBlank()) {
+			return null;
+		}
+
+		long[] decoded = hashids.decode(hash);
+
+		if (decoded.length == 0) {
+			throw new BusinessException(CommonErrorCode.INVALID_IDENTIFIER);
+		}
+		return decoded[0];
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/ChatApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/ChatApiIntegrationTest.java
@@ -40,6 +40,7 @@ import com.sofa.linkiving.domain.link.repository.SummaryRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
@@ -77,6 +78,9 @@ public class ChatApiIntegrationTest {
 
 	@Autowired
 	private ChatFacade chatFacade;
+
+	@Autowired
+	private HashidsUtils hashidsUtils;
 
 	@MockitoBean
 	private RedisService redisService;
@@ -171,9 +175,10 @@ public class ChatApiIntegrationTest {
 	void shouldReturn400WhenSizeExceedsLimit() throws Exception {
 		// given
 		Long chatId = 1L;
+		String hashChatId = hashidsUtils.encode(chatId);
 
 		// when & then
-		mockMvc.perform(get(BASE_URL + "/{chatId}", chatId)
+		mockMvc.perform(get(BASE_URL + "/{chatId}", hashChatId)
 				.param("size", "100")
 				.with(user(testUserDetails)))
 			.andDo(print())
@@ -227,9 +232,10 @@ public class ChatApiIntegrationTest {
 			.build());
 
 		Long chatId = chat.getId();
+		String hashChatId = hashidsUtils.encode(chatId);
 
 		// when & then
-		mockMvc.perform(delete(BASE_URL + "/{chatId}", chatId)
+		mockMvc.perform(delete(BASE_URL + "/{chatId}", hashChatId)
 				.with(csrf())
 				.with(user(testUserDetails)))
 			.andDo(print())

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/FeedbackIntegrationTest.java
@@ -32,6 +32,7 @@ import com.sofa.linkiving.domain.chat.repository.MessageRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
@@ -59,6 +60,9 @@ class FeedbackIntegrationTest {
 
 	@Autowired
 	private FeedbackRepository feedbackRepository;
+
+	@Autowired
+	private HashidsUtils hashidsUtils;
 
 	@MockitoBean
 	private RedisService redisService;
@@ -91,10 +95,11 @@ class FeedbackIntegrationTest {
 	void shouldCreateNewFeedbackAndReturnOkWhenNoExistingFeedback() throws Exception {
 		// given
 		Long messageId = testMessage.getId();
+		String hashMessageId = hashidsUtils.encode(messageId);
 		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.LIKE, "매우 유용한 답변입니다.");
 
 		// when & then
-		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", hashMessageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -102,7 +107,7 @@ class FeedbackIntegrationTest {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.id").isNumber());
+			.andExpect(jsonPath("$.data.id").isString());
 
 		assertThat(feedbackRepository.count()).isEqualTo(1);
 		Feedback savedFeedback = feedbackRepository.findAll().get(0);
@@ -122,10 +127,11 @@ class FeedbackIntegrationTest {
 			.build());
 
 		Long messageId = testMessage.getId();
+		String hashMessageId = hashidsUtils.encode(messageId);
 		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.DISLIKE, "내용이 수정되었습니다.");
 
 		// when & then
-		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", hashMessageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -133,7 +139,7 @@ class FeedbackIntegrationTest {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.id").value(existingFeedback.getId()));
+			.andExpect(jsonPath("$.data.id").value(hashidsUtils.encode(existingFeedback.getId())));
 
 		assertThat(feedbackRepository.count()).isEqualTo(1);
 		Feedback updatedFeedback = feedbackRepository.findAll().get(0);
@@ -147,10 +153,11 @@ class FeedbackIntegrationTest {
 	void shouldReturnBadRequestWhenSentimentIsNull() throws Exception {
 		// given
 		Long messageId = testMessage.getId();
+		String hashMessageId = hashidsUtils.encode(messageId);
 		UpsertFeedbackReq req = new UpsertFeedbackReq(null, "내용만 있음");
 
 		// when & then
-		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", messageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", hashMessageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -164,10 +171,11 @@ class FeedbackIntegrationTest {
 	void shouldReturnNotFoundWhenMessageDoesNotExist() throws Exception {
 		// given
 		Long invalidMessageId = 99999L;
+		String hashInvalidMessageId = hashidsUtils.encode(invalidMessageId);
 		UpsertFeedbackReq req = new UpsertFeedbackReq(Sentiment.DISLIKE, "별로예요");
 
 		// when & then
-		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", invalidMessageId)
+		mockMvc.perform(put(BASE_URL + "/{messageId}/feedback", hashInvalidMessageId)
 				.with(csrf())
 				.with(user(testUserDetails))
 				.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
@@ -50,6 +50,7 @@ import com.sofa.linkiving.domain.link.repository.LinkRepository;
 import com.sofa.linkiving.domain.link.repository.SummaryRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 import com.sofa.linkiving.security.jwt.error.CustomJwtException;
@@ -85,6 +86,12 @@ public class WebSocketChatIntegrationTest {
 
 	@MockitoSpyBean
 	private JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	private HashidsUtils hashidsUtils;
+
+	@Autowired
+	private ObjectMapper objectMapper;
 
 	@MockitoBean
 	private AnswerClient answerClient;
@@ -126,7 +133,7 @@ public class WebSocketChatIntegrationTest {
 		WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(createTransportClient()));
 
 		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
-		converter.setObjectMapper(new ObjectMapper().registerModule(new JavaTimeModule()));
+		converter.setObjectMapper(objectMapper);
 		stompClient.setMessageConverter(converter);
 
 		this.blockingQueue = new LinkedBlockingQueue<>();
@@ -257,10 +264,11 @@ public class WebSocketChatIntegrationTest {
 	void shouldReceiveAnswerWhenMessageSent() throws InterruptedException {
 		// given
 		Long chatId = testChat.getId();
+		String hashedChatId = hashidsUtils.encode(chatId);
 		String userMessage = "Gemini에 대해 알려줘";
 
 		Map<String, Object> req = new HashMap<>();
-		req.put("chatId", chatId);
+		req.put("chatId", hashedChatId);
 		req.put("message", userMessage);
 
 		subscribeToChatQueue();
@@ -272,7 +280,8 @@ public class WebSocketChatIntegrationTest {
 		// then
 		Map<String, Object> received = blockingQueue.poll(10, SECONDS);
 
-		assertThat(received).isNotNull();
+		String receivedHashedChatId = String.valueOf(received.get("chatId"));
+		assertThat(hashidsUtils.decode(receivedHashedChatId)).isEqualTo(chatId);
 		assertThat(received.get("success")).isEqualTo(true);
 		assertThat(String.valueOf(received.get("content"))).contains("Gemini와 관련된 내용");
 	}
@@ -282,14 +291,16 @@ public class WebSocketChatIntegrationTest {
 	void shouldReceiveErrorMessageWhenCancelled() throws InterruptedException {
 		// given
 		Long chatId = testChat.getId();
+		String hashedChatId = hashidsUtils.encode(chatId);
 		String userMessage = "취소될 질문";
 
-		Map<String, Object> sendReq = new HashMap<>();
-		sendReq.put("chatId", chatId);
+		java.util.Map<String, Object> sendReq = new java.util.HashMap<>();
+		sendReq.put("chatId", hashedChatId);
 		sendReq.put("message", userMessage);
 
-		Map<String, Object> cancelReq = new HashMap<>();
-		cancelReq.put("chatId", chatId);
+		// 취소용 Map 구성
+		Map<String, Object> cancelReq = new java.util.HashMap<>();
+		cancelReq.put("chatId", hashedChatId);
 
 		given(answerClient.generateAnswer(any())).willAnswer(invocation -> {
 			Thread.sleep(1500);
@@ -309,8 +320,11 @@ public class WebSocketChatIntegrationTest {
 		Map<String, Object> received = blockingQueue.poll(10, SECONDS);
 
 		assertThat(received).isNotNull();
+
+		String receivedHashedChatId = String.valueOf(received.get("chatId"));
+		assertThat(hashidsUtils.decode(receivedHashedChatId)).isEqualTo(chatId);
+
 		assertThat(received.get("success")).isEqualTo(false);
 		assertThat(String.valueOf(received.get("content"))).isEqualTo(userMessage);
 	}
 }
-

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sofa.linkiving.domain.link.abstraction.ImageUploader;
-import com.sofa.linkiving.domain.link.ai.SummaryClient;
 import com.sofa.linkiving.domain.link.dto.request.LinkCreateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkMemoUpdateReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkTitleUpdateReq;
@@ -40,6 +39,7 @@ import com.sofa.linkiving.domain.link.repository.SummaryRepository;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
 @SpringBootTest
@@ -66,7 +66,7 @@ public class LinkApiIntegrationTest {
 	private SummaryRepository summaryRepository;
 
 	@Autowired
-	private SummaryClient summaryClient;
+	private HashidsUtils hashidsUtils;
 
 	@MockitoBean
 	private ImageUploader imageUploader;
@@ -74,7 +74,6 @@ public class LinkApiIntegrationTest {
 	private Member testMember;
 	private Member otherMember;
 	private UserDetails testUserDetails;
-	private UserDetails otherUserDetails;
 
 	@BeforeEach
 	void setUp() {
@@ -89,7 +88,6 @@ public class LinkApiIntegrationTest {
 			.build());
 
 		testUserDetails = new CustomMemberDetail(testMember, Role.USER);
-		otherUserDetails = new CustomMemberDetail(otherMember, Role.USER);
 	}
 
 	@Test
@@ -178,16 +176,18 @@ public class LinkApiIntegrationTest {
 			.selected(true)
 			.build());
 
+		String hashLinkId = hashidsUtils.encode(link.getId());
+
 		// when & then
 		mockMvc.perform(
-				get(BASE_URL + "/{id}", link.getId())
+				get(BASE_URL + "/{id}", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.accept(MediaType.APPLICATION_JSON)
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.id").value(link.getId()))
+			.andExpect(jsonPath("$.data.id").value(hashidsUtils.encode(link.getId())))
 			.andExpect(jsonPath("$.data.url").value(link.getUrl()))
 			.andExpect(jsonPath("$.data.title").value(link.getTitle()))
 			.andExpect(jsonPath("$.data.memo").value(link.getMemo()))
@@ -205,9 +205,12 @@ public class LinkApiIntegrationTest {
 			.title("다른 사용자 링크")
 			.build());
 
+		Long otherUserLinkId = otherUserLink.getId();
+		String hashOtherLinkId = hashidsUtils.encode(otherUserLinkId);
+
 		// when & then
 		mockMvc.perform(
-				get(BASE_URL + "/{id}", otherUserLink.getId())
+				get(BASE_URL + "/{id}", hashOtherLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.accept(MediaType.APPLICATION_JSON)
@@ -230,9 +233,12 @@ public class LinkApiIntegrationTest {
 
 		LinkTitleUpdateReq req = new LinkTitleUpdateReq("수정된 제목");
 
+		Long linkId = link.getId();
+		String hashLinkId = hashidsUtils.encode(link.getId());
+
 		// when & then
 		mockMvc.perform(
-				patch(BASE_URL + "/{id}/title", link.getId())
+				patch(BASE_URL + "/{id}/title", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.contentType(MediaType.APPLICATION_JSON)
@@ -245,7 +251,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.data.title").value(req.title()));
 
 		// DB 검증
-		Link updated = linkRepository.findById(link.getId()).orElseThrow();
+		Link updated = linkRepository.findById(linkId).orElseThrow();
 		assertThat(updated.getTitle()).isEqualTo(req.title());
 	}
 
@@ -259,9 +265,13 @@ public class LinkApiIntegrationTest {
 			.title("삭제할 링크")
 			.build());
 
+		Long linkId = link.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
+
+
 		// when & then
 		mockMvc.perform(
-				delete(BASE_URL + "/{id}", link.getId())
+				delete(BASE_URL + "/{id}", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 			)
@@ -270,7 +280,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.message").value("링크 삭제 완료"));
 
 		// DB 검증 - Soft Delete 확인
-		Link deleted = linkRepository.findById(link.getId()).orElseThrow();
+		Link deleted = linkRepository.findById(linkId).orElseThrow();
 		assertThat(deleted.isDeleted()).isTrue();
 	}
 
@@ -296,7 +306,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.exists").value(true))
-			.andExpect(jsonPath("$.data.linkId").isNumber())
+			.andExpect(jsonPath("$.data.linkId").isString())
 			.andExpect(jsonPath("$.message").value("URL 중복 체크 완료"));
 	}
 
@@ -360,7 +370,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.data.links[1].title").value("링크 1"))
 			.andExpect(jsonPath("$.data.links[1].summary").isEmpty()) // 링크 1은 요약 없음
 			.andExpect(jsonPath("$.data.hasNext").value(false)) // 2개 조회, size 10이므로 다음 없음
-			.andExpect(jsonPath("$.data.lastId").value(link1.getId()));
+			.andExpect(jsonPath("$.data.lastId").value(hashidsUtils.encode(link1.getId())));
 	}
 
 	@Test
@@ -384,10 +394,12 @@ public class LinkApiIntegrationTest {
 			"수정된 메모",
 			originalImageUrl
 		);
+		Long linkId = link.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
 		mockMvc.perform(
-				put(BASE_URL + "/{id}", link.getId())
+				put(BASE_URL + "/{id}", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.contentType(MediaType.APPLICATION_JSON)
@@ -402,7 +414,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.data.imageUrl").value(uploadedS3Url));
 
 		// DB 검증
-		Link updated = linkRepository.findById(link.getId()).orElseThrow();
+		Link updated = linkRepository.findById(linkId).orElseThrow();
 		assertThat(updated.getTitle()).isEqualTo(req.title());
 		assertThat(updated.getMemo()).isEqualTo(req.memo());
 	}
@@ -419,10 +431,12 @@ public class LinkApiIntegrationTest {
 			.build());
 
 		LinkMemoUpdateReq req = new LinkMemoUpdateReq("수정된 메모");
+		Long linkId = link.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
 		mockMvc.perform(
-				patch(BASE_URL + "/{id}/memo", link.getId())
+				patch(BASE_URL + "/{id}/memo", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.contentType(MediaType.APPLICATION_JSON)
@@ -435,7 +449,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.data.memo").value(req.memo()));
 
 		// DB 검증
-		Link updated = linkRepository.findById(link.getId()).orElseThrow();
+		Link updated = linkRepository.findById(linkId).orElseThrow();
 		assertThat(updated.getMemo()).isEqualTo(req.memo());
 	}
 
@@ -444,10 +458,11 @@ public class LinkApiIntegrationTest {
 	void shouldFailWhenLinkNotFound() throws Exception {
 		// given
 		Long nonExistentId = 99999L;
+		String hashNonExistentId = hashidsUtils.encode(nonExistentId);
 
 		// when & then
 		mockMvc.perform(
-				get(BASE_URL + "/{id}", nonExistentId)
+				get(BASE_URL + "/{id}", hashNonExistentId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.accept(MediaType.APPLICATION_JSON)
@@ -470,9 +485,12 @@ public class LinkApiIntegrationTest {
 
 		LinkTitleUpdateReq req = new LinkTitleUpdateReq("해킹 시도");
 
+		Long otherUserLinkId = otherUserLink.getId();
+		String hashOtherUserLinkId = hashidsUtils.encode(otherUserLinkId);
+
 		// when & then
 		mockMvc.perform(
-				patch(BASE_URL + "/{id}/title", otherUserLink.getId())
+				patch(BASE_URL + "/{id}/title", hashOtherUserLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.contentType(MediaType.APPLICATION_JSON)
@@ -484,7 +502,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.status").value(LinkErrorCode.LINK_NOT_FOUND.getStatus().name()));
 
 		// DB 검증 - 변경되지 않았는지 확인
-		Link unchanged = linkRepository.findById(otherUserLink.getId()).orElseThrow();
+		Link unchanged = linkRepository.findById(otherUserLinkId).orElseThrow();
 		assertThat(unchanged.getTitle()).isEqualTo("다른 사용자 링크");
 	}
 
@@ -498,9 +516,12 @@ public class LinkApiIntegrationTest {
 			.title("다른 사용자 링크")
 			.build());
 
+		Long linkId = otherUserLink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
+
 		// when & then
 		mockMvc.perform(
-				delete(BASE_URL + "/{id}", otherUserLink.getId())
+				delete(BASE_URL + "/{id}", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 			)
@@ -509,7 +530,7 @@ public class LinkApiIntegrationTest {
 			.andExpect(jsonPath("$.status").value(LinkErrorCode.LINK_NOT_FOUND.getStatus().name()));
 
 		// DB 검증 - 삭제되지 않았는지 확인
-		Link unchanged = linkRepository.findById(otherUserLink.getId()).orElseThrow();
+		Link unchanged = linkRepository.findById(linkId).orElseThrow();
 		assertThat(unchanged.isDeleted()).isFalse();
 	}
 
@@ -523,12 +544,14 @@ public class LinkApiIntegrationTest {
 			.title("삭제된 링크")
 			.build());
 
-		link.markDeleted(); // Soft delete
+		link.markDeleted();
 		linkRepository.save(link);
+		Long linkId = link.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
 		mockMvc.perform(
-				get(BASE_URL + "/{id}", link.getId())
+				get(BASE_URL + "/{id}", hashLinkId)
 					.with(csrf())
 					.with(user(testUserDetails))
 					.accept(MediaType.APPLICATION_JSON)
@@ -634,7 +657,10 @@ public class LinkApiIntegrationTest {
 			.title("테스트 링크")
 			.build());
 		savedLink.updateSummaryStatus(SummaryStatus.COMPLETED);
+
 		Long linkId = savedLink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
+
 
 		summaryRepository.save(Summary.builder()
 			.link(savedLink)
@@ -647,7 +673,7 @@ public class LinkApiIntegrationTest {
 		RegenerateSummaryReq req = new RegenerateSummaryReq(format);
 
 		// when & then
-		mockMvc.perform(post(BASE_URL + "/{id}/summary", linkId)
+		mockMvc.perform(post(BASE_URL + "/{id}/summary", hashLinkId)
 				.param("format", "DETAILED")
 				.with(csrf())
 				.with(user(testUserDetails))
@@ -744,11 +770,12 @@ public class LinkApiIntegrationTest {
 
 		savedLink.updateSummaryStatus(SummaryStatus.COMPLETED);
 		Long linkId = savedLink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		SummaryUpdateReq request = new SummaryUpdateReq("수정된 요약 텍스트", Format.DETAILED);
 
 		// when & then
-		mockMvc.perform(patch(BASE_URL + "/{id}/summary", linkId)
+		mockMvc.perform(patch(BASE_URL + "/{id}/summary", hashLinkId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request))
 				.with(csrf())
@@ -770,15 +797,17 @@ public class LinkApiIntegrationTest {
 			.build();
 		link.updateSummaryStatus(SummaryStatus.COMPLETED);
 		Link savedlink = linkRepository.save(link);
+		Long linkId = savedlink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
-		mockMvc.perform(get(BASE_URL + "/{id}/summary-status", savedlink.getId())
+		mockMvc.perform(get(BASE_URL + "/{id}/summary-status", hashLinkId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.with(csrf())
 				.with(user(testUserDetails))
 			)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.linkId").value(savedlink.getId()))
+			.andExpect(jsonPath("$.data.linkId").value(hashidsUtils.encode(linkId)))
 			.andExpect(jsonPath("$.data.status").value(link.getSummaryStatus().toString()))
 			.andExpect(jsonPath("$.message").value("요약 상태 조회 완료"));
 	}
@@ -838,9 +867,10 @@ public class LinkApiIntegrationTest {
 			.build());
 		savedLink.updateSummaryStatus(SummaryStatus.FAILED);
 		Long linkId = savedLink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
-		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", linkId)
+		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", hashLinkId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.with(csrf())
 				.with(user(testUserDetails))
@@ -859,9 +889,10 @@ public class LinkApiIntegrationTest {
 			.build());
 		savedLink.updateSummaryStatus(SummaryStatus.COMPLETED);
 		Long linkId = savedLink.getId();
+		String hashLinkId = hashidsUtils.encode(linkId);
 
 		// when & then
-		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", linkId)
+		mockMvc.perform(post(BASE_URL + "/{id}/retry-summary", hashLinkId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.with(csrf())
 				.with(user(testUserDetails))

--- a/src/test/java/com/sofa/linkiving/global/config/jackson/HashidsDeserializerTest.java
+++ b/src/test/java/com/sofa/linkiving/global/config/jackson/HashidsDeserializerTest.java
@@ -1,0 +1,72 @@
+package com.sofa.linkiving.global.config.jackson;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HashidsDeserializer 단위 테스트")
+class HashidsDeserializerTest {
+
+	@InjectMocks
+	private HashidsDeserializer hashidsDeserializer;
+
+	@Mock
+	private HashidsUtils hashidsUtils;
+
+	@Mock
+	private JsonParser jsonParser;
+
+	@Mock
+	private DeserializationContext deserializationContext;
+
+	@BeforeEach
+	void setUp() {
+		hashidsDeserializer.setHashidsUtils(hashidsUtils);
+	}
+
+	@Test
+	@DisplayName("정상적인 해시 문자열이 주어지면 디코딩하여 Long 값으로 반환한다")
+	void deserialize_Success() throws IOException {
+		// given
+		String encodedHash = "abc123de";
+		Long expectedDecodedValue = 123L;
+
+		given(jsonParser.getValueAsString()).willReturn(encodedHash);
+		given(hashidsUtils.decode(encodedHash)).willReturn(expectedDecodedValue);
+
+		// when
+		Long result = hashidsDeserializer.deserialize(jsonParser, deserializationContext);
+
+		// then
+		assertThat(result).isEqualTo(expectedDecodedValue);
+		verify(hashidsUtils, times(1)).decode(encodedHash);
+	}
+
+	@Test
+	@DisplayName("해시 문자열이 null이거나 비어있으면 null을 반환한다")
+	void deserialize_NullOrBlank() throws IOException {
+		// given
+		given(jsonParser.getValueAsString()).willReturn("   ");
+
+		// when
+		Long result = hashidsDeserializer.deserialize(jsonParser, deserializationContext);
+
+		// then
+		assertThat(result).isNull();
+		verify(hashidsUtils, never()).decode(anyString());
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/config/jackson/HashidsSerializerTest.java
+++ b/src/test/java/com/sofa/linkiving/global/config/jackson/HashidsSerializerTest.java
@@ -1,0 +1,65 @@
+package com.sofa.linkiving.global.config.jackson;
+
+import static org.mockito.BDDMockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.sofa.linkiving.global.util.HashidsUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HashidsSerializer 단위 테스트")
+class HashidsSerializerTest {
+
+	@InjectMocks
+	private HashidsSerializer hashidsSerializer;
+
+	@Mock
+	private HashidsUtils hashidsUtils;
+
+	@Mock
+	private JsonGenerator jsonGenerator;
+
+	@Mock
+	private SerializerProvider serializerProvider;
+
+	@BeforeEach
+	void setUp() {
+		hashidsSerializer.setHashidsUtils(hashidsUtils);
+	}
+
+	@Test
+	@DisplayName("정상적인 Long 값이 주어지면 Hashids로 인코딩하여 JSON 문자열로 쓴다")
+	void serialize_Success() throws IOException {
+		// given
+		Long value = 123L;
+		String encodedHash = "abc123de";
+		given(hashidsUtils.encode(value)).willReturn(encodedHash);
+
+		// when
+		hashidsSerializer.serialize(value, jsonGenerator, serializerProvider);
+
+		// then
+		verify(jsonGenerator, times(1)).writeString(encodedHash);
+	}
+
+	@Test
+	@DisplayName("null 값이 주어지면 JSON null을 쓴다")
+	void serialize_Null() throws IOException {
+		// when
+		hashidsSerializer.serialize(null, jsonGenerator, serializerProvider);
+
+		// then
+		verify(jsonGenerator, times(1)).writeNull();
+		verify(hashidsUtils, never()).encode(any());
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/util/HashidsUtilsTest.java
+++ b/src/test/java/com/sofa/linkiving/global/util/HashidsUtilsTest.java
@@ -1,0 +1,73 @@
+package com.sofa.linkiving.global.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+@DisplayName("HashidsUtils 단위 테스트")
+class HashidsUtilsTest {
+
+	private HashidsUtils hashidsUtils;
+
+	@BeforeEach
+	void setUp() {
+		hashidsUtils = new HashidsUtils("test-salt", 8);
+	}
+
+	@Test
+	@DisplayName("Long 타입 ID를 해시 문자열로 인코딩한다")
+	void encode_Success() {
+		// given
+		Long id = 123L;
+
+		// when
+		String encoded = hashidsUtils.encode(id);
+
+		// then
+		assertThat(encoded).isNotNull();
+		assertThat(encoded).hasSizeGreaterThanOrEqualTo(8);
+	}
+
+	@Test
+	@DisplayName("null을 인코딩하려고 하면 null을 반환한다")
+	void encode_Null() {
+		// when & then
+		assertThat(hashidsUtils.encode(null)).isNull();
+	}
+
+	@Test
+	@DisplayName("해시 문자열을 다시 원래의 Long 타입 ID로 디코딩한다")
+	void decode_Success() {
+		// given
+		Long originalId = 123L;
+		String encoded = hashidsUtils.encode(originalId);
+
+		// when
+		Long decoded = hashidsUtils.decode(encoded);
+
+		// then
+		assertThat(decoded).isEqualTo(originalId);
+	}
+
+	@Test
+	@DisplayName("null이거나 빈 문자열을 디코딩하면 null을 반환한다")
+	void decode_NullOrBlank() {
+		// when & then
+		assertThat(hashidsUtils.decode(null)).isNull();
+		assertThat(hashidsUtils.decode("")).isNull();
+		assertThat(hashidsUtils.decode("   ")).isNull();
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 해시 문자열 디코딩 시 예외가 발생한다")
+	void decode_Fail_InvalidHash() {
+		// when & then
+		assertThatThrownBy(() -> hashidsUtils.decode("invalidHash!@#"))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("유효하지 않은 식별자입니다.");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #55 

## PR 설명
### 작업 내용
#### 1. Hashids 유틸리티 도입 및 환경 설정
* **HashidUtils 구현**: `application.yml`의 전용 Salt 값을 활용하여 인코딩(Long -> String) 및 디코딩(String -> Long)을 전담하는 컴포넌트를 구현함.
* 인프라 변경 없이 애플리케이션 레이어에서만 동작하도록 설계하여 도입 비용을 최소화함.

#### 2. Jackson 커스텀 직렬화/역직렬화 자동화
* **커스텀 라이브러리 구현**: `HashidSerializer`와 `HashidDeserializer`를 구현하여 DTO 변환 과정을 자동화함.
* **아키텍처 분리**: 서비스 및 레포지토리 계층에서는 기존 `Long` 타입을 유지하여 로직의 일관성을 확보하고, 외부 통신 계층(DTO)에서만 데이터가 투명하게 변환되도록 처리함.

#### 3. @DecodeHash 어노테이션 및 Formatter 구현
* **커스텀 어노테이션 추가**: Controller의 파라미터 레벨에 적용할 수 있는 `@DecodeHash` 어노테이션을 생성
* **FormatterFactory 구현**: 스프링의 데이터 바인딩 시점에 개입하여, 난독화된 문자열을 `Long` 타입으로 자동 파싱해주는 `HashidsFormatterFactory`를 구현
* **WebMvcConfig 등록**: 구현한 FormatterFactory를 스프링 `FormatterRegistry`에 등록하여 전역적으로 동작하도록 설정

#### 3. API 적용 및 컨트롤러 보완
* **DTO 적용**: `LinkResponseDto` 등 외부 노출 DTO의 ID 필드에 `@JsonSerialize`, `@JsonDeserialize` 어노테이션을 반영함.
* **Controller 간소화**: `@PathVariable` 또는 `@RequestParam`에 `@DecodeHash` 어노테이션만 선언하면, 프론트엔드에서 넘어온 Hash 문자열이 자동으로 `Long` 타입 식별자로 바인딩됩니다.

#### 2. Swagger(OpenAPI) 문서화 전역 자동
* **Controller 파라미터 자동화 (`OperationCustomizer`)**:
  * 구현체에 `@DecodeHash`만 선언하면 Swagger 문서 상에 자동으로 `string` 타입과 예시 값(`aB9x2K8R`)이 완벽하게 매핑되도록 커스터마이징함.
* **DTO 필드 자동화 (`PropertyCustomizer`)**:
  * DTO 내부 식별자 필드마다 중복 작성되던 지저분한 `@Schema(type = "string", ...)` 설정을 완전히 제거함.
  * Jackson의 `@JsonSerialize` 및 `@JsonDeserialize` 속성을 추적·스캔하여, 해시 난독화 시리얼라이저를 사용하는 모든 DTO 필드가 Swagger 상에서 자동으로 `string` 타입으로 기술되도록 완전 자동화를 구현함
