### PR TITLE
prod 로그 레벨/프로필 drift 제거 및 SQL 바인딩 로그 차단

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -55,6 +55,9 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ROLLING_FILE"/>
         </root>
+        <logger level="OFF" name="org.hibernate.SQL"/>
+        <logger level="OFF" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
+        <logger level="OFF" name="org.hibernate.orm.jdbc.bind"/>
     </springProfile>
 
 </configuration>


### PR DESCRIPTION
## 관련 이슈

- close #238

## PR 설명

## Overview
- prod 프로필에서 Hibernate SQL/bind 로그가 다시 켜지는 drift를 막도록 명시적인 OFF 설정을 추가했습니다.

## Changes
- `logback-spring.xml`의 `prod` profile에 아래 로거를 `OFF`로 추가
- `org.hibernate.SQL`
- `org.hibernate.type.descriptor.sql.BasicBinder`
- `org.hibernate.orm.jdbc.bind`

## Notes
- dev/default에서의 SQL 디버깅 동작은 유지하고, prod에서만 명시적으로 차단합니다.