### PR TITLE
웹소켓 STOMP 쿠키 기반 인증 도입 및 SEND 커맨드 실시간 검증

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/config/WebSocketConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/WebSocketConfig.java
@@ -1,18 +1,25 @@
 package com.sofa.linkiving.global.config;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.HandshakeInterceptor;
 
 import com.sofa.linkiving.security.config.StompHandler;
 import com.sofa.linkiving.security.resolver.AuthMemberWebsocketArgumentResolver;
 
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -33,12 +40,38 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		HandshakeInterceptor cookieInterceptor = new HandshakeInterceptor() {
+			@Override
+			public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+				WebSocketHandler wsHandler, Map<String, Object> attributes) {
+				if (request instanceof ServletServerHttpRequest servletRequest) {
+					Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+					if (cookies != null) {
+						for (Cookie cookie : cookies) {
+							if ("accessToken".equals(cookie.getName())) {
+								attributes.put("accessToken", cookie.getValue()); // 세션 주머니에 보관!
+								break;
+							}
+						}
+					}
+				}
+				return true;
+			}
+
+			@Override
+			public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+				WebSocketHandler wsHandler, Exception exception) {
+			}
+		};
+
 		registry.addEndpoint("/ws/chat")
 			.setAllowedOriginPatterns("*")
+			.addInterceptors(cookieInterceptor)
 			.withSockJS();
 
 		registry.addEndpoint("/ws/link")
 			.setAllowedOriginPatterns("*")
+			.addInterceptors(cookieInterceptor)
 			.withSockJS();
 	}
 

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -14,10 +14,6 @@ public abstract class SecurityConstants {
 		/* h2 */
 		"/h2-console/**",
 
-		/* web socket */
-		"/ws/chat/**",
-		"/ws/link/**",
-
 		/* temp */
 		"/v1/member/signup", "/v1/member/login", "/mock/**",
 

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -20,7 +20,9 @@ import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Order(Ordered.HIGHEST_PRECEDENCE + 99)
@@ -32,37 +34,50 @@ public class StompHandler implements ChannelInterceptor {
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-			String token = null;
+		if (accessor != null) {
+			StompCommand command = accessor.getCommand();
 
-			Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-			if (sessionAttributes != null && sessionAttributes.containsKey("accessToken")) {
-				token = (String)sessionAttributes.get("accessToken");
-			}
+			if (StompCommand.CONNECT.equals(command) || StompCommand.SEND.equals(command)) {
+				String token = null;
+				Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
 
-			if (token == null) {
-				String authorizationHeader = accessor.getFirstNativeHeader(JwtKeys.Headers.AUTHORIZATION);
-
-				if (authorizationHeader != null && authorizationHeader.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
-					token = authorizationHeader.substring(JwtKeys.Headers.BEARER_PREFIX.length());
-				}
-			}
-
-			try {
-				if (token == null) {
-					throw new BusinessException(JwtErrorCode.EMPTY_TOKEN);
+				if (sessionAttributes != null && sessionAttributes.containsKey("accessToken")) {
+					token = (String)sessionAttributes.get("accessToken");
 				}
 
-				if (jwtTokenProvider.validateAccessToken(token)) {
-					Authentication authentication = jwtTokenProvider.getAuthentication(token);
-					accessor.setUser(authentication);
+				if (token == null && StompCommand.CONNECT.equals(command)) {
+					String authorizationHeader = accessor.getFirstNativeHeader(JwtKeys.Headers.AUTHORIZATION);
+
+					if (authorizationHeader != null && authorizationHeader.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
+						token = authorizationHeader.substring(JwtKeys.Headers.BEARER_PREFIX.length());
+
+						if (sessionAttributes != null) {
+							sessionAttributes.put("accessToken", token);
+						}
+					}
 				}
 
-			} catch (BusinessException e) {
-				throw new MessagingException(e.getMessage());
+				try {
+					if (token == null) {
+						throw new BusinessException(JwtErrorCode.EMPTY_TOKEN);
+					}
 
-			} catch (Exception e) {
-				throw new MessagingException("서버 내부 오류로 연결에 실패했습니다.");
+					if (jwtTokenProvider.validateAccessToken(token)) {
+
+						if (StompCommand.CONNECT.equals(command)) {
+							Authentication authentication = jwtTokenProvider.getAuthentication(token);
+							accessor.setUser(authentication);
+						}
+					}
+
+				} catch (BusinessException e) {
+					log.warn("웹소켓 인증/만료 에러 차단: {}", e.getMessage());
+					throw new MessagingException(e.getMessage());
+
+				} catch (Exception e) {
+					log.error("웹소켓 서버 내부 오류", e);
+					throw new MessagingException("서버 내부 오류로 연결에 실패했습니다.");
+				}
 			}
 		}
 

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -1,5 +1,7 @@
 package com.sofa.linkiving.security.config;
 
+import java.util.Map;
+
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.messaging.Message;
@@ -31,12 +33,19 @@ public class StompHandler implements ChannelInterceptor {
 		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
 		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-
-			String authorizationHeader = accessor.getFirstNativeHeader(JwtKeys.Headers.AUTHORIZATION);
 			String token = null;
 
-			if (authorizationHeader != null && authorizationHeader.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
-				token = authorizationHeader.substring(JwtKeys.Headers.BEARER_PREFIX.length());
+			Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+			if (sessionAttributes != null && sessionAttributes.containsKey("accessToken")) {
+				token = (String)sessionAttributes.get("accessToken");
+			}
+
+			if (token == null) {
+				String authorizationHeader = accessor.getFirstNativeHeader(JwtKeys.Headers.AUTHORIZATION);
+
+				if (authorizationHeader != null && authorizationHeader.startsWith(JwtKeys.Headers.BEARER_PREFIX)) {
+					token = authorizationHeader.substring(JwtKeys.Headers.BEARER_PREFIX.length());
+				}
 			}
 
 			try {

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
@@ -7,7 +7,9 @@ import static org.mockito.BDDMockito.*;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
@@ -28,6 +31,7 @@ import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
@@ -38,9 +42,6 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sofa.linkiving.domain.chat.ai.AnswerClient;
-import com.sofa.linkiving.domain.chat.dto.request.AnswerCancelReq;
-import com.sofa.linkiving.domain.chat.dto.request.AnswerReq;
-import com.sofa.linkiving.domain.chat.dto.response.AnswerRes;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
 import com.sofa.linkiving.domain.chat.entity.Chat;
 import com.sofa.linkiving.domain.chat.repository.ChatRepository;
@@ -51,6 +52,10 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+import com.sofa.linkiving.security.jwt.error.CustomJwtException;
+import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
+
+import jakarta.annotation.Nonnull;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -78,15 +83,16 @@ public class WebSocketChatIntegrationTest {
 	@MockitoBean
 	private RedisService redisService;
 
-	@Autowired
+	@MockitoSpyBean
 	private JwtTokenProvider jwtTokenProvider;
 
 	@MockitoBean
 	private AnswerClient answerClient;
 
 	private StompSession stompSession;
-	private BlockingQueue<AnswerRes> blockingQueue;
+	private BlockingQueue<Map<String, Object>> blockingQueue;
 	private Chat testChat;
+	private Member testMember;
 
 	@BeforeEach
 	void setUp() throws ExecutionException, InterruptedException, TimeoutException {
@@ -97,7 +103,7 @@ public class WebSocketChatIntegrationTest {
 		memberRepository.deleteAllInBatch();
 
 		// 1. 데이터 초기화
-		Member testMember = memberRepository.save(Member.builder()
+		testMember = memberRepository.save(Member.builder()
 			.email("test@test.com")
 			.password("password")
 			.build());
@@ -127,14 +133,19 @@ public class WebSocketChatIntegrationTest {
 
 		// 3. WebSocket 연결
 		String wsUrl = "ws://localhost:" + port + "/ws/chat";
-		StompHeaders headers = new StompHeaders();
 
 		String validToken = jwtTokenProvider.createAccessToken(testMember.getEmail());
-		headers.add("Authorization", "Bearer " + validToken);
+		String authHeaderValue = "Bearer " + validToken;
+
+		StompHeaders headers = new StompHeaders();
+		headers.add("Authorization", authHeaderValue);
+
+		WebSocketHttpHeaders webSocketHttpHeaders = new WebSocketHttpHeaders();
+		webSocketHttpHeaders.add(HttpHeaders.COOKIE, "accessToken=" + validToken);
 
 		this.stompSession = stompClient.connectAsync(
 			wsUrl,
-			new WebSocketHttpHeaders(),
+			webSocketHttpHeaders,
 			headers,
 			new StompSessionHandlerAdapter() {
 			}
@@ -158,38 +169,112 @@ public class WebSocketChatIntegrationTest {
 
 	private void subscribeToChatQueue() {
 		stompSession.subscribe("/user/queue/chat", new StompFrameHandler() {
+			@Nonnull
 			@Override
-			public Type getPayloadType(StompHeaders headers) {
-				return AnswerRes.class;
+			public Type getPayloadType(@Nonnull StompHeaders headers) {
+				return Map.class;
 			}
 
 			@Override
-			public void handleFrame(StompHeaders headers, Object payload) {
-				blockingQueue.offer((AnswerRes)payload);
+			public void handleFrame(@Nonnull StompHeaders headers, Object payload) {
+				if (payload != null) {
+					blockingQueue.add((Map<String, Object>)payload);
+				}
 			}
 		});
 	}
 
 	@Test
-	@DisplayName("유저가 메시지를 보내면 AI 응답이 Queue로 수신된다")
+	@DisplayName("쿠키에 담긴 accessToken으로 정상적으로 웹소켓 연결이 가능하다")
+	void shouldConnectSuccessfullyWithCookie() throws Exception {
+		// given
+		WebSocketStompClient customClient = new WebSocketStompClient(new SockJsClient(createTransportClient()));
+		String validToken = jwtTokenProvider.createAccessToken(testMember.getEmail());
+
+		WebSocketHttpHeaders httpHeaders = new WebSocketHttpHeaders();
+		httpHeaders.add(HttpHeaders.COOKIE, "accessToken=" + validToken);
+
+		// when
+		StompSession session = customClient.connectAsync(
+			"ws://localhost:" + port + "/ws/chat",
+			httpHeaders,
+			new StompHeaders(),
+			new StompSessionHandlerAdapter() {
+			}
+		).get(5, SECONDS);
+
+		// then
+		assertThat(session.isConnected()).isTrue();
+		session.disconnect();
+	}
+
+	@Test
+	@DisplayName("쿠키(토큰)가 없거나 유효하지 않으면 웹소켓 연결에 실패한다 (401)")
+	void shouldFailToConnectWithInvalidToken() {
+		// given
+		WebSocketStompClient customClient = new WebSocketStompClient(new SockJsClient(createTransportClient()));
+
+		// 잘못된 쿠키 세팅
+		WebSocketHttpHeaders httpHeaders = new WebSocketHttpHeaders();
+		httpHeaders.add(HttpHeaders.COOKIE, "accessToken=invalid_token_value");
+
+		// when & then
+		assertThatThrownBy(() -> customClient.connectAsync(
+			"ws://localhost:" + port + "/ws/chat",
+			httpHeaders,
+			new StompHeaders(),
+			new StompSessionHandlerAdapter() {
+			}
+		).get(5, SECONDS))
+			.isInstanceOf(ExecutionException.class);
+	}
+
+	@Test
+	@DisplayName("연결 이후 SEND 요청 시 인증 토큰이 만료/조작된 경우 메시지를 차단하고 ERROR 프레임을 반환한다")
+	void shouldFailToSendWhenTokenIsInvalid() throws Exception {
+		// given
+		subscribeToChatQueue();
+		Thread.sleep(1000);
+
+		// when
+		doThrow(new CustomJwtException(JwtErrorCode.EXPIRED_JWT_TOKEN))
+			.when(jwtTokenProvider).validateAccessToken(anyString());
+
+		Long chatId = testChat.getId();
+		Map<String, Object> req = new HashMap<>();
+		req.put("chatId", chatId);
+		req.put("message", "만료된 토큰으로 전송 시도");
+
+		stompSession.send("/ws/chat/send", req);
+
+		// then
+		Thread.sleep(1000);
+		verify(answerClient, never()).generateAnswer(any());
+	}
+
+	@Test
+	@DisplayName("정상적인 유저가 메시지를 보내면 AI 응답이 Queue로 수신된다")
 	void shouldReceiveAnswerWhenMessageSent() throws InterruptedException {
 		// given
 		Long chatId = testChat.getId();
 		String userMessage = "Gemini에 대해 알려줘";
-		AnswerReq req = new AnswerReq(chatId, userMessage);
+
+		Map<String, Object> req = new HashMap<>();
+		req.put("chatId", chatId);
+		req.put("message", userMessage);
 
 		subscribeToChatQueue();
+		Thread.sleep(1000);
 
 		// when
 		stompSession.send("/ws/chat/send", req);
 
 		// then
-		AnswerRes received = blockingQueue.poll(10, SECONDS);
+		Map<String, Object> received = blockingQueue.poll(10, SECONDS);
 
 		assertThat(received).isNotNull();
-		assertThat(received.chatId()).isEqualTo(chatId);
-		assertThat(received.success()).isTrue();
-		assertThat(received.content()).contains("Gemini와 관련된 내용");
+		assertThat(received.get("success")).isEqualTo(true);
+		assertThat(String.valueOf(received.get("content"))).contains("Gemini와 관련된 내용");
 	}
 
 	@Test
@@ -198,29 +283,34 @@ public class WebSocketChatIntegrationTest {
 		// given
 		Long chatId = testChat.getId();
 		String userMessage = "취소될 질문";
-		AnswerReq sendReq = new AnswerReq(chatId, userMessage);
-		AnswerCancelReq cancelReq = new AnswerCancelReq(chatId);
+
+		Map<String, Object> sendReq = new HashMap<>();
+		sendReq.put("chatId", chatId);
+		sendReq.put("message", userMessage);
+
+		Map<String, Object> cancelReq = new HashMap<>();
+		cancelReq.put("chatId", chatId);
 
 		given(answerClient.generateAnswer(any())).willAnswer(invocation -> {
-			Thread.sleep(500);
+			Thread.sleep(1500);
 			return new RagAnswerRes("지연된 답변", Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				true);
 		});
 
 		subscribeToChatQueue();
+		Thread.sleep(1000);
 
 		// when
 		stompSession.send("/ws/chat/send", sendReq);
-		Thread.sleep(50);
+		Thread.sleep(300);
 		stompSession.send("/ws/chat/cancel", cancelReq);
 
 		// then
-		AnswerRes received = blockingQueue.poll(5, SECONDS);
+		Map<String, Object> received = blockingQueue.poll(10, SECONDS);
 
 		assertThat(received).isNotNull();
-		assertThat(received.chatId()).isEqualTo(chatId);
-		assertThat(received.success()).isFalse();
-		assertThat(received.content()).isEqualTo(userMessage);
+		assertThat(received.get("success")).isEqualTo(false);
+		assertThat(String.valueOf(received.get("content"))).isEqualTo(userMessage);
 	}
-
 }
+


### PR DESCRIPTION
## 관련 이슈

- close #223 

## PR 설명
* 기존 웹소켓 통신은 연결(`CONNECT`) 시점에만 헤더를 통해 인증을 수행하여, 연결 이후 토큰이 만료되거나 비정상적인 `SEND` 요청이 들어올 때 이를 방어하지 못하는 보안 취약점이 있었습니다.
* 이를 해결하기 위해 HTTP Handshake 과정에서 쿠키를 통해 토큰을 추출하는 로직을 추가하고, 메시지 발행(`SEND`) 시점마다 토큰의 유효성을 실시간으로 검증하도록 인증 아키텍처를 크게 개선했습니다.

### 작업 내용
#### 1. 웹소켓 엔드포인트 보안 정책 강화 (`SecurityConstants`)
* 기존 `PERMIT_URLS`에 포함되어 무조건 허용되던 웹소켓 경로(`/ws/chat/**`, `/ws/link/**`)를 제거하여, 기본적인 Spring Security 인증 정책의 보호를 받도록 변경했습니다.

#### 2. 쿠키 기반 Handshake 인터셉터 추가 (`WebSocketConfig`)
* 웹소켓 연결 최초 진입점인 HTTP Handshake 단계에서 동작하는 `HandshakeInterceptor`를 추가했습니다.
* 클라이언트의 요청 쿠키에서 `accessToken`을 추출하여 STOMP 세션 정보(`attributes`)에 저장해 둠으로써, 이후 TCP 통신 단계에서도 토큰 정보에 접근할 수 있도록 하이브리드 인증 기반을 마련했습니다.

#### 3. SEND 커맨드 JWT 실시간 검증 (`StompHandler`)
* `ChannelInterceptor`의 `preSend` 로직을 개선하여, `CONNECT`뿐만 아니라 `SEND` 커맨드 유입 시에도 인증을 수행하도록 분기를 확장했습니다.
* 세션 속성에 저장된 쿠키 토큰(또는 헤더 토큰)을 가져와 만료 여부를 실시간으로 체크(`validateAccessToken`)하며, 만료되거나 유효하지 않은 토큰으로 메시지를 전송하려 할 경우 `MessagingException`을 발생시켜 원천 차단합니다.
