### PR TITLE
Refresh Token 기반 토큰 재발급 API 추가

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/auth/controller/AuthApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/auth/controller/AuthApi.java
@@ -1,0 +1,19 @@
+package com.sofa.linkiving.domain.auth.controller;
+
+import com.sofa.linkiving.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "Auth", description = "인증 및 토큰 관리 API")
+public interface AuthApi {
+	@Operation(summary = "토큰 재발급", description = "Refresh Token을 검증하여 Access/Refresh Token을 재발급합니다.")
+	BaseResponse<Void> reissue(
+		@Parameter(description = "리프레시 토큰") String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
+	);
+}

--- a/src/main/java/com/sofa/linkiving/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sofa/linkiving/domain/auth/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.sofa.linkiving.domain.auth.controller;
+
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.auth.dto.internal.TokenDto;
+import com.sofa.linkiving.domain.auth.service.AuthService;
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.util.CookieUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+	private final AuthService authService;
+	private final CookieUtils cookieUtils;
+
+	@Override
+	@PostMapping("/reissue")
+	public BaseResponse<Void> reissue(
+		@CookieValue(value = "refreshToken", required = false) String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		TokenDto newTokens = authService.reissue(refreshToken);
+
+		cookieUtils.addCookie(request, response, "accessToken", newTokens.accessToken(), newTokens.accessExp());
+		cookieUtils.addCookie(request, response, "refreshToken", newTokens.refreshToken(), newTokens.refreshExp());
+
+		return BaseResponse.noContent("토큰 재발급 완료");
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/auth/dto/internal/TokenDto.java
+++ b/src/main/java/com/sofa/linkiving/domain/auth/dto/internal/TokenDto.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.domain.auth.dto.internal;
+
+public record TokenDto(
+	String accessToken,
+	int accessExp,
+	String refreshToken,
+	int refreshExp
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sofa/linkiving/domain/auth/service/AuthService.java
@@ -1,0 +1,29 @@
+package com.sofa.linkiving.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sofa.linkiving.domain.auth.dto.internal.TokenDto;
+import com.sofa.linkiving.security.jwt.JwtProperties;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtProperties jwtProperties;
+
+	public TokenDto reissue(String refreshToken) {
+
+		String email = jwtTokenProvider.validateRefreshToken(refreshToken);
+
+		String newAccessToken = jwtTokenProvider.createAccessToken(email);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
+
+		int accessExp = (int)(jwtProperties.accessTokenValidTime() / 1000);
+		int refreshExp = (int)(jwtProperties.refreshTokenValidTime() / 1000);
+
+		return new TokenDto(newAccessToken, accessExp, newRefreshToken, refreshExp);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/util/CookieUtils.java
+++ b/src/main/java/com/sofa/linkiving/global/util/CookieUtils.java
@@ -1,0 +1,42 @@
+package com.sofa.linkiving.global.util;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.sofa.linkiving.global.config.CookieProperties;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtils {
+
+	private final CookieProperties cookieProperties;
+
+	public void addCookie(HttpServletRequest request, HttpServletResponse response, String name, String value,
+		int maxAge) {
+		String domain = request.getServerName();
+		boolean isLocal = "localhost".equals(domain) || "127.0.0.1".equals(domain);
+		ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+			.path("/")
+			.maxAge(maxAge)
+			.httpOnly(!isLocal)
+			.secure(!isLocal)
+			// TODO: Review security implications of SameSite=None (CSRF risk) before finalizing.
+			.sameSite(isLocal ? "Lax" : "None");
+
+		if (!isLocal) {
+			String cookieDomain = cookieProperties.domain();
+			if (StringUtils.hasText(cookieDomain)) {
+				builder.domain(cookieDomain);
+			}
+		}
+
+		ResponseCookie cookie = builder.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -22,7 +22,10 @@ public abstract class SecurityConstants {
 		"/v1/member/signup", "/v1/member/login", "/mock/**",
 
 		/* oauth2 */
-		"/oauth2/**"
+		"/oauth2/**",
+
+		/* auth */
+		"/v1/auth/reissue"
 	};
 
 	private static final String[] SEMI_PERMIT_URLS = {

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
@@ -2,15 +2,12 @@ package com.sofa.linkiving.security.auth.handler;
 
 import java.io.IOException;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import com.sofa.linkiving.global.config.CookieProperties;
+import com.sofa.linkiving.global.util.CookieUtils;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 import com.sofa.linkiving.security.jwt.JwtProperties;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
@@ -26,7 +23,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final OAuth2Properties oauth2Properties;
 	private final JwtProperties jwtProperties;
-	private final CookieProperties cookieProperties;
+	private final CookieUtils cookieUtils;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -41,33 +38,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		int accessExp = (int)(jwtProperties.accessTokenValidTime() / 1000);
 		int refreshExp = (int)(jwtProperties.refreshTokenValidTime() / 1000);
 
-		addCookie(request, response, "accessToken", accessToken, accessExp);
-		addCookie(request, response, "refreshToken", refreshToken, refreshExp);
+		cookieUtils.addCookie(request, response, "accessToken", accessToken, accessExp);
+		cookieUtils.addCookie(request, response, "refreshToken", refreshToken, refreshExp);
 
 		String targetUrl = oauth2Properties.successRedirectUrl();
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
-	}
-
-	private void addCookie(HttpServletRequest request, HttpServletResponse response, String name, String value,
-		int maxAge) {
-		String domain = request.getServerName();
-		boolean isLocal = "localhost".equals(domain) || "127.0.0.1".equals(domain);
-		ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
-			.path("/")
-			.maxAge(maxAge)
-			.httpOnly(!isLocal)
-			.secure(!isLocal)
-			// TODO: Review security implications of SameSite=None (CSRF risk) before finalizing.
-			.sameSite(isLocal ? "Lax" : "None");
-
-		if (!isLocal) {
-			String cookieDomain = cookieProperties.domain();
-			if (StringUtils.hasText(cookieDomain)) {
-				builder.domain(cookieDomain);
-			}
-		}
-
-		ResponseCookie cookie = builder.build();
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -114,53 +114,49 @@ public class JwtTokenProvider {
 		return null;
 	}
 
-	public Date getExpiration(String token) {
-		return parseClaims(token).getExpiration();
+	private Claims validateToken(String token) {
+		if (token == null || token.isBlank()) {
+			throw new CustomJwtException(JwtErrorCode.EMPTY_TOKEN);
+		}
+
+		try {
+			return parseClaims(token);
+		} catch (ExpiredJwtException e) {
+			throw new CustomJwtException(JwtErrorCode.EXPIRED_JWT_TOKEN);
+		} catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
+			throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);
+		} catch (UnsupportedJwtException e) {
+			throw new CustomJwtException(JwtErrorCode.UNSUPPORTED_JWT_TOKEN);
+		}
 	}
 
-	public String getUserIdFromToken(String token) {
-		return parseClaims(token).getSubject();
-	}
+	public String validateRefreshToken(String refreshToken) {
+		Claims claims = validateToken(refreshToken);
 
-	public void validateRefreshToken(String refreshToken, String userId) {
-		Claims claims = parseClaims(refreshToken);
 		String tokenType = claims.get(JwtKeys.Claims.TOKEN_TYPE, String.class);
 
 		if (!JwtKeys.TokenType.REFRESH.equals(tokenType)) {
 			throw new CustomJwtException(JwtErrorCode.INVALID_REFRESH);
 		}
 
+		String userId = claims.getSubject();
+
 		if (redisService.hasNoKey(RedisKeyRegistry.REFRESH_TOKEN, userId)) {
 			throw new CustomJwtException(JwtErrorCode.CANNOT_REFRESH);
 		}
 
 		String redisToken = redisService.get(RedisKeyRegistry.REFRESH_TOKEN, userId);
-
 		if (!redisToken.equals(refreshToken)) {
 			throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);
 		}
 
+		return userId;
 	}
 
 	public boolean validateAccessToken(String token) {
-		if (token == null || token.isBlank()) {
-			throw new CustomJwtException(JwtErrorCode.EMPTY_TOKEN);
-		}
+		Claims claims = validateToken(token);
 
-		try {
-			Claims claims = parseClaims(token);
-			boolean notExpired = !claims.getExpiration().before(new Date());
-
-			String tokenType = claims.get(JwtKeys.Claims.TOKEN_TYPE, String.class);
-			boolean isAccess = JwtKeys.TokenType.ACCESS.equals(tokenType);
-
-			return notExpired && isAccess;
-		} catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
-			throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);
-		} catch (ExpiredJwtException e) {
-			throw new CustomJwtException(JwtErrorCode.EXPIRED_JWT_TOKEN);
-		} catch (UnsupportedJwtException e) {
-			throw new CustomJwtException(JwtErrorCode.UNSUPPORTED_JWT_TOKEN);
-		}
+		String tokenType = claims.get(JwtKeys.Claims.TOKEN_TYPE, String.class);
+		return JwtKeys.TokenType.ACCESS.equals(tokenType);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/auth/integration/AuthApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/auth/integration/AuthApiIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.sofa.linkiving.domain.auth.integration;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.infra.redis.RedisService;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+
+import jakarta.servlet.http.Cookie;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthApiIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockitoBean
+	private RedisService redisService;
+
+	private Member testMember;
+
+	@BeforeEach
+	void setUp() {
+		testMember = memberRepository.save(Member.builder()
+			.email("auth@test.com")
+			.password("password")
+			.build());
+	}
+
+	@Test
+	@DisplayName("유효한 RefreshToken을 쿠키에 담아 재발급 요청 시 새로운 토큰 쿠키와 200 OK를 반환한다")
+	void shouldReissueTokensAndReturnOk() throws Exception {
+		// given
+		String email = testMember.getEmail();
+		String validRefreshToken = jwtTokenProvider.createRefreshToken(email);
+		Cookie refreshTokenCookie = new Cookie("refreshToken", validRefreshToken);
+
+		given(redisService.hasNoKey(any(), eq(email))).willReturn(false);
+		given(redisService.get(any(), eq(email))).willReturn(validRefreshToken);
+
+		// when & then
+		mockMvc.perform(
+				post("/v1/auth/reissue")
+					.cookie(refreshTokenCookie)
+					.with(csrf())
+					.accept(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("토큰 재발급 완료"))
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().exists("refreshToken"));
+	}
+
+	@Test
+	@DisplayName("RefreshToken 쿠키 없이 재발급 요청 시 에러를 반환한다")
+	void shouldFailWhenRefreshTokenCookieIsMissing() throws Exception {
+		// given - Cookie 설정 없음
+
+		// when & then
+		mockMvc.perform(
+				post("/v1/auth/reissue")
+					.with(csrf())
+					.accept(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.data").value("J-003"));
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,76 @@
+package com.sofa.linkiving.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sofa.linkiving.domain.auth.dto.internal.TokenDto;
+import com.sofa.linkiving.security.jwt.JwtProperties;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+import com.sofa.linkiving.security.jwt.error.CustomJwtException;
+import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 단위 테스트")
+public class AuthServiceTest {
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private JwtProperties jwtProperties;
+
+	@Test
+	@DisplayName("유효한 RefreshToken이 주어지면 새로운 토큰 쌍을 발급한다")
+	void shouldReissueTokensSuccessfully() {
+		// given
+
+		String oldRefreshToken = "old-refresh-token";
+
+		String newAccessToken = "new-access-token";
+		String newRefreshToken = "new-refresh-token";
+
+		given(jwtTokenProvider.validateRefreshToken(oldRefreshToken)).willReturn("test@test.com");
+		given(jwtTokenProvider.createAccessToken("test@test.com")).willReturn(newAccessToken);
+		given(jwtTokenProvider.createRefreshToken("test@test.com")).willReturn(newRefreshToken);
+
+		// 1시간 = 3600000ms, 2주 = 1209600000ms
+		given(jwtProperties.accessTokenValidTime()).willReturn(3600000L);
+		given(jwtProperties.refreshTokenValidTime()).willReturn(1209600000L);
+
+		// when
+		TokenDto result = authService.reissue(oldRefreshToken);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.accessToken()).isEqualTo(newAccessToken);
+		assertThat(result.accessExp()).isEqualTo(3600);
+		assertThat(result.refreshToken()).isEqualTo(newRefreshToken);
+		assertThat(result.refreshExp()).isEqualTo(1209600);
+
+		verify(jwtTokenProvider, times(1)).validateRefreshToken(oldRefreshToken);
+	}
+
+	@Test
+	@DisplayName("RefreshToken 검증에 실패하면 예외가 발생한다")
+	void shouldThrowExceptionWhenRefreshTokenIsInvalid() {
+		// given
+		String invalidToken = "invalid-token";
+
+		willThrow(new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN))
+			.given(jwtTokenProvider).validateRefreshToken(invalidToken);
+
+		// when & then
+		assertThatThrownBy(() -> authService.reissue(invalidToken))
+			.isInstanceOf(RuntimeException.class);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
@@ -174,7 +174,7 @@ public class JwtTokenProviderTest {
 			.willReturn(true);
 
 		// when & then
-		assertThatThrownBy(() -> provider.validateRefreshToken(refreshToken, userId))
+		assertThatThrownBy(() -> provider.validateRefreshToken(refreshToken))
 			.isInstanceOf(CustomJwtException.class)
 			.extracting("errorCode")
 			.isEqualTo(JwtErrorCode.CANNOT_REFRESH);
@@ -190,7 +190,7 @@ public class JwtTokenProviderTest {
 		String accessToken = provider.createAccessToken("member");
 
 		// when & then
-		assertThatThrownBy(() -> provider.validateRefreshToken(accessToken, "member-5"))
+		assertThatThrownBy(() -> provider.validateRefreshToken(accessToken))
 			.isInstanceOf(CustomJwtException.class)
 			.extracting("errorCode")
 			.isEqualTo(JwtErrorCode.INVALID_REFRESH);
@@ -211,7 +211,7 @@ public class JwtTokenProviderTest {
 			.willReturn("another-token");
 
 		// when & then
-		assertThatThrownBy(() -> provider.validateRefreshToken(refreshToken, userId))
+		assertThatThrownBy(() -> provider.validateRefreshToken(refreshToken))
 			.isInstanceOf(CustomJwtException.class)
 			.extracting("errorCode")
 			.isEqualTo(JwtErrorCode.INVALID_JWT_TOKEN);
@@ -231,7 +231,7 @@ public class JwtTokenProviderTest {
 		given(redisService.get(RedisKeyRegistry.REFRESH_TOKEN, userId)).willReturn(refreshToken);
 
 		// when & then
-		assertThatCode(() -> provider.validateRefreshToken(refreshToken, userId))
+		assertThatCode(() -> provider.validateRefreshToken(refreshToken))
 			.doesNotThrowAnyException();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/global/util/CookieUtilsTest.java
+++ b/src/test/java/com/sofa/linkiving/global/util/CookieUtilsTest.java
@@ -1,0 +1,79 @@
+package com.sofa.linkiving.global.util;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.sofa.linkiving.global.config.CookieProperties;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CookieUtils 단위 테스트")
+class CookieUtilsTest {
+
+	@InjectMocks
+	private CookieUtils cookieUtils;
+
+	@Mock
+	private CookieProperties cookieProperties;
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	@BeforeEach
+	void setUp() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+	}
+
+	@Test
+	@DisplayName("로컬 환경(localhost)에서는 httpOnly=false, secure=false, SameSite=Lax 로 쿠키가 생성된다")
+	void shouldAddCookieInLocalEnvironment() {
+		// given
+		request.setServerName("localhost");
+
+		// when
+		cookieUtils.addCookie(request, response, "accessToken", "token-value", 3600);
+
+		// then
+		String setCookieHeader = response.getHeader(HttpHeaders.SET_COOKIE);
+		assertThat(setCookieHeader).isNotNull();
+		assertThat(setCookieHeader).contains("accessToken=token-value");
+		assertThat(setCookieHeader).contains("Max-Age=3600");
+		assertThat(setCookieHeader).contains("Path=/");
+		assertThat(setCookieHeader).contains("SameSite=Lax");
+		assertThat(setCookieHeader).doesNotContain("HttpOnly");
+		assertThat(setCookieHeader).doesNotContain("Secure");
+	}
+
+	@Test
+	@DisplayName("운영 환경(localhost가 아님)에서는 httpOnly=true, secure=true, SameSite=None 으로 쿠키가 생성된다")
+	void shouldAddCookieInProdEnvironment() {
+		// given
+		request.setServerName("api.linkiving.com");
+		given(cookieProperties.domain()).willReturn("linkiving.com");
+
+		// when
+		cookieUtils.addCookie(request, response, "accessToken", "token-value", 3600);
+
+		// then
+		String setCookieHeader = response.getHeader(HttpHeaders.SET_COOKIE);
+		assertThat(setCookieHeader).isNotNull();
+		assertThat(setCookieHeader).contains("accessToken=token-value");
+		assertThat(setCookieHeader).contains("Max-Age=3600");
+		assertThat(setCookieHeader).contains("Path=/");
+		assertThat(setCookieHeader).contains("SameSite=None");
+		assertThat(setCookieHeader).contains("HttpOnly");
+		assertThat(setCookieHeader).contains("Secure");
+		assertThat(setCookieHeader).contains("Domain=linkiving.com");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #229 

## PR 설명
유효한 Refresh Token을 기반으로 새로운 토큰을 재발급하는 Reissue API를 구현

### 작업 내용
#### 1. 토큰 재발급 API 구현 (`AuthController`, `AuthApi`)
* **Endpoint 추가**: `POST /v1/auth/reissue`
* 요청에 포함된 쿠키(`refreshToken`)를 읽어들여 검증을 수행하고, 새로운 토큰 쌍을 다시 쿠키로 응답하도록 컨트롤러 계층을 구성

#### 2. 비즈니스 로직 및 RTR 정책 적용 (`AuthService`)
* `reissue` 메서드를 통해 전달받은 Refresh Token의 서명과 만료 여부를 검증
* 유효성 검증을 통과하면 새로운 Access Token과 Refresh Token을 동시에 발급하는 RTR 방식 적용

#### 3. Cookie 설정 로직 공통화 및 리팩토링 (`CookieUtils`, `OAuth2SuccessHandler`)
* **리팩토링**: 기존 `OAuth2SuccessHandler` 내부에 종속되어 있던 `Set-Cookie` 로직을 분리하여 `CookieUtils` 컴포넌트로 유틸화
* `OAuth2SuccessHandler`와 `AuthController`가 동일한 `CookieUtils`를 참조하도록 하여 응답 일관성 유지
