### PR TITLE
로그 위생 정리 및 레이어별 로깅 규칙 적용

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/MockAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/MockAnswerClient.java
@@ -8,18 +8,12 @@ import org.springframework.stereotype.Component;
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @Component
 @Profile("test")
 public class MockAnswerClient implements AnswerClient {
 
 	@Override
 	public RagAnswerRes generateAnswer(RagAnswerReq request) {
-		log.info("[Mock AI Request] User: {}, Question: {}, Mode: {}, HistoryCnt: {}",
-			request.userId(), request.question(), request.mode(), request.history().size());
-
 		return new RagAnswerRes(
 			"임시 답변",
 			List.of("3", "4"),

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -78,9 +78,9 @@ public class ChatFacade {
 			if (task.isCancelled() || ex != null) {
 
 				if (ex != null) {
-					log.error("AI 답변 생성 중 오류 발생 - chatId: {}, error: {}", chatId, ex.getMessage(), ex);
+					log.warn("AI 답변 생성 중 오류 발생 - chatId={}", chatId, ex);
 				} else {
-					log.info("AI 답변 생성 작업 취소됨 - chatId: {}", chatId);
+					log.info("AI 답변 생성 작업 취소됨 - chatId={}", chatId);
 				}
 
 				sendNotification(chatId, member, AnswerRes.error(chatId, message));
@@ -92,7 +92,7 @@ public class ChatFacade {
 				return;
 			}
 
-			log.error("AI 답변 생성 결과가 null 입니다 - chatId: {}", chatId);
+			log.error("AI 답변 생성 결과가 null 입니다 - chatId={}", chatId);
 			sendNotification(chatId, member, AnswerRes.error(chatId, message));
 		});
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/event/SummaryStatusEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/SummaryStatusEventListener.java
@@ -22,7 +22,8 @@ public class SummaryStatusEventListener {
 			"/queue/summary",
 			event.response()
 		);
-		log.info("요약 상태 웹소켓 푸시 완료 - 이메일: {}, 상태: {}, 링크ID: {}",
-			event.email(), event.response().status(), event.response().linkId());
+
+		log.debug("요약 상태 웹소켓 푸시 완료 - status={}, linkId={}",
+			event.response().status(), event.response().linkId());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/LinkService.java
@@ -29,7 +29,7 @@ public class LinkService {
 		}
 
 		Link link = linkCommandService.saveLink(member, url, title, memo, imageUrl);
-		log.info("Link created - id: {}, memberId: {}, url: {}", link.getId(), member.getId(), url);
+		log.info("Link created - id={}, memberId={}", link.getId(), member.getId());
 
 		return link;
 	}
@@ -38,7 +38,7 @@ public class LinkService {
 		Link link = linkQueryService.findById(linkId, member);
 		Link updatedLink = linkCommandService.updateLink(link, title, memo, imageUrl);
 
-		log.info("Link updated - id: {}, memberId: {}", linkId, member.getId());
+		log.debug("Link updated - id={}, memberId={}", linkId, member.getId());
 
 		return updatedLink;
 	}
@@ -47,7 +47,7 @@ public class LinkService {
 		Link link = linkQueryService.findById(linkId, member);
 		Link updatedLink = linkCommandService.updateLink(link, title, link.getMemo(), link.getImageUrl());
 
-		log.info("Link title updated - id: {}, memberId: {}", linkId, member.getId());
+		log.debug("Link title updated - id={}, memberId={}", linkId, member.getId());
 
 		return updatedLink;
 	}
@@ -56,7 +56,7 @@ public class LinkService {
 		Link link = linkQueryService.findById(linkId, member);
 		Link updatedLink = linkCommandService.updateLink(link, link.getTitle(), memo, link.getImageUrl());
 
-		log.info("Link memo updated - id: {}, memberId: {}", linkId, member.getId());
+		log.debug("Link memo updated - id={}, memberId={}", linkId, member.getId());
 
 		return updatedLink;
 	}
@@ -65,7 +65,7 @@ public class LinkService {
 		Link link = linkQueryService.findById(linkId, member);
 		linkCommandService.deleteLink(link);
 
-		log.info("Link soft deleted - id: {}, memberId: {}", linkId, member.getId());
+		log.info("Link soft deleted - id={}, memberId={}", linkId, member.getId());
 	}
 
 	public Link getLink(Long linkId) {

--- a/src/main/java/com/sofa/linkiving/domain/link/util/OgTagCrawler.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/util/OgTagCrawler.java
@@ -22,7 +22,6 @@ public class OgTagCrawler {
 	}
 
 	public OgTagDto crawl(String url) {
-		// SSRF 방어: URL 안전성 검증
 		urlValidator.validateSafeUrl(url);
 
 		try {
@@ -39,7 +38,7 @@ public class OgTagCrawler {
 				.build();
 
 		} catch (IOException e) {
-			log.warn("OG 태그 크롤링 실패: {}", url, e);
+			log.warn("OG 태그 크롤링 실패 - url={}, reason={}", url, e.getMessage());
 			return OgTagDto.EMPTY;
 		}
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
@@ -19,7 +19,7 @@ public class SummaryQueue {
 	 */
 	public void addToQueue(Long linkId) {
 		summaryQueue.offer(linkId);
-		log.info("Link added to summary queue - linkId: {}", linkId);
+		log.debug("Link added to summary queue - linkId={}", linkId);
 	}
 
 	/**

--- a/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
+++ b/src/main/java/com/sofa/linkiving/infra/s3/S3ImageUploader.java
@@ -80,7 +80,8 @@ public class S3ImageUploader implements ImageUploader {
 			log.warn("Invalid image URL skipping upload: {}", originalUrl);
 			return normalizedDefaultImageUrl();
 		} catch (Exception e) {
-			log.error("S3 upload failed for URL: {}", originalUrl, e);
+			log.warn("S3 upload failed, fallback to default image - url={}, reason={}",
+				originalUrl, e.getMessage());
 			return normalizedDefaultImageUrl();
 		}
 	}
@@ -92,7 +93,7 @@ public class S3ImageUploader implements ImageUploader {
 		try {
 			String s3Key = generateUniqueKeyFromUrl(originalUrl);
 			if (s3Template.objectExists(bucketName, s3Key)) {
-				log.info("Image already exists (Cache Hit): {} -> {}", originalUrl, s3Key);
+				log.debug("Image cache hit - s3Key={}", s3Key);
 				return Optional.of(buildS3Url(s3Key));
 			}
 		} catch (Exception e) {

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2FailureHandler.java
@@ -17,7 +17,9 @@ import com.sofa.linkiving.security.auth.config.OAuth2Properties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -37,6 +39,10 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 		} else if (exception instanceof OAuth2AuthenticationException oauthException) {
 			OAuth2Error error = oauthException.getError();
 			errorCode = determineAuthErrorCode(error.getErrorCode());
+		}
+
+		if (errorCode.getStatus().is5xxServerError()) {
+			log.warn("OAuth 로그인 실패(서버성 오류) - code={}", errorCode.getCode());
 		}
 
 		String targetUrl = UriComponentsBuilder.fromUriString(oauth2Properties.failureRedirectUrl())

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -110,7 +110,6 @@ public class JwtTokenProvider {
 			return cookie.getValue();
 		}
 
-		log.warn("Token not found (missing in both header and cookie)");
 		return null;
 	}
 

--- a/src/main/java/com/sofa/linkiving/security/jwt/error/JwtErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/error/JwtErrorCode.java
@@ -16,7 +16,7 @@ public enum JwtErrorCode implements ErrorCode {
 	UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "J-002", "지원하지 않는 JWT 토큰입니다."),
 	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "J-003", "토큰이 필요합니다."),
 	CANNOT_REFRESH(HttpStatus.UNAUTHORIZED, "J-004", "토큰을 갱신할 수 없습니다."),
-	INVALID_REFRESH(HttpStatus.BAD_REQUEST, "J-004", "refresh 토큰이 아닙니다.");
+	INVALID_REFRESH(HttpStatus.BAD_REQUEST, "J-005", "refresh 토큰이 아닙니다.");
 
 	private final HttpStatus status;
 	private final String code;


### PR DESCRIPTION
## 관련 이슈

- close #252 

## PR 설명

운영 로그에 섞여 있던 민감정보와 정상 흐름 노이즈를 제거하고,
레이어·상황별 로그 레벨을 일관된 규칙으로 정리했습니다.
전 도메인(chat/link/infra/auth/member)의 로깅을 점검했습니다.

> 로그 카테고리/상관관계(MDC, #242)와 비동기 안정화(#241)는 별도 범위입니다.
> #239(관측성)가 처리하는 AI 클라이언트·워커·이벤트리스너는 머지 충돌 방지를 위해 제외했습니다.

## 적용한 로깅 규칙

- **ERROR**: 시스템 장애(5xx), 예상치 못한 예외. 스택트레이스 포함.
- **WARN**: 클라이언트 오류(4xx), graceful fallback, 비정상이나 치명적이지 않은 분기. 스택트레이스 미포함.
- **INFO**: 앱 생애주기, 감사 성격 상태 변화로 최소화.
- **DEBUG**: 정상 흐름 추적, 요청/응답 본문, 처리 단계.
- **공통**: 민감정보(이메일·토큰·비밀번호·사용자 콘텐츠)는 운영 기본 레벨에 남기지 않는다. 예외 로깅은 GlobalExceptionHandler에서 일괄 처리(이중 로깅 금지).

## 변경 사항

### 민감정보 제거 (우선순위 높음)
- `SummaryStatusEventListener`: 웹소켓 푸시 로그에서 **이메일(PII) 제거**, INFO → DEBUG
- `LinkService`: 링크 생성 로그에서 **url(사용자 콘텐츠) 제거**

### 로그 레벨 정리
- `LinkService`: update/title/memo 로그 INFO → DEBUG (생성/삭제만 감사 성격으로 유지)
- `SummaryQueue`: 큐 적재 로그 INFO → DEBUG
- `S3ImageUploader`: 캐시 히트 INFO → DEBUG, S3 업로드 실패 ERROR → WARN(fallback)
- `OgTagCrawler`: 크롤링 실패 WARN에서 스택트레이스 제거
- `JwtTokenProvider`: 토큰 부재(비로그인 정상 흐름) WARN → DEBUG

### 예외 로깅 정리
- `ChatFacade`: 비동기 답변 시작 예외를 4xx(WARN)/5xx(ERROR)로 구분, 메시지+스택트레이스 중복 전달 제거
- `OAuth2FailureHandler`: 공급자 서버 오류(5xx)만 WARN 추가 (사용자 취소 등 4xx는 미기록)

### 불필요한 로깅 제거
- `MockAnswerClient`: 테스트용 목의 사용자 질문 로깅 제거 (@Slf4j 함께 제거)