### PR TITLE
예외 로깅 레벨 4xx/5xx 분리

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sofa/linkiving/global/error/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.global.error.handler;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -25,7 +26,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NoResourceFoundException.class)
 	public ResponseEntity<Void> handleNoResourceFound(NoResourceFoundException exception) {
-		log.debug("No static resource: {}", exception.getResourcePath());
+		log.warn("No static resource: {}", exception.getResourcePath());
 		return ResponseEntity.notFound().build();
 	}
 
@@ -34,64 +35,71 @@ public class GlobalExceptionHandler {
 	  ========================= */
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<BaseResponse<String>> handleBusinessException(BusinessException ex) {
-		log.error(ex.getMessage(), ex);
+		if (ex.getErrorCode().getStatus().is5xxServerError()) {
+			log.error("BusinessException [{}]", ex.getErrorCode().getCode(), ex);
+		} else {
+			log.warn("BusinessException [{}]: {}", ex.getErrorCode().getCode(), ex.getMessage());
+		}
 		return ErrorResponse.build(ex.getErrorCode());
 	}
 
 	/* =========================
-       검증/바인딩 예외
+       검증/바인딩 예외 (모두 4xx)
        ========================= */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<BaseResponse<String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Validation failed: {} field error(s) - fields={}",
+			ex.getBindingResult().getErrorCount(),
+			ex.getBindingResult().getFieldErrors().stream()
+				.map(FieldError::getField).distinct().toList());
 		return ErrorResponse.build(CommonErrorCode.INVALID_INPUT_VALUE);
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	public ResponseEntity<BaseResponse<String>> handleConstraintViolation(ConstraintViolationException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Constraint violation: {}", ex.getMessage());
 		return ErrorResponse.build(CommonErrorCode.INVALID_INPUT_VALUE);
 	}
 
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	public ResponseEntity<BaseResponse<String>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Type mismatch: parameter '{}'", ex.getName());
 		return ErrorResponse.build(CommonErrorCode.TYPE_MISMATCH);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<BaseResponse<String>> handleMissingParam(MissingServletRequestParameterException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Missing request parameter: {}", ex.getParameterName());
 		return ErrorResponse.build(CommonErrorCode.MISSING_REQUEST_PARAMS);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<BaseResponse<String>> handleNotReadable(HttpMessageNotReadableException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Malformed request body");
 		return ErrorResponse.build(CommonErrorCode.BAD_REQUEST);
 	}
 
 	/* =========================
-	 HTTP 관련 예외
+	 HTTP 관련 예외 (모두 4xx)
 	 ========================= */
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ResponseEntity<BaseResponse<String>> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Method not supported: {}", ex.getMethod());
 		return ErrorResponse.build(CommonErrorCode.METHOD_NOT_ALLOWED);
 	}
 
 	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
 	public ResponseEntity<BaseResponse<String>> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
-		log.error(ex.getMessage(), ex);
+		log.warn("Media type not supported: {}", ex.getContentType());
 		return ErrorResponse.build(CommonErrorCode.HTTP_MEDIA_NOT_SUPPORT);
 	}
 
 	/* =========================
-       그 외 모든 예외
+       그 외 모든 예외 (예상 못 한 5xx)
        ========================= */
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<BaseResponse<String>> handleException(Exception ex) {
-		log.error(ex.getMessage(), ex);
+		log.error("Unhandled exception", ex);
 		return ErrorResponse.build(CommonErrorCode.INTERNAL_SERVER_ERROR);
 	}
 


### PR DESCRIPTION
## 관련 이슈

- close #243 

## PR 설명
### 배경
- 모든 핸들러가 `log.error(ex.getMessage(), ex)`로 동일하게 로깅하여,
  클라이언트 잘못인 4xx(검증 실패, 405, 404 등)까지 ERROR + 풀스택으로 기록됨.
- 운영 로그에서 `Request method 'POST' is not supported`, `채팅을 찾을 수 없습니다` 등이 ERROR 로 다수 확인됨.
- 이 상태로 ERROR 알림을 도입하면 클라이언트 실수 때문에 계속 울려 알림이 무의미해짐.

### 적용된 로깅 원칙
- 4xx (클라이언트 잘못): WARN, 스택 트레이스 없이 메시지만. 서버 문제가 아니므로 ERROR 금지.
- 정적 리소스 404: WARN, 스택 트레이스 없이 경로만 기록 (봇·스캐너의 비정상 경로 접근 추적용) 
- 5xx (서버 잘못): ERROR, 예외 객체를 넘겨 전체 스택 트레이스를 남김.
- 민감 데이터가 들어가는 예외라면 메시지를 그대로 찍지 말고 필요한 필드만 추려 남길 것.

### 변경 사항
- 검증/바인딩/HTTP 메서드 예외(확정 4xx) → WARN, 스택 트레이스 없이 필드명·에러 개수만 기록
- `BusinessException` → `ErrorCode.getStatus()`로 분기: 5xx만 ERROR + 스택, 4xx는 WARN
- catch-all `Exception`(예상 못 한 5xx) → `ERROR` + 풀스택 유지, 예외 객체를 인자로 전달
- 메시지에 요청 본문/PII가 섞일 수 있는 예외는 고정 문구만 기록