### PR TITLE
채팅 시작 시 빈 채팅방 누락 및 WebSocket 인증 보완

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.chat.ai.TitleClient;
@@ -65,25 +66,34 @@ public class ChatFacade {
 		chatService.delete(chat);
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public void generateAnswer(Long chatId, Member member, String message) {
+		try {
+			chatService.getChat(chatId, member);
+		} catch (RuntimeException ex) {
+			log.error("채팅 답변 시작 중 오류 발생 - chatId: {}, error: {}", chatId, ex.getMessage(), ex);
+			sendNotification(chatId, member, AnswerRes.error(chatId, message));
+			return;
+		}
 
-		CompletableFuture<AnswerRes> task = ragChatService.generateAnswer(chatId, member, message);
+		Long effectiveChatId = chatId;
 
-		taskManager.put(chatId, task);
+		CompletableFuture<AnswerRes> task = ragChatService.generateAnswer(effectiveChatId, member, message);
+
+		taskManager.put(effectiveChatId, task);
 
 		task.whenComplete((result, ex) -> {
-			taskManager.remove(chatId);
+			taskManager.remove(effectiveChatId);
 
 			if (task.isCancelled() || ex != null) {
 
 				if (ex != null) {
-					log.error("AI 답변 생성 중 오류 발생 - chatId: {}, error: {}", chatId, ex.getMessage(), ex);
+					log.error("AI 답변 생성 중 오류 발생 - chatId: {}, error: {}", effectiveChatId, ex.getMessage(), ex);
 				} else {
-					log.info("AI 답변 생성 작업 취소됨 - chatId: {}", chatId);
+					log.info("AI 답변 생성 작업 취소됨 - chatId: {}", effectiveChatId);
 				}
 
-				sendNotification(chatId, member, AnswerRes.error(chatId, message));
+				sendNotification(effectiveChatId, member, AnswerRes.error(effectiveChatId, message));
 				return;
 			}
 
@@ -92,8 +102,8 @@ public class ChatFacade {
 				return;
 			}
 
-			log.error("AI 답변 생성 결과가 null 입니다 - chatId: {}", chatId);
-			sendNotification(chatId, member, AnswerRes.error(chatId, message));
+			log.error("AI 답변 생성 결과가 null 입니다 - chatId: {}", effectiveChatId);
+			sendNotification(effectiveChatId, member, AnswerRes.error(effectiveChatId, message));
 		});
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/repository/ChatRepository.java
@@ -16,10 +16,10 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 	@Query("""
 		SELECT c
 		FROM Chat c
-		JOIN Message m ON m.chat = c
+		LEFT JOIN Message m ON m.chat = c
 		WHERE c.member = :member
 		GROUP BY c
-		ORDER BY MAX(m.createdAt) DESC
+		ORDER BY COALESCE(MAX(m.createdAt), c.createdAt) DESC
 		""")
 	List<Chat> findAllByMemberOrderByLastMessageDesc(@Param("member") Member member);
 

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -21,7 +21,10 @@ public abstract class SecurityConstants {
 		"/oauth2/**",
 
 		/* auth */
-		"/v1/auth/reissue"
+		"/v1/auth/reissue",
+
+		/* websocket handshake */
+		"/ws/chat/**", "/ws/link/**"
 	};
 
 	private static final String[] SEMI_PERMIT_URLS = {

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -91,7 +91,14 @@ public class SecurityConfig {
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true);
 
+		CorsConfiguration webSocketConfig = new CorsConfiguration();
+		webSocketConfig.setAllowedOriginPatterns(List.of("*"));
+		webSocketConfig.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+		webSocketConfig.setAllowedHeaders(List.of("*"));
+		webSocketConfig.setAllowCredentials(true);
+
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/ws/**", webSocketConfig);
 		source.registerCorsConfiguration("/**", config);
 		return source;
 	}

--- a/src/test/java/com/sofa/linkiving/domain/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/facade/ChatFacadeTest.java
@@ -187,6 +187,29 @@ public class ChatFacadeTest {
 	}
 
 	@Test
+	@DisplayName("채팅방 조회에 실패하면 비동기 작업을 시작하지 않고 에러 알림 전송")
+	void shouldSendErrorNotificationWhenChatLookupFails() {
+		// given
+		Long chatId = 999L;
+		String userMessage = "질문입니다";
+		member = mock(Member.class);
+		given(member.getEmail()).willReturn("test@test.com");
+		given(chatService.getChat(chatId, member)).willThrow(new RuntimeException("chat not found"));
+
+		// when
+		chatFacade.generateAnswer(chatId, member, userMessage);
+
+		// then
+		verify(ragChatService, never()).generateAnswer(anyLong(), any(), anyString());
+		verify(taskManager, never()).put(anyLong(), any());
+		verify(messagingTemplate).convertAndSendToUser(
+			eq(member.getEmail()),
+			eq("/queue/chat"),
+			any(AnswerRes.class)
+		);
+	}
+
+	@Test
 	@DisplayName("답변 생성 중 예외가 발생하면 에러 알림 전송")
 	void shouldSendErrorNotificationWhenExceptionOccurs() {
 		// given

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/ChatApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/ChatApiIntegrationTest.java
@@ -1,12 +1,15 @@
 package com.sofa.linkiving.domain.chat.integration;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sofa.linkiving.domain.chat.ai.TitleClient;
 import com.sofa.linkiving.domain.chat.dto.request.CreateChatReq;
+import com.sofa.linkiving.domain.chat.dto.response.AnswerRes;
 import com.sofa.linkiving.domain.chat.dto.response.MessageRes;
 import com.sofa.linkiving.domain.chat.dto.response.MessagesRes;
 import com.sofa.linkiving.domain.chat.entity.Chat;
@@ -32,6 +36,7 @@ import com.sofa.linkiving.domain.chat.enums.Type;
 import com.sofa.linkiving.domain.chat.facade.ChatFacade;
 import com.sofa.linkiving.domain.chat.repository.ChatRepository;
 import com.sofa.linkiving.domain.chat.repository.MessageRepository;
+import com.sofa.linkiving.domain.chat.service.RagChatService;
 import com.sofa.linkiving.domain.link.dto.response.LinkCardRes;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
@@ -85,6 +90,9 @@ public class ChatApiIntegrationTest {
 	@MockitoBean
 	private RedisService redisService;
 
+	@MockitoBean
+	private RagChatService ragChatService;
+
 	private UserDetails testUserDetails;
 	private Member testMember;
 
@@ -96,6 +104,13 @@ public class ChatApiIntegrationTest {
 			.build());
 
 		testUserDetails = new CustomMemberDetail(testMember, Role.USER);
+
+		given(ragChatService.generateAnswer(anyLong(), any(Member.class), anyString()))
+			.willAnswer(invocation -> {
+				Long chatId = invocation.getArgument(0);
+				String message = invocation.getArgument(2);
+				return CompletableFuture.completedFuture(AnswerRes.error(chatId, message));
+			});
 	}
 
 	@Test
@@ -204,6 +219,25 @@ public class ChatApiIntegrationTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.title").value(title))
 			.andExpect(jsonPath("$.data.firstChat").value(firstChatContent));
+	}
+
+	@Test
+	@DisplayName("메시지가 없는 새 채팅방도 목록 조회에 포함된다")
+	void shouldIncludeChatWithoutMessagesInChatList() throws Exception {
+		// given
+		chatRepository.save(Chat.builder()
+			.member(testMember)
+			.title("빈 채팅방")
+			.build());
+
+		// when & then
+		mockMvc.perform(get(BASE_URL)
+				.with(user(testUserDetails)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.chats").isArray())
+			.andExpect(jsonPath("$.data.chats[0].title").value("빈 채팅방"));
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/repository/ChatRepositoryTest.java
@@ -48,11 +48,11 @@ public class ChatRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("메시지가 있는 채팅방만 조회되며, 최신 메시지 순으로 정렬됨")
-	void shouldReturnOnlyChatsWithMessagesOrderByLastMessageTime() throws InterruptedException {
+	@DisplayName("빈 채팅방도 조회되며, 마지막 메시지 또는 생성 시각 기준으로 최신순 정렬됨")
+	void shouldReturnChatsIncludingEmptyRoomsOrderByLastActivity() throws InterruptedException {
 		// given
 
-		// 메시지 없는 채팅방 -> 조회되지 않아야 함
+		// 메시지 없는 채팅방 -> 생성 시각 기준으로 함께 조회되어야 함
 		chatRepository.save(Chat
 			.builder()
 			.member(member)
@@ -90,9 +90,10 @@ public class ChatRepositoryTest {
 		List<Chat> result = chatRepository.findAllByMemberOrderByLastMessageDesc(member);
 
 		// then
-		assertThat(result).hasSize(2);
+		assertThat(result).hasSize(3);
 		assertThat(result.get(0).getTitle()).isEqualTo("New Msg Chat");
 		assertThat(result.get(1).getTitle()).isEqualTo("Old Msg Chat");
+		assertThat(result.get(2).getTitle()).isEqualTo("No Msg Chat");
 	}
 
 	@Test


### PR DESCRIPTION
## Overview
- 채팅 시작 시 응답이 없고 채팅방이 생성되지 않은 것처럼 보이던 문제를 수정했습니다.
- 실제 원인은 새 채팅방이 메시지 없이 생성된 뒤 목록에서 누락되는 문제와, SockJS 환경의 WebSocket 인증 불안정이 겹친 것이었습니다.

Close: #247
## Changes
- 메시지가 없는 새 채팅방도 채팅 목록에 포함되도록 조회 쿼리를 수정했습니다.
- 마지막 메시지가 없는 경우 `chat.createdAt` 기준으로 정렬되도록 보완했습니다.
- SockJS handshake 단계에서 쿠키의 `accessToken` 을 STOMP 인증에 전달하도록 처리했습니다.
- 채팅 조회 실패 시 무응답처럼 끝나지 않고 에러 payload 를 내려주도록 보완했습니다.
- 빈 채팅방 노출, 쿠키 기반 WebSocket 인증, 초기 조회 실패 처리에 대한 테스트를 추가했습니다.