### PR TITLE
로그 카테고리 분리와 MDC 기반 요청 상관관계 구축

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -21,6 +21,7 @@ import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.service.LinkQueryService;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,36 +39,39 @@ public class RagChatService {
 	@Async
 	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public CompletableFuture<AnswerRes> generateAnswer(Long chatId, Member member, String userMessage) {
+		try (LogContext.MdcScope memberScope = LogContext.withMemberId(member.getId());
+			LogContext.MdcScope chatScope = LogContext.withChatId(chatId)) {
 
-		Chat chat = chatQueryService.findChat(chatId, member);
+			Chat chat = chatQueryService.findChat(chatId, member);
 
-		Message question = messageCommandService.saveUserMessage(chat, userMessage);
-		List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
-			question.getId(), chat);
-		Collections.reverse(history);
+			Message question = messageCommandService.saveUserMessage(chat, userMessage);
+			List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
+				question.getId(), chat);
+			Collections.reverse(history);
 
-		RagAnswerReq request = RagAnswerReq.of(
-			member.getId(),
-			userMessage,
-			history,
-			Mode.DETAILED
-		);
+			RagAnswerReq request = RagAnswerReq.of(
+				member.getId(),
+				userMessage,
+				history,
+				Mode.DETAILED
+			);
 
-		RagAnswerRes res = answerClient.generateAnswer(request);
+			RagAnswerRes res = answerClient.generateAnswer(request);
 
-		String fullAnswer = res.answer();
+			String fullAnswer = res.answer();
 
-		List<Long> linkIds = parseLinkIds(res.linkIds());
-		List<LinkDto> linkDtos = linkQueryService.findAllByIdInWithSummary(linkIds, member);
-		List<Link> links = linkDtos.stream().map(LinkDto::link).toList();
+			List<Long> linkIds = parseLinkIds(res.linkIds());
+			List<LinkDto> linkDtos = linkQueryService.findAllByIdInWithSummary(linkIds, member);
+			List<Link> links = linkDtos.stream().map(LinkDto::link).toList();
 
-		List<String> steps = res.reasoningSteps().stream().map(RagAnswerRes.ReasoningStep::step).toList();
+			List<String> steps = res.reasoningSteps().stream().map(RagAnswerRes.ReasoningStep::step).toList();
 
-		Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, links);
+			Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, links);
 
-		AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
+			AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
 
-		return CompletableFuture.completedFuture(payload);
+			return CompletableFuture.completedFuture(payload);
+		}
 
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkCreatedEvent.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkCreatedEvent.java
@@ -1,11 +1,17 @@
 package com.sofa.linkiving.domain.link.event;
 
+import java.util.Map;
+
 /**
  * 링크 생성 완료 이벤트
  * 트랜잭션 커밋 이후 발행되는 이벤트
  */
 public record LinkCreatedEvent(
 	Long linkId,
-	String email
+	String email,
+	Map<String, String> logContext
 ) {
+	public LinkCreatedEvent(Long linkId, String email) {
+		this(linkId, email, Map.of());
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
@@ -13,6 +13,7 @@ import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.link.worker.SummaryQueue;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -48,14 +49,17 @@ public class LinkEventListener {
 	 */
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleLinkCreated(LinkCreatedEvent event) {
-		eventPublisher.publishEvent(new SummaryStatusEvent(
-			event.email(),
-			SummaryStatusRes.of(event.linkId(), SummaryStatus.PENDING)
-		));
+		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
+			LogContext.MdcScope linkScope = LogContext.withLinkId(event.linkId())) {
+			eventPublisher.publishEvent(new SummaryStatusEvent(
+				event.email(),
+				SummaryStatusRes.of(event.linkId(), SummaryStatus.PENDING)
+			));
 
-		selfProvider.getObject().addToQueueWithRetry(event);
+			selfProvider.getObject().addToQueueWithRetry(event);
 
-		log.info("Link created event received & queued async - linkId: {}", event.linkId());
+			log.info("Link created event received & queued async - linkId: {}", event.linkId());
+		}
 
 	}
 
@@ -76,16 +80,17 @@ public class LinkEventListener {
 	 */
 	@Recover
 	public void recover(Exception exception, LinkCreatedEvent event) {
-		log.error("Final failure to queue link after retries - linkId: {}", event.linkId(), exception);
+		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
+			LogContext.MdcScope linkScope = LogContext.withLinkId(event.linkId())) {
+			log.error("Final failure to queue link after retries - linkId: {}", event.linkId(), exception);
+			enqueueFailureCounter.increment();
+			summaryWorkerFacade.updateSummaryStatus(event.linkId(), SummaryStatus.FAILED);
 
-		enqueueFailureCounter.increment();
-
-		summaryWorkerFacade.updateSummaryStatus(event.linkId(), SummaryStatus.FAILED);
-
-		eventPublisher.publishEvent(new SummaryStatusEvent(
-			event.email(),
-			SummaryStatusRes.failed(event.linkId(), "요약 대기열 등록에 실패했습니다.")
-		));
-		// TODO: 관리자 알림, 슬랙 발송 또는 실패 큐 적재 등 후속 처리
+			eventPublisher.publishEvent(new SummaryStatusEvent(
+				event.email(),
+				SummaryStatusRes.failed(event.linkId(), "요약 대기열 등록에 실패했습니다.")
+			));
+			// TODO: 관리자 알림, 슬랙 발송 또는 실패 큐 적재 등 후속 처리
+		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEvent.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEvent.java
@@ -1,28 +1,36 @@
 package com.sofa.linkiving.domain.link.event;
 
+import java.util.Map;
+
 import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SyncAction;
+import com.sofa.linkiving.global.logging.LogContext;
 
 public record LinkSyncEvent(
 	LinkSyncUpdateReq req,
-	SyncAction action
+	SyncAction action,
+	Map<String, String> logContext
 ) {
+	public LinkSyncEvent(LinkSyncUpdateReq req, SyncAction action) {
+		this(req, action, Map.of());
+	}
+
 	public static LinkSyncEvent deleteEvent(Long linkId) {
 		LinkSyncUpdateReq req = LinkSyncUpdateReq.builder()
 			.linkId(linkId)
 			.build();
-		return new LinkSyncEvent(req, SyncAction.DELETE);
+		return new LinkSyncEvent(req, SyncAction.DELETE, LogContext.snapshot());
 	}
 
 	public static LinkSyncEvent createEvent(Link link) {
 		LinkSyncUpdateReq req = LinkSyncUpdateReq.from(link);
-		return new LinkSyncEvent(req, SyncAction.CREATE);
+		return new LinkSyncEvent(req, SyncAction.CREATE, LogContext.snapshot());
 	}
 
 	public static LinkSyncEvent updateEvent(Link link, Summary summary) {
 		LinkSyncUpdateReq req = LinkSyncUpdateReq.of(link, summary);
-		return new LinkSyncEvent(req, SyncAction.UPDATE);
+		return new LinkSyncEvent(req, SyncAction.UPDATE, LogContext.snapshot());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.sofa.linkiving.domain.link.ai.LinkSyncClient;
 import com.sofa.linkiving.domain.link.enums.SyncAction;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -48,20 +49,25 @@ public class LinkSyncEventListener {
 	)
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleLinkSyncEvent(LinkSyncEvent event) {
-		log.info("AI 서버 동기화 비동기 실행 시도 - action: {}, linkId: {}", event.action(), event.req().linkId());
+		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
+			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
+			log.info("AI 서버 동기화 비동기 실행 시도 - action: {}, linkId: {}", event.action(), event.req().linkId());
 
-		switch (event.action()) {
-			case CREATE -> linkSyncClient.syncCreate(event.req());
-			case UPDATE -> linkSyncClient.syncUpdate(event.req());
-			case DELETE -> linkSyncClient.syncDelete(event.req().linkId());
+			switch (event.action()) {
+				case CREATE -> linkSyncClient.syncCreate(event.req());
+				case UPDATE -> linkSyncClient.syncUpdate(event.req());
+				case DELETE -> linkSyncClient.syncDelete(event.req().linkId());
+			}
 		}
 	}
 
 	@Recover
 	public void recover(Exception exception, LinkSyncEvent event) {
-		log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
-			event.action(), event.req().linkId(), exception);
-
-		failureCounters.get(event.action()).increment();
+		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
+			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
+			log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
+				event.action(), event.req().linkId(), exception);
+			failureCounters.get(event.action()).increment();
+		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -29,6 +29,7 @@ import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
 
@@ -48,7 +49,7 @@ public class LinkFacade {
 		String storedImageUrl = processImageUpload(imageUrl);
 		Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 
-		eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail()));
+		eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail(), LogContext.snapshot()));
 		eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
 
 		return LinkRes.from(link);
@@ -155,7 +156,7 @@ public class LinkFacade {
 
 	public void retrySummary(Long id, Member member) {
 		linkService.resetSummaryStatusForRetry(id, member);
-		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getEmail()));
+		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getEmail(), LogContext.snapshot()));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
@@ -6,19 +6,21 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.sofa.linkiving.global.logging.LogContext;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 public class SummaryQueue {
 
-	private final Queue<Long> summaryQueue = new ConcurrentLinkedQueue<>();
+	private final Queue<SummaryTask> summaryQueue = new ConcurrentLinkedQueue<>();
 
 	/**
 	 * 요약 대기 큐에 링크 ID 추가
 	 */
 	public void addToQueue(Long linkId) {
-		summaryQueue.offer(linkId);
+		summaryQueue.offer(new SummaryTask(linkId, LogContext.snapshot()));
 		log.debug("Link added to summary queue - linkId={}", linkId);
 	}
 
@@ -26,6 +28,10 @@ public class SummaryQueue {
 	 * 요약 대기 큐에서 링크 ID 꺼내기
 	 */
 	public Optional<Long> pollFromQueue() {
+		return pollTaskFromQueue().map(SummaryTask::linkId);
+	}
+
+	public Optional<SummaryTask> pollTaskFromQueue() {
 		return Optional.ofNullable(summaryQueue.poll());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryTask.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryTask.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.domain.link.worker;
+
+import java.util.Map;
+
+public record SummaryTask(
+	Long linkId,
+	Map<String, String> logContext
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -19,6 +19,7 @@ import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -80,58 +81,66 @@ public class SummaryWorker {
 	}
 
 	private void processQueue() throws InterruptedException {
-		Optional<Long> linkIdOpt = summaryQueue.pollFromQueue();
+		Optional<SummaryTask> taskOpt = summaryQueue.pollTaskFromQueue();
 
-		if (linkIdOpt.isEmpty()) {
+		if (taskOpt.isEmpty()) {
 			Thread.sleep(properties.sleepDuration().toMillis());
 			return;
 		}
 
-		Long linkId = linkIdOpt.get();
-		String userEmail = null;
-		log.info("Processing link for summary - linkId: {}", linkId);
-
-		try {
-			Link link = summaryWorkerFacade.getLinkWithMember(linkId);
-			userEmail = link.getMember().getEmail();
-
-			if (link.getSummaryStatus() != SummaryStatus.PENDING) {
-				log.warn("Link is not in PENDING state. Skipping summary generation - linkId: {}", linkId);
-				return;
-			}
-
-			summaryWorkerFacade.updateSummaryStatus(link.getId(), SummaryStatus.PROCESSING);
-			eventPublisher.publishEvent(new SummaryStatusEvent(
-				userEmail,
-				SummaryStatusRes.of(linkId, SummaryStatus.PROCESSING)
-			));
-
-			RagInitialSummaryRes res = selfProvider.getObject().callAiServerWithRetry(link);
-
-			Summary summary = summaryWorkerFacade.createInitialSummaryAndUpdateStatus(link.getId(), res.summary());
-			if (summary != null) {
-				eventPublisher.publishEvent(new SummaryStatusEvent(
-					userEmail,
-					SummaryStatusRes.completed(linkId, SummaryRes.from(summary))
-				));
-			}
-		} catch (Exception e) {
-			log.error("Failed to generate summary for linkId: {}", linkId, e);
+		SummaryTask task = taskOpt.get();
+		Long linkId = task.linkId();
+		try (LogContext.MdcScope ignored = LogContext.restore(task.logContext());
+			LogContext.MdcScope linkScope = LogContext.withLinkId(linkId)) {
+			String userEmail = null;
+			log.info("Processing link for summary - linkId: {}", linkId);
 
 			generateFailureCounter.increment();
 
 			try {
-				Link linkToFail = summaryWorkerFacade.getLinkWithMember(linkId);
-				summaryWorkerFacade.updateSummaryStatus(linkToFail.getId(), SummaryStatus.FAILED);
-			} catch (Exception innerEx) {
-				log.error("Failed to update status to FAILED - linkId: {}", linkId, innerEx);
-			}
+				Link link = summaryWorkerFacade.getLinkWithMember(linkId);
+				userEmail = link.getMember().getEmail();
+				LogContext.put(LogContext.MEMBER_ID, link.getMember().getId());
 
-			if (userEmail != null) {
+				if (link.getSummaryStatus() != SummaryStatus.PENDING) {
+					log.warn("Link is not in PENDING state. Skipping summary generation - linkId: {}", linkId);
+					return;
+				}
+
+				summaryWorkerFacade.updateSummaryStatus(link.getId(), SummaryStatus.PROCESSING);
 				eventPublisher.publishEvent(new SummaryStatusEvent(
 					userEmail,
-					SummaryStatusRes.failed(linkId, "Failed to communicate with the AI server (Retry limit exceeded).")
+					SummaryStatusRes.of(linkId, SummaryStatus.PROCESSING)
 				));
+
+				RagInitialSummaryRes res = selfProvider.getObject().callAiServerWithRetry(link);
+
+				Summary summary = summaryWorkerFacade.createInitialSummaryAndUpdateStatus(link.getId(), res.summary());
+				if (summary != null) {
+					eventPublisher.publishEvent(new SummaryStatusEvent(
+						userEmail,
+						SummaryStatusRes.completed(linkId, SummaryRes.from(summary))
+					));
+				}
+			} catch (Exception e) {
+				log.error("Failed to generate summary for linkId: {}", linkId, e);
+
+				try {
+					Link linkToFail = summaryWorkerFacade.getLinkWithMember(linkId);
+					summaryWorkerFacade.updateSummaryStatus(linkToFail.getId(), SummaryStatus.FAILED);
+				} catch (Exception innerEx) {
+					log.error("Failed to update status to FAILED - linkId: {}", linkId, innerEx);
+				}
+
+				if (userEmail != null) {
+					eventPublisher.publishEvent(new SummaryStatusEvent(
+						userEmail,
+						SummaryStatusRes.failed(
+							linkId,
+							"Failed to communicate with the AI server (Retry limit exceeded)."
+						)
+					));
+				}
 			}
 		}
 	}

--- a/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
@@ -1,11 +1,40 @@
 package com.sofa.linkiving.global.config;
 
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableRetry
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
+
+	private final TaskDecorator taskDecorator;
+
+	public AsyncConfig(TaskDecorator taskDecorator) {
+		this.taskDecorator = taskDecorator;
+	}
+
+	@Bean
+	public ThreadPoolTaskExecutor applicationTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(10);
+		executor.setMaxPoolSize(50);
+		executor.setQueueCapacity(200);
+		executor.setThreadNamePrefix("async-");
+		executor.setTaskDecorator(taskDecorator);
+		executor.initialize();
+		return executor;
+	}
+
+	@Override
+	public Executor getAsyncExecutor() {
+		return applicationTaskExecutor();
+	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/web/WebMvcConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/web/WebMvcConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -11,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.sofa.linkiving.global.logging.RequestContextInterceptor;
 import com.sofa.linkiving.security.resolver.AuthMemberArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
@@ -22,10 +24,18 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	private final AuthMemberArgumentResolver authMemberArgumentResolver;
 	private final HashidsFormatterFactory hashidsFormatterFactory;
 	private final DecodeHashInterceptor decodeHashInterceptor;
+	private final RequestContextInterceptor requestContextInterceptor;
+	private final TaskDecorator taskDecorator;
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(authMemberArgumentResolver);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(decodeHashInterceptor);
+		registry.addInterceptor(requestContextInterceptor);
 	}
 
 	@Override
@@ -39,6 +49,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		executor.setMaxPoolSize(100);
 		executor.setQueueCapacity(50);
 		executor.setThreadNamePrefix("mvc-async-");
+		executor.setTaskDecorator(taskDecorator);
 		executor.initialize();
 		return executor;
 	}
@@ -46,10 +57,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addFormatters(FormatterRegistry registry) {
 		registry.addFormatterForFieldAnnotation(hashidsFormatterFactory);
-	}
-
-	@Override
-	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(decodeHashInterceptor);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
+++ b/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
@@ -4,12 +4,18 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import com.sofa.linkiving.global.logging.AccessLogger;
+import com.sofa.linkiving.global.logging.LogContext;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -19,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestLoggingFilter extends OncePerRequestFilter {
 
 	private static final Set<String> SENSITIVE_HEADERS = Set.of(
@@ -59,44 +66,53 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
-
 		HttpServletRequest requestToUse = isLoggableBody(request.getContentType())
 			? new ContentCachingRequestWrapper(request)
 			: request;
 
 		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
-		long startNs = System.nanoTime();
-		try {
+		long startedAt = System.nanoTime();
+		String requestId = resolveRequestId(request);
+		String traceId = resolveTraceId(request, requestId);
+
+		try (LogContext.MdcScope ignored = LogContext.withRequest(requestId, traceId)) {
 			filterChain.doFilter(requestToUse, responseWrapper);
 		} finally {
-			logRequestDetails(requestToUse, responseWrapper, startNs);
+			logRequestDetails(requestToUse, responseWrapper, startedAt);
 			responseWrapper.copyBodyToResponse();
 		}
 	}
 
-	private void logRequestDetails(HttpServletRequest request, ContentCachingResponseWrapper response, long startNs) {
+	private void logRequestDetails(HttpServletRequest request, ContentCachingResponseWrapper response, long startedAt) {
 		String uri = request.getRequestURI();
 		if (shouldSkip(uri)) {
 			return;
 		}
 
-		long tookMs = (System.nanoTime() - startNs) / 1_000_000;
-		String query = maskQueryString(request.getQueryString());
-
-		log.info("[API] {} {}{} -> {} ({}ms) ip={} ua=\"{}\"",
+		long latencyMs = (System.nanoTime() - startedAt) / 1_000_000;
+		AccessLogger.info(
+			"requestId={} method={} path={} status={} latencyMs={}",
+			LogContext.snapshot().get(LogContext.REQUEST_ID),
 			request.getMethod(),
 			uri,
-			query,
 			response.getStatus(),
-			tookMs,
-			clientIp(request),
-			request.getHeader("User-Agent"));
+			latencyMs
+		);
 
 		if (log.isDebugEnabled()) {
-			log.debug("[API REQUEST BODY] {} {} body={}", request.getMethod(), uri, requestBody(request));
-			log.debug("[API HEADERS] {} {} {}", request.getMethod(), uri, maskedHeaders(request));
-			log.debug("[API RESPONSE] {} {} -> {} body={}", request.getMethod(), uri, response.getStatus(),
+			String uriWithQuery = uri + maskQueryString(request.getQueryString());
+			log.debug("[API REQUEST BODY] {} {} body={}", request.getMethod(), uriWithQuery, requestBody(request));
+			log.debug("[API HEADERS] {} {} ip={} ua=\"{}\" {}",
+				request.getMethod(),
+				uriWithQuery,
+				clientIp(request),
+				request.getHeader("User-Agent"),
+				maskedHeaders(request));
+			log.debug("[API RESPONSE] {} {} -> {} body={}",
+				request.getMethod(),
+				uriWithQuery,
+				response.getStatus(),
 				responseBody(response));
 		}
 	}
@@ -108,6 +124,36 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			}
 		}
 		return false;
+	}
+
+	private String resolveRequestId(HttpServletRequest request) {
+		String requestId = request.getHeader("X-Request-Id");
+		if (hasText(requestId)) {
+			return requestId;
+		}
+		return UUID.randomUUID().toString();
+	}
+
+	private String resolveTraceId(HttpServletRequest request, String fallback) {
+		String traceparent = request.getHeader("traceparent");
+		if (hasText(traceparent)) {
+			String[] parts = traceparent.split("-");
+			if (parts.length >= 2 && hasText(parts[1])) {
+				return parts[1];
+			}
+		}
+
+		String xB3TraceId = request.getHeader("X-B3-TraceId");
+		if (hasText(xB3TraceId)) {
+			return xB3TraceId;
+		}
+
+		String xTraceId = request.getHeader("X-Trace-Id");
+		if (hasText(xTraceId)) {
+			return xTraceId;
+		}
+
+		return fallback;
 	}
 
 	private String maskQueryString(String queryString) {
@@ -198,5 +244,9 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		}
 		masked = JWT_PATTERN.matcher(masked).replaceAll("***JWT***");
 		return masked;
+	}
+
+	private boolean hasText(String value) {
+		return value != null && !value.isBlank();
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/logging/AccessLogger.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/AccessLogger.java
@@ -1,0 +1,17 @@
+package com.sofa.linkiving.global.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AccessLogger {
+	private static final Logger LOG = LoggerFactory.getLogger("ACCESS");
+
+	private AccessLogger() {
+	}
+
+	public static void info(String message, Object... arguments) {
+		try (LogContext.MdcScope ignored = LogContext.withLogCategory("access")) {
+			LOG.info(message, arguments);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/logging/AuditLogger.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/AuditLogger.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.global.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AuditLogger {
+	private static final Logger LOG = LoggerFactory.getLogger("AUDIT");
+
+	private AuditLogger() {
+	}
+
+	public static void info(String message, Object... arguments) {
+		try (LogContext.MdcScope ignored = LogContext.withLogCategory("audit")) {
+			LOG.info(message, arguments);
+		}
+	}
+
+	public static void warn(String message, Object... arguments) {
+		try (LogContext.MdcScope ignored = LogContext.withLogCategory("audit")) {
+			LOG.warn(message, arguments);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/logging/LogContext.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/LogContext.java
@@ -1,0 +1,117 @@
+package com.sofa.linkiving.global.logging;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.slf4j.MDC;
+
+public final class LogContext {
+	public static final String REQUEST_ID = "requestId";
+	public static final String TRACE_ID = "traceId";
+	public static final String MEMBER_ID = "memberId";
+	public static final String LINK_ID = "linkId";
+	public static final String CHAT_ID = "chatId";
+	public static final String LOG_CATEGORY = "logCategory";
+
+	private LogContext() {
+	}
+
+	public static MdcScope withRequest(String requestId, String traceId) {
+		Map<String, String> values = new LinkedHashMap<>();
+		putIfHasText(values, REQUEST_ID, requestId);
+		putIfHasText(values, TRACE_ID, traceId);
+		putIfHasText(values, LOG_CATEGORY, "app");
+		return withValues(values);
+	}
+
+	public static MdcScope withMemberId(Long memberId) {
+		return withValue(MEMBER_ID, memberId);
+	}
+
+	public static MdcScope withLinkId(Long linkId) {
+		return withValue(LINK_ID, linkId);
+	}
+
+	public static MdcScope withChatId(Long chatId) {
+		return withValue(CHAT_ID, chatId);
+	}
+
+	public static MdcScope withLogCategory(String category) {
+		return withValue(LOG_CATEGORY, category);
+	}
+
+	public static MdcScope withValue(String key, Object value) {
+		Map<String, String> values = new LinkedHashMap<>();
+		putIfHasText(values, key, value);
+		return withValues(values);
+	}
+
+	public static void put(String key, Object value) {
+		if (value == null) {
+			return;
+		}
+
+		String stringValue = String.valueOf(value);
+		if (hasText(stringValue)) {
+			MDC.put(key, stringValue);
+		}
+	}
+
+	public static MdcScope withValues(Map<String, String> values) {
+		Map<String, String> previous = snapshot();
+		values.forEach((key, value) -> {
+			if (hasText(value)) {
+				MDC.put(key, value);
+			}
+		});
+		return () -> restorePrevious(previous);
+	}
+
+	public static Map<String, String> snapshot() {
+		Map<String, String> contextMap = MDC.getCopyOfContextMap();
+		if (contextMap == null || contextMap.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(contextMap);
+	}
+
+	public static MdcScope restore(Map<String, String> context) {
+		Map<String, String> previous = snapshot();
+		restoreContext(context);
+		return () -> restorePrevious(previous);
+	}
+
+	public static void restoreContext(Map<String, String> context) {
+		if (context == null || context.isEmpty()) {
+			MDC.clear();
+			return;
+		}
+		MDC.setContextMap(context);
+	}
+
+	private static void restorePrevious(Map<String, String> previous) {
+		restoreContext(previous);
+	}
+
+	private static void putIfHasText(Map<String, String> values, String key, Object value) {
+		if (value == null) {
+			return;
+		}
+
+		String stringValue = String.valueOf(value);
+		if (hasText(stringValue)) {
+			values.put(key, stringValue);
+		}
+	}
+
+	private static boolean hasText(String value) {
+		return value != null && !value.isBlank();
+	}
+
+	@FunctionalInterface
+	public interface MdcScope extends AutoCloseable {
+		@Override
+		void close();
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/logging/MdcTaskDecorator.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/MdcTaskDecorator.java
@@ -1,0 +1,20 @@
+package com.sofa.linkiving.global.logging;
+
+import java.util.Map;
+
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MdcTaskDecorator implements TaskDecorator {
+
+	@Override
+	public Runnable decorate(Runnable runnable) {
+		Map<String, String> context = LogContext.snapshot();
+		return () -> {
+			try (LogContext.MdcScope ignored = LogContext.restore(context)) {
+				runnable.run();
+			}
+		};
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/logging/RequestContextInterceptor.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/RequestContextInterceptor.java
@@ -1,0 +1,55 @@
+package com.sofa.linkiving.global.logging;
+
+import java.util.Map;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RequestContextInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal() instanceof CustomMemberDetail memberDetail) {
+			LogContext.put(LogContext.MEMBER_ID, memberDetail.member().getId());
+		}
+
+		Object attribute = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+		if (attribute instanceof Map<?, ?> pathVariables) {
+			putIfPresent(LogContext.LINK_ID, pathVariables.get("linkId"));
+			putIfPresent(LogContext.CHAT_ID, pathVariables.get("chatId"));
+			putDomainIdByRoute(request, pathVariables.get("id"));
+		}
+
+		putIfPresent(LogContext.LINK_ID, request.getParameter("linkId"));
+		putIfPresent(LogContext.CHAT_ID, request.getParameter("chatId"));
+		return true;
+	}
+
+	private void putDomainIdByRoute(HttpServletRequest request, Object id) {
+		if (id == null) {
+			return;
+		}
+
+		String uri = request.getRequestURI();
+		if (uri.startsWith("/v1/links/")) {
+			LogContext.put(LogContext.LINK_ID, id);
+		}
+	}
+
+	private void putIfPresent(String key, Object value) {
+		if (value == null) {
+			return;
+		}
+		LogContext.put(key, value);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.sofa.linkiving.global.error.code.ErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.security.auth.code.AuthErrorCode;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 
@@ -48,6 +49,12 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 		String targetUrl = UriComponentsBuilder.fromUriString(oauth2Properties.failureRedirectUrl())
 			.queryParam("code", errorCode.getCode())
 			.build().toUriString();
+
+		AuditLogger.warn(
+			"event=oauth2_login result=FAILED code={} path={}",
+			errorCode.getCode(),
+			request.getRequestURI()
+		);
 
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
@@ -7,6 +7,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.global.util.CookieUtils;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 import com.sofa.linkiving.security.jwt.JwtProperties;
@@ -40,6 +41,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		cookieUtils.addCookie(request, response, "accessToken", accessToken, accessExp);
 		cookieUtils.addCookie(request, response, "refreshToken", refreshToken, refreshExp);
+
+		AuditLogger.info("event=oauth2_login result=SUCCESS email={}", email);
 
 		String targetUrl = oauth2Properties.successRedirectUrl();
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.security.jwt.JwtKeys;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
@@ -72,6 +73,7 @@ public class StompHandler implements ChannelInterceptor {
 
 				} catch (BusinessException e) {
 					log.warn("웹소켓 인증/만료 에러 차단: {}", e.getMessage());
+					AuditLogger.warn("event=websocket_auth result=FAILED message={}", e.getMessage());
 					throw new MessagingException(e.getMessage());
 
 				} catch (Exception e) {

--- a/src/main/java/com/sofa/linkiving/security/jwt/entrypoint/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/entrypoint/CustomAuthenticationEntryPoint.java
@@ -12,6 +12,7 @@ import com.sofa.linkiving.global.common.BaseResponse;
 import com.sofa.linkiving.global.error.code.CommonErrorCode;
 import com.sofa.linkiving.global.error.code.ErrorCode;
 import com.sofa.linkiving.global.error.util.ErrorResponse;
+import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,6 +46,8 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 		if (response.isCommitted()) {
 			return;
 		}
+		AuditLogger.warn("event=authentication result=FAILED code={} status={}", errorCode.getCode(),
+			errorCode.getStatus().value());
 		ResponseEntity<BaseResponse<String>> entity = ErrorResponse.build(errorCode);
 
 		response.setStatus(errorCode.getStatus().value());

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,10 +3,10 @@
     <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
 
     <property name="CONSOLE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%-40.40logger{39}) : %msg%n"/>
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %magenta([%thread]) %cyan(%-20.20X{logCategory:-app}) %cyan([req=%X{requestId:-} trace=%X{traceId:-} member=%X{memberId:-} link=%X{linkId:-} chat=%X{chatId:-}]) %cyan(%-40.40logger{39}) : %msg%n"/>
 
     <property name="FILE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{logCategory:-app}] [req=%X{requestId:-} trace=%X{traceId:-} member=%X{memberId:-} link=%X{linkId:-} chat=%X{chatId:-}] %logger{36} - %msg%n"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -26,6 +26,30 @@
         </rollingPolicy>
     </appender>
 
+    <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/access.log</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/access-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="AUDIT_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/audit.log</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/audit-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
@@ -37,6 +61,14 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ROLLING_FILE"/>
         </root>
+        <logger name="ACCESS" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ACCESS_FILE"/>
+        </logger>
+        <logger name="AUDIT" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="AUDIT_FILE"/>
+        </logger>
         <logger level="DEBUG" name="org.hibernate.SQL"/>
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
     </springProfile>
@@ -46,6 +78,14 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ROLLING_FILE"/>
         </root>
+        <logger name="ACCESS" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ACCESS_FILE"/>
+        </logger>
+        <logger name="AUDIT" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="AUDIT_FILE"/>
+        </logger>
         <logger level="DEBUG" name="org.hibernate.SQL"/>
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
     </springProfile>
@@ -55,6 +95,14 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ROLLING_FILE"/>
         </root>
+        <logger name="ACCESS" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ACCESS_FILE"/>
+        </logger>
+        <logger name="AUDIT" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="AUDIT_FILE"/>
+        </logger>
         <logger level="OFF" name="org.hibernate.SQL"/>
         <logger level="OFF" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
         <logger level="OFF" name="org.hibernate.orm.jdbc.bind"/>

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -76,6 +77,10 @@ class SummaryWorkerTest {
 		summaryWorker.stopWorker();
 	}
 
+	private SummaryTask task(Long linkId) {
+		return new SummaryTask(linkId, Map.of());
+	}
+
 	@Test
 	@DisplayName("워커 실행 시 메인 쓰레드가 차단되지 않고 백그라운드 쓰레드(summary-worker)에서 동작함")
 	void shouldRunInBackgroundThread() {
@@ -83,7 +88,7 @@ class SummaryWorkerTest {
 		String mainThreadName = Thread.currentThread().getName();
 		String[] workerThreadName = new String[1];
 
-		given(summaryQueue.pollFromQueue()).willAnswer(invocation -> {
+		given(summaryQueue.pollTaskFromQueue()).willAnswer(invocation -> {
 			workerThreadName[0] = Thread.currentThread().getName();
 			return Optional.empty();
 		});
@@ -92,7 +97,7 @@ class SummaryWorkerTest {
 		summaryWorker.startWorker();
 
 		// then
-		verify(summaryQueue, timeout(1000).atLeastOnce()).pollFromQueue();
+		verify(summaryQueue, timeout(1000).atLeastOnce()).pollTaskFromQueue();
 
 		assertThat(workerThreadName[0]).isNotNull();
 		assertThat(workerThreadName[0]).isNotEqualTo(mainThreadName);
@@ -103,7 +108,7 @@ class SummaryWorkerTest {
 	@DisplayName("워커 루프 내부에서 예상치 못한 예외 발생 시 에러를 로깅하고 루프를 계속 실행함")
 	void shouldCatchExceptionAndContinueLoop_WhenUnexpectedErrorOccurs() {
 		// given
-		given(summaryQueue.pollFromQueue())
+		given(summaryQueue.pollTaskFromQueue())
 			.willThrow(new RuntimeException("Unexpected Error"))
 			.willReturn(Optional.empty());
 
@@ -111,15 +116,15 @@ class SummaryWorkerTest {
 		summaryWorker.startWorker();
 
 		// then
-		verify(summaryQueue, timeout(1000).atLeast(2)).pollFromQueue();
+		verify(summaryQueue, timeout(1000).atLeast(2)).pollTaskFromQueue();
 	}
 
 	@Test
 	@DisplayName("PENDING 상태가 아닌 링크는 AI 요약을 건너뛴다")
 	void shouldSkipIfNotPending() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
@@ -138,8 +143,8 @@ class SummaryWorkerTest {
 	void shouldProcessLinkAndSaveSummary() {
 		// given
 		Long linkId = 1L;
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(linkId))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(linkId)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(linkId)).willReturn(mockLink);
@@ -164,8 +169,8 @@ class SummaryWorkerTest {
 	void shouldContinueWorking_WhenExceptionOccurs() {
 		// given
 		Long linkId = 3L;
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(linkId))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(linkId)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(linkId)).willThrow(new RuntimeException("DB Connection Error"));
@@ -175,7 +180,7 @@ class SummaryWorkerTest {
 
 		// then
 		verify(summaryWorkerFacade, timeout(1000).times(2)).getLinkWithMember(linkId);
-		verify(summaryQueue, timeout(1000).atLeast(2)).pollFromQueue();
+		verify(summaryQueue, timeout(1000).atLeast(2)).pollTaskFromQueue();
 		verify(summaryWorkerFacade, never()).createInitialSummaryAndUpdateStatus(any(), any());
 	}
 
@@ -183,13 +188,13 @@ class SummaryWorkerTest {
 	@DisplayName("큐가 비어있으면 지정된 시간만큼 Sleep 후 다시 확인")
 	void shouldSleepAndRetry_WhenQueueIsEmpty() {
 		// given
-		given(summaryQueue.pollFromQueue()).willReturn(Optional.empty());
+		given(summaryQueue.pollTaskFromQueue()).willReturn(Optional.empty());
 
 		// when
 		summaryWorker.startWorker();
 
 		// then
-		verify(summaryQueue, timeout(500).atLeast(3)).pollFromQueue();
+		verify(summaryQueue, timeout(500).atLeast(3)).pollTaskFromQueue();
 	}
 
 	@Test
@@ -199,9 +204,9 @@ class SummaryWorkerTest {
 		Long linkId1 = 10L;
 		Long linkId2 = 20L;
 
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(linkId1))
-			.willReturn(Optional.of(linkId2))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(linkId1)))
+			.willReturn(Optional.of(task(linkId2)))
 			.willReturn(Optional.empty());
 
 		Link link1 = mock(Link.class);
@@ -244,8 +249,8 @@ class SummaryWorkerTest {
 	@DisplayName("정상 처리 시 PROCESSING 및 COMPLETED 이벤트를 순차적으로 발행함")
 	void shouldPublishProcessingAndCompletedEvents_WhenSuccess() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
@@ -274,8 +279,8 @@ class SummaryWorkerTest {
 	@DisplayName("AI 응답이 null일 경우 예외가 발생하여 FAILED 이벤트를 발행함")
 	void shouldPublishFailedEvent_WhenAiResponseIsNull() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
@@ -300,8 +305,8 @@ class SummaryWorkerTest {
 	@DisplayName("처리 중 내부 예외 발생 시 FAILED 이벤트를 발행함")
 	void shouldPublishFailedEvent_WhenExceptionOccurs() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
@@ -327,8 +332,8 @@ class SummaryWorkerTest {
 	@DisplayName("Facade에서 요약 생성 결과가 null일 경우 COMPLETED 이벤트를 발행하지 않는다")
 	void shouldNotPublishCompletedEvent_WhenFacadeReturnsNull() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
@@ -353,8 +358,8 @@ class SummaryWorkerTest {
 	@DisplayName("userEmail 추출 전(조회 단계) 예외가 발생하면 웹소켓 이벤트 발행 없이 루프를 계속한다")
 	void shouldNotPublishEvent_WhenExceptionOccursBeforeEmailExtraction() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willThrow(new RuntimeException("DB Connection Error"));
@@ -364,15 +369,15 @@ class SummaryWorkerTest {
 
 		// then
 		verify(eventPublisher, after(500).never()).publishEvent(any());
-		verify(summaryQueue, timeout(1000).atLeast(2)).pollFromQueue();
+		verify(summaryQueue, timeout(1000).atLeast(2)).pollTaskFromQueue();
 	}
 
 	@Test
 	@DisplayName("예외 복구(catch) 중 DB 상태 업데이트(inner catch)에 실패해도 FAILED 이벤트는 정상 발행된다")
 	void shouldPublishFailedEvent_EvenIfInnerStatusUpdateFails() {
 		// given
-		given(summaryQueue.pollFromQueue())
-			.willReturn(Optional.of(1L))
+		given(summaryQueue.pollTaskFromQueue())
+			.willReturn(Optional.of(task(1L)))
 			.willReturn(Optional.empty());
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);

--- a/src/test/java/com/sofa/linkiving/global/logging/MdcTaskDecoratorTest.java
+++ b/src/test/java/com/sofa/linkiving/global/logging/MdcTaskDecoratorTest.java
@@ -1,0 +1,41 @@
+package com.sofa.linkiving.global.logging;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+class MdcTaskDecoratorTest {
+
+	private final MdcTaskDecorator decorator = new MdcTaskDecorator();
+
+	@AfterEach
+	void tearDown() {
+		MDC.clear();
+	}
+
+	@Test
+	@DisplayName("비동기 작업 데코레이터는 요청 MDC를 그대로 전파한다")
+	void shouldPropagateMdcContext() {
+		MDC.put(LogContext.REQUEST_ID, "req-123");
+		MDC.put(LogContext.TRACE_ID, "trace-456");
+		MDC.put(LogContext.MEMBER_ID, "99");
+
+		AtomicReference<Map<String, String>> captured = new AtomicReference<>();
+		Runnable decorated = decorator.decorate(() -> captured.set(LogContext.snapshot()));
+
+		MDC.clear();
+		decorated.run();
+
+		assertThat(captured.get())
+			.containsEntry(LogContext.REQUEST_ID, "req-123")
+			.containsEntry(LogContext.TRACE_ID, "trace-456")
+			.containsEntry(LogContext.MEMBER_ID, "99");
+		assertThat(MDC.getCopyOfContextMap()).isNull();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/logging/RequestContextInterceptorTest.java
+++ b/src/test/java/com/sofa/linkiving/global/logging/RequestContextInterceptorTest.java
@@ -1,0 +1,35 @@
+package com.sofa.linkiving.global.logging;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+
+class RequestContextInterceptorTest {
+
+	private final RequestContextInterceptor interceptor = new RequestContextInterceptor();
+
+	@AfterEach
+	void tearDown() {
+		MDC.clear();
+	}
+
+	@Test
+	@DisplayName("링크 API의 path variable id는 linkId MDC로 기록한다")
+	void shouldPopulateLinkIdFromLinkRouteId() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v1/links/123");
+		request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("id", "123"));
+
+		boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+		assertThat(result).isTrue();
+		assertThat(MDC.get(LogContext.LINK_ID)).isEqualTo("123");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- close #242

## PR 설명


### Overview
- access/app/audit 로그를 역할별로 나눌 수 있는 기반을 추가했습니다.
- requestId/traceId/memberId/linkId/chatId MDC를 공통 컨텍스트로 넣고, 비동기 실행 흐름까지 전파되도록 정리했습니다.

### Changes
- `RequestLoggingFilter`를 access 로그 중심으로 변경하고 requestId/traceId를 생성하도록 수정
- `logback-spring.xml`에 MDC 패턴 및 `access.log`, `audit.log` appender 추가
- `LogContext`, `MdcTaskDecorator`, `AccessLogger`, `AuditLogger`, `RequestContextInterceptor` 추가
- `@Async`, MVC async executor에 MDC task decorator 적용
- link sync event, summary queue/worker, chat async 응답 생성 흐름에 MDC 복원/전파 적용
- OAuth2 로그인 성공/실패, 인증 실패, websocket 인증 실패를 audit 로그로 남기도록 추가
- 링크 API의 `/{id}` 경로에서도 `linkId` MDC가 채워지도록 보정
- local profile에서는 access/audit 파일 로그가 생기지 않도록 profile 범위 정리