### PR TITLE
API 요청/응답 로깅 개선

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
@@ -25,10 +25,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NoResourceFoundException.class)
 	public ResponseEntity<Void> handleNoResourceFound(NoResourceFoundException exception) {
-		if (exception.getResourcePath().contains("favicon")) {
-			return ResponseEntity.notFound().build();
-		}
-		log.error("No static resource {}", exception.getResourcePath(), exception);
+		log.debug("No static resource: {}", exception.getResourcePath());
 		return ResponseEntity.notFound().build();
 	}
 

--- a/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
+++ b/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
@@ -47,6 +47,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 	private static final Pattern JWT_PATTERN =
 		Pattern.compile("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+");
 
+	private static final String[] SKIP_PATH_PREFIXES = {
+		"/actuator",
+		"/favicon.ico",
+		"/swagger",
+		"/v3/api-docs",
+		"/health-check"
+	};
+
 	private static final int MAX_BODY_LENGTH = 2000;
 
 	@Override
@@ -70,6 +78,9 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 
 	private void logRequestDetails(HttpServletRequest request, ContentCachingResponseWrapper response, long startNs) {
 		String uri = request.getRequestURI();
+		if (shouldSkip(uri)) {
+			return;
+		}
 
 		long tookMs = (System.nanoTime() - startNs) / 1_000_000;
 		String query = maskQueryString(request.getQueryString());
@@ -87,6 +98,15 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			log.debug("[API REQUEST BODY] {} {} body={}", request.getMethod(), uri, requestBody(request));
 			log.debug("[API HEADERS] {} {} {}", request.getMethod(), uri, maskedHeaders(request));
 		}
+	}
+
+	private boolean shouldSkip(String uri) {
+		for (String prefix : SKIP_PATH_PREFIXES) {
+			if (uri.startsWith(prefix)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private String maskQueryString(String queryString) {
@@ -174,5 +194,4 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		masked = JWT_PATTERN.matcher(masked).replaceAll("***JWT***");
 		return masked;
 	}
-
 }

--- a/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
+++ b/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
@@ -35,8 +35,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		"password",
 		"accessToken",
 		"refreshToken",
-		"token",
-		"secret"
+		"token"
 	);
 
 	private static final Set<String> SENSITIVE_QUERY_PARAMS = Set.of(
@@ -97,6 +96,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		if (log.isDebugEnabled()) {
 			log.debug("[API REQUEST BODY] {} {} body={}", request.getMethod(), uri, requestBody(request));
 			log.debug("[API HEADERS] {} {} {}", request.getMethod(), uri, maskedHeaders(request));
+			log.debug("[API RESPONSE] {} {} -> {} body={}", request.getMethod(), uri, response.getStatus(),
+				responseBody(response));
 		}
 	}
 
@@ -166,6 +167,10 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			return formatBody(wrapper.getContentType(), wrapper.getContentAsByteArray());
 		}
 		return "(skipped, content-type=" + request.getContentType() + ")";
+	}
+
+	private String responseBody(ContentCachingResponseWrapper response) {
+		return formatBody(response.getContentType(), response.getContentAsByteArray());
 	}
 
 	private String formatBody(String contentType, byte[] content) {

--- a/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
+++ b/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
@@ -2,11 +2,14 @@ package com.sofa.linkiving.global.fillter;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -18,39 +21,158 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class RequestLoggingFilter extends OncePerRequestFilter {
 
+	private static final Set<String> SENSITIVE_HEADERS = Set.of(
+		"authorization",
+		"cookie",
+		"set-cookie",
+		"proxy-authorization",
+		"x-auth-token",
+		"x-api-key"
+	);
+
+	private static final Set<String> SENSITIVE_BODY_FIELDS = Set.of(
+		"email",
+		"password",
+		"accessToken",
+		"refreshToken",
+		"token",
+		"secret"
+	);
+
+	private static final Set<String> SENSITIVE_QUERY_PARAMS = Set.of(
+		"code",
+		"state"
+	);
+
+	private static final Pattern JWT_PATTERN =
+		Pattern.compile("eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+");
+
+	private static final int MAX_BODY_LENGTH = 2000;
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
-		ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
 
-		filterChain.doFilter(wrappingRequest, response);
+		HttpServletRequest requestToUse = isLoggableBody(request.getContentType())
+			? new ContentCachingRequestWrapper(request)
+			: request;
 
-		logRequestDetails(wrappingRequest);
+		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+		long startNs = System.nanoTime();
+		try {
+			filterChain.doFilter(requestToUse, responseWrapper);
+		} finally {
+			logRequestDetails(requestToUse, responseWrapper, startNs);
+			responseWrapper.copyBodyToResponse();
+		}
 	}
 
-	private void logRequestDetails(ContentCachingRequestWrapper request) {
-		String method = request.getMethod();
-		String url = request.getRequestURI();
-		String queryString = request.getQueryString() != null ? "?" + request.getQueryString() : "";
+	private void logRequestDetails(HttpServletRequest request, ContentCachingResponseWrapper response, long startNs) {
+		String uri = request.getRequestURI();
 
-		StringBuilder logMsg = new StringBuilder();
-		logMsg.append("\n[API REQUEST] ").append(method).append(" ").append(url).append(queryString).append("\n");
+		long tookMs = (System.nanoTime() - startNs) / 1_000_000;
+		String query = maskQueryString(request.getQueryString());
 
-		logMsg.append(" > [HEADERS]\n");
-		Collections.list(request.getHeaderNames()).forEach(headerName ->
-			logMsg.append("   - ").append(headerName).append(": ").append(request.getHeader(headerName)).append("\n")
-		);
+		log.info("[API] {} {}{} -> {} ({}ms) ip={} ua=\"{}\"",
+			request.getMethod(),
+			uri,
+			query,
+			response.getStatus(),
+			tookMs,
+			clientIp(request),
+			request.getHeader("User-Agent"));
 
-		byte[] content = request.getContentAsByteArray();
-		if (content.length > 0) {
-			String body = new String(content, StandardCharsets.UTF_8);
-			logMsg.append(" > [Body Data]       : ").append(body.trim()).append("\n");
-		} else {
-			logMsg.append(" > [Body Data]       : (Empty)\n");
+		if (log.isDebugEnabled()) {
+			log.debug("[API REQUEST BODY] {} {} body={}", request.getMethod(), uri, requestBody(request));
+			log.debug("[API HEADERS] {} {} {}", request.getMethod(), uri, maskedHeaders(request));
+		}
+	}
+
+	private String maskQueryString(String queryString) {
+		if (queryString == null || queryString.isBlank()) {
+			return "";
 		}
 
-		logMsg.append("--------------------------------------------------------------------------------");
-
-		log.info(logMsg.toString());
+		StringBuilder sb = new StringBuilder("?");
+		String[] pairs = queryString.split("&");
+		for (int i = 0; i < pairs.length; i++) {
+			String pair = pairs[i];
+			int eq = pair.indexOf('=');
+			if (eq > 0) {
+				String key = pair.substring(0, eq);
+				if (SENSITIVE_QUERY_PARAMS.contains(key.toLowerCase())) {
+					sb.append(key).append("=***");
+				} else {
+					sb.append(pair);
+				}
+			} else {
+				sb.append(pair);
+			}
+			if (i < pairs.length - 1) {
+				sb.append("&");
+			}
+		}
+		return sb.toString();
 	}
+
+	private String clientIp(HttpServletRequest request) {
+		String forwarded = request.getHeader("X-Forwarded-For");
+		if (forwarded != null && !forwarded.isBlank()) {
+			return forwarded.split(",")[0].trim();
+		}
+		String realIp = request.getHeader("X-Real-IP");
+		if (realIp != null && !realIp.isBlank()) {
+			return realIp;
+		}
+		return request.getRemoteAddr();
+	}
+
+	private String maskedHeaders(HttpServletRequest request) {
+		StringBuilder sb = new StringBuilder();
+		Enumeration<String> names = request.getHeaderNames();
+		while (names.hasMoreElements()) {
+			String name = names.nextElement();
+			String value = SENSITIVE_HEADERS.contains(name.toLowerCase())
+				? "***MASKED***"
+				: request.getHeader(name);
+			sb.append(name).append("=").append(value).append("; ");
+		}
+		return sb.toString();
+	}
+
+	private String requestBody(HttpServletRequest request) {
+		if (request instanceof ContentCachingRequestWrapper wrapper) {
+			return formatBody(wrapper.getContentType(), wrapper.getContentAsByteArray());
+		}
+		return "(skipped, content-type=" + request.getContentType() + ")";
+	}
+
+	private String formatBody(String contentType, byte[] content) {
+		if (!isLoggableBody(contentType)) {
+			return "(skipped, content-type=" + contentType + ")";
+		}
+		if (content.length == 0) {
+			return "(empty)";
+		}
+		String body = maskBody(new String(content, StandardCharsets.UTF_8));
+		if (body.length() > MAX_BODY_LENGTH) {
+			return body.substring(0, MAX_BODY_LENGTH) + "...(truncated, total " + body.length() + " chars)";
+		}
+		return body;
+	}
+
+	private boolean isLoggableBody(String contentType) {
+		return contentType != null && (contentType.contains("json") || contentType.startsWith("text/"));
+	}
+
+	private String maskBody(String body) {
+		String masked = body;
+		for (String field : SENSITIVE_BODY_FIELDS) {
+			masked = masked.replaceAll("(\"" + field + "\"\\s*:\\s*)\"[^\"]*\"", "$1\"***\"");
+		}
+		masked = JWT_PATTERN.matcher(masked).replaceAll("***JWT***");
+		return masked;
+	}
+
 }

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -110,7 +110,6 @@ public class JwtTokenProvider {
 			return cookie.getValue();
 		}
 
-		log.warn("Token not found (missing in both header and cookie)");
 		return null;
 	}
 


### PR DESCRIPTION
## 관련 이슈

- close #244
- close #237 
- close #240 

## PR 설명
### 배경
- 기존 `RequestLoggingFilter`가 모든 요청의 헤더·바디를 INFO 로 통째 로깅하여
  `authorization`/`cookie`의 JWT 토큰, 로그인 요청의 비밀번호가 평문으로 남고 있었음.
- 헬스체크·정적리소스·스캐너 탐색 요청까지 매번 기록되어 운영 로그가 노이즈로 가득 찼음.

### 변경 사항

**민감 정보 로깅 제거**
- INFO 로그에서 헤더/바디 전체 덤프 제거 → `method / uri / status / 소요시간 / ip / user-agent`만 한 줄로 기록
- 요청 헤더는 DEBUG 에서만 출력하며 민감 헤더(`Authorization`, `Cookie`, `Set-Cookie` 등)는 값 전체 마스킹
- 응답 헤더(`Set-Cookie`)는 로깅하지 않아 토큰이 헤더로 새지 않음

**요청/응답 본문 로깅 (마스킹 적용)**
- 응답 본문: `DEBUG `기록, 민감 필드(`email` 등)·JWT 패턴 마스킹 + 2000자 상한
- 요청 본문: `DEBUG` 기록(클라이언트 통제 불가 입력이라 보수적), 동일 마스킹 적용
- `email`/`password`/토큰류 필드 값 마스킹, 필드명과 무관하게 `eyJ...` JWT 패턴은 통째로 마스킹
- `ContentCachingResponseWrapper` 사용 시 `copyBodyToResponse()` 호출로 빈 응답 방지
- 파일 업로드(multipart)·바이너리는 메모리 버퍼링 방지를 위해 래핑·로깅에서 제외

**로그 노이즈 제거**
- `RequestLoggingFilter`에서 노이즈 경로(`/actuator`, `/favicon.ico`, `/swagger`, `/v3/api-docs`) 요청 로깅 제외
- `GlobalExceptionHandler`에서 `NoResourceFoundException`(스캐너 404) ERROR → DEBUG 강등
- `JwtTokenProvider`에서 익명 요청에 대한 `Token not found` 로그 삭제
