### PR TITLE
비동기 Executor 안정화 및 AI 연동 실패 처리 전환

### DIFF
--- a/docker/alerting/alert.rules.yml
+++ b/docker/alerting/alert.rules.yml
@@ -66,3 +66,28 @@ groups:
         annotations:
           summary: "비동기 작업 최종 실패: {{ $labels.task }}"
           description: "task '{{ $labels.task }}'{{ if $labels.action }} (action {{ $labels.action }}){{ end }} 에서 재시도 소진 후 최종 실패가 발생했습니다. 수동 복구가 필요할 수 있습니다."
+
+      # ── 비동기 executor 큐 포화 임박 ──────────────────────
+      # applicationTaskExecutor 큐(capacity 100)의 80% 이상(=80건)이 2분 지속되면 경고.
+      # 큐가 가득 차고 풀도 max면 CallerRunsPolicy가 발동해 호출/이벤트 스레드가 작업을 직접 실행하게 됨.
+      - alert: AsyncExecutorQueueSaturation
+        expr: executor_queued_tasks{name="applicationTaskExecutor"} >= 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "async executor 큐 포화 임박"
+          description: "applicationTaskExecutor 대기 작업이 큐 용량(100)의 80%를 2분 이상 초과했습니다 (현재 대기 {{ $value }}건). 큐가 가득 차면 CallerRunsPolicy로 호출 스레드가 작업을 직접 실행하여 응답 지연이 발생할 수 있습니다."
+
+      # ── 비동기 executor 스레드 풀 max 도달 ────────────────
+      # 현재 풀 스레드 수가 max(20)에 도달한 상태가 2분 지속되면 경고 (큐까지 차면 포화).
+      - alert: AsyncExecutorPoolExhausted
+        expr: |
+          executor_pool_size_threads{name="applicationTaskExecutor"}
+          >= executor_pool_max_threads{name="applicationTaskExecutor"}
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "async executor 스레드 풀 max 도달"
+          description: "applicationTaskExecutor 풀이 max({{ $value }})에 2분 이상 도달했습니다. 큐까지 가득 차면 CallerRunsPolicy로 호출/이벤트 스레드가 작업을 직접 실행하게 됩니다."

--- a/docker/grafana/dashboards/linkiving-ai-async-overview.json
+++ b/docker/grafana/dashboards/linkiving-ai-async-overview.json
@@ -38,7 +38,7 @@
   "timezone": "",
   "title": "Linkiving AI / Async Overview",
   "uid": "linkiving-ai-async-overview",
-  "version": 1,
+  "version": 2,
   "panels": [
     {
       "id": 1,
@@ -341,6 +341,235 @@
           },
           "expr": "sum by (task, action) (async_task_failures_total)",
           "legendFormat": "{{task}} {{action}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Async Executor 큐 대기 (capacity 100)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "executor_queued_tasks{name=\"applicationTaskExecutor\"}",
+          "legendFormat": "queued",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Async Executor 스레드 (active / pool / max)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "max"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "executor_active_threads{name=\"applicationTaskExecutor\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "executor_pool_size_threads{name=\"applicationTaskExecutor\"}",
+          "legendFormat": "pool",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "executor_pool_max_threads{name=\"applicationTaskExecutor\"}",
+          "legendFormat": "max",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "큐 사용률 (현재)",
+      "type": "gauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "executor_queued_tasks{name=\"applicationTaskExecutor\"}",
+          "legendFormat": "queued",
           "refId": "A"
         }
       ]

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
+import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -43,23 +46,26 @@ public class RagAnswerClient implements AnswerClient {
 
 	@Override
 	public RagAnswerRes generateAnswer(RagAnswerReq request) {
+		List<RagAnswerRes> ragAnswerRes;
 		try {
-			List<RagAnswerRes> ragAnswerRes = ragAnswerFeign.generateAnswer(request);
-
-			if (ragAnswerRes == null || ragAnswerRes.isEmpty()) {
-				log.warn("RagAnswerClient generateAnswer empty response");
-				emptyCounter.increment();
-				return null;
-			}
-
-			log.info("RagAnswerClient generateAnswer ragAnswerRes={}", ragAnswerRes);
-			successCounter.increment();
-			return ragAnswerRes.get(0);
-
-		} catch (Exception e) {
-			log.error("RagAnswerClient generateAnswer error", e);
+			ragAnswerRes = ragAnswerFeign.generateAnswer(request);
+		} catch (BusinessException e) {
 			failureCounter.increment();
-			return null;
+			log.warn("[AI Server] generateAnswer failed - code={}", e.getErrorCode().getCode());
+			throw e;
+		} catch (Exception e) {
+			failureCounter.increment();
+			log.warn("[AI Server] generateAnswer failed - reason={}", e.getMessage());
+			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		}
+
+		if (ragAnswerRes == null || ragAnswerRes.isEmpty()) {
+			emptyCounter.increment();
+			log.warn("[AI Server] generateAnswer empty response");
+			throw new EmptyAiResponseException();
+		}
+
+		successCounter.increment();
+		return ragAnswerRes.get(0);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
@@ -9,6 +9,9 @@ import com.sofa.linkiving.domain.link.dto.request.RagInitialSummaryReq;
 import com.sofa.linkiving.domain.link.dto.request.RagRegenerateSummaryReq;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
+import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -51,47 +54,53 @@ public class RagSummaryClient implements SummaryClient {
 
 	@Override
 	public RagInitialSummaryRes initialSummary(Long linkId, Long userId, String title, String url, String memo) {
+		List<RagInitialSummaryRes> response;
 		try {
 			RagInitialSummaryReq req = new RagInitialSummaryReq(linkId, userId, title, url, memo);
-			List<RagInitialSummaryRes> response = ragSummaryFeign.requestInitialSummary(req);
-
-			if (response != null && !response.isEmpty()) {
-				log.info("[AI Server]  Initial Summary Requested Success. LinkId: {}", linkId);
-				initialSuccess.increment();
-				return response.get(0);
-			}
-
-			initialEmpty.increment();
-			return null;
-
-		} catch (Exception e) {
-			log.error("[AI Server Error] Failed to request initial summary for LinkId: {}. Error: {}", linkId,
-				e.getMessage());
+			response = ragSummaryFeign.requestInitialSummary(req);
+		} catch (BusinessException e) {
 			initialFailure.increment();
-			return null;
+			log.warn("[AI Server] Initial summary failed - linkId={}, code={}", linkId, e.getErrorCode().getCode());
+			throw e;
+		} catch (Exception e) {
+			initialFailure.increment();
+			log.warn("[AI Server] Initial summary failed - linkId={}, reason={}", linkId, e.getMessage());
+			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		}
+
+		if (response == null || response.isEmpty()) {
+			initialEmpty.increment();
+			log.warn("[AI Server] Initial summary empty response - linkId={}", linkId);
+			throw new EmptyAiResponseException();
+		}
+
+		initialSuccess.increment();
+		return response.get(0);
 	}
 
 	@Override
 	public RagRegenerateSummaryRes regenerateSummary(Long linkId, Long userId, String url, String existingSummary) {
+		List<RagRegenerateSummaryRes> response;
 		try {
 			RagRegenerateSummaryReq req = new RagRegenerateSummaryReq(linkId, userId, url, existingSummary);
-			List<RagRegenerateSummaryRes> response = ragSummaryFeign.requestRegenerateSummary(req);
-
-			if (response != null && !response.isEmpty()) {
-				log.info("[AI Server] Regenerate Summary Success. LinkId: {}", linkId);
-				regenerateSuccess.increment();
-				return response.get(0);
-			}
-
-			regenerateEmpty.increment();
-			return null;
-
-		} catch (Exception e) {
-			log.error("[AI Server Error] Failed to regenerate summary for LinkId: {}. Error: {}", linkId,
-				e.getMessage());
+			response = ragSummaryFeign.requestRegenerateSummary(req);
+		} catch (BusinessException e) {
 			regenerateFailure.increment();
-			return null;
+			log.warn("[AI Server] Regenerate summary failed - linkId={}, code={}", linkId, e.getErrorCode().getCode());
+			throw e;
+		} catch (Exception e) {
+			regenerateFailure.increment();
+			log.warn("[AI Server] Regenerate summary failed - linkId={}, reason={}", linkId, e.getMessage());
+			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		}
+
+		if (response == null || response.isEmpty()) {
+			regenerateEmpty.increment();
+			log.warn("[AI Server] Regenerate summary empty response - linkId={}", linkId);
+			throw new EmptyAiResponseException();
+		}
+
+		regenerateSuccess.increment();
+		return response.get(0);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -20,6 +20,7 @@ import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.global.logging.LogContext;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -95,8 +96,6 @@ public class SummaryWorker {
 			String userEmail = null;
 			log.info("Processing link for summary - linkId: {}", linkId);
 
-			generateFailureCounter.increment();
-
 			try {
 				Link link = summaryWorkerFacade.getLinkWithMember(linkId);
 				userEmail = link.getMember().getEmail();
@@ -123,6 +122,7 @@ public class SummaryWorker {
 					));
 				}
 			} catch (Exception e) {
+				generateFailureCounter.increment();
 				log.error("Failed to generate summary for linkId: {}", linkId, e);
 
 				try {
@@ -146,25 +146,20 @@ public class SummaryWorker {
 	}
 
 	@Retryable(
-		value = {Exception.class},
+		retryFor = {Exception.class},
+		noRetryFor = {EmptyAiResponseException.class},
 		maxAttempts = 3,
 		backoff = @Backoff(delay = 2000)
 	)
 	public RagInitialSummaryRes callAiServerWithRetry(Link link) {
 		log.info("Attempting summary request to AI server - linkId: {}", link.getId());
 
-		RagInitialSummaryRes res = summaryClient.initialSummary(
+		return summaryClient.initialSummary(
 			link.getId(),
 			link.getMember().getId(),
 			link.getTitle(),
 			link.getUrl(),
 			link.getMemo()
 		);
-
-		if (res == null) {
-			throw new RuntimeException("Received a null response from the AI server.");
-		}
-
-		return res;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.sofa.linkiving.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,11 +25,19 @@ public class AsyncConfig implements AsyncConfigurer {
 	@Bean
 	public ThreadPoolTaskExecutor applicationTaskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(10);
-		executor.setMaxPoolSize(50);
-		executor.setQueueCapacity(200);
+
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(20);
+		executor.setQueueCapacity(100);
 		executor.setThreadNamePrefix("async-");
+
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(30);
+
 		executor.setTaskDecorator(taskDecorator);
+
 		executor.initialize();
 		return executor;
 	}

--- a/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
+++ b/src/main/java/com/sofa/linkiving/global/fillter/RequestLoggingFilter.java
@@ -58,7 +58,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		"/favicon.ico",
 		"/swagger",
 		"/v3/api-docs",
-		"/health-check"
+		"/health-check",
+		"/h2-console"
 	};
 
 	private static final int MAX_BODY_LENGTH = 2000;

--- a/src/main/java/com/sofa/linkiving/infra/feign/EmptyAiResponseException.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/EmptyAiResponseException.java
@@ -1,0 +1,9 @@
+package com.sofa.linkiving.infra.feign;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+public class EmptyAiResponseException extends BusinessException {
+	public EmptyAiResponseException() {
+		super(ExternalApiErrorCode.EXTERNAL_API_INVALID_RESPONSE);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
@@ -17,6 +17,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
+import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -60,34 +63,32 @@ class RagAnswerClientTest {
 	}
 
 	@Test
-	@DisplayName("Feign 요청 중 예외가 발생하면 예외를 잡고 null을 반환한다")
-	void shouldCatchExceptionAndReturnNull_WhenGenerateAnswerThrowsException() {
+	@DisplayName("Feign 요청 중 예외가 발생하면 통신 오류 예외로 전환하고 failure 로 집계한다")
+	void shouldThrowCommunicationError_WhenGenerateAnswerThrowsException() {
 		// given
 		RagAnswerReq req = mock(RagAnswerReq.class);
 		given(ragAnswerFeign.generateAnswer(any(RagAnswerReq.class)))
 			.willThrow(new RuntimeException("AI Server Error"));
 
-		// when
-		RagAnswerRes actualRes = ragAnswerClient.generateAnswer(req);
-
-		// then
-		assertThat(actualRes).isNull();
+		// when & then
+		assertThatThrownBy(() -> ragAnswerClient.generateAnswer(req))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		assertThat(counterCount("failure")).isEqualTo(1.0);
 	}
 
 	@Test
-	@DisplayName("Feign 응답이 비어있으면 null 을 반환하고 empty 로 집계한다")
-	void shouldReturnNullAndCountEmpty_WhenResponseIsEmpty() {
+	@DisplayName("Feign 응답이 비어있으면 EmptyAiResponseException 을 던지고 empty 로 집계한다")
+	void shouldThrowEmptyResponse_WhenResponseIsEmpty() {
 		// given
 		RagAnswerReq req = mock(RagAnswerReq.class);
 		given(ragAnswerFeign.generateAnswer(any(RagAnswerReq.class)))
 			.willReturn(Collections.emptyList());
 
-		// when
-		RagAnswerRes actualRes = ragAnswerClient.generateAnswer(req);
-
-		// then
-		assertThat(actualRes).isNull();
+		// when & then
+		assertThatThrownBy(() -> ragAnswerClient.generateAnswer(req))
+			.isInstanceOf(EmptyAiResponseException.class);
 		assertThat(counterCount("empty")).isEqualTo(1.0);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/ai/RagSummaryClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/ai/RagSummaryClientTest.java
@@ -19,6 +19,9 @@ import com.sofa.linkiving.domain.link.dto.request.RagInitialSummaryReq;
 import com.sofa.linkiving.domain.link.dto.request.RagRegenerateSummaryReq;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
+import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -74,32 +77,30 @@ public class RagSummaryClientTest {
 	}
 
 	@Test
-	@DisplayName("최초 요약 요청 시 응답이 비어있으면 null을 반환한다")
-	void shouldReturnNullWhenInitialSummaryResponseIsEmpty() {
+	@DisplayName("최초 요약 요청 시 응답이 비어있으면 EmptyAiResponseException 을 던지고 empty 로 집계한다")
+	void shouldThrowEmptyResponse_WhenInitialSummaryResponseIsEmpty() {
 		// given
 		given(ragSummaryFeign.requestInitialSummary(any(RagInitialSummaryReq.class)))
 			.willReturn(Collections.emptyList());
 
-		// when
-		RagInitialSummaryRes result = ragSummaryClient.initialSummary(1L, 100L, "Title", "URL", "Memo");
-
-		// then
-		assertThat(result).isNull();
+		// when & then
+		assertThatThrownBy(() -> ragSummaryClient.initialSummary(1L, 100L, "Title", "URL", "Memo"))
+			.isInstanceOf(EmptyAiResponseException.class);
 		assertThat(counterCount("initial", "empty")).isEqualTo(1.0);
 	}
 
 	@Test
-	@DisplayName("최초 요약 요청 중 예외 발생 시 로그를 남기고 null을 반환한다")
-	void shouldReturnNullWhenInitialSummaryThrowsException() {
+	@DisplayName("최초 요약 요청 중 예외 발생 시 통신 오류 예외로 전환하고 failure 로 집계한다")
+	void shouldThrowCommunicationError_WhenInitialSummaryThrowsException() {
 		// given
 		given(ragSummaryFeign.requestInitialSummary(any(RagInitialSummaryReq.class)))
 			.willThrow(new RuntimeException("AI Server Error"));
 
-		// when
-		RagInitialSummaryRes result = ragSummaryClient.initialSummary(1L, 100L, "Title", "URL", "Memo");
-
-		// then
-		assertThat(result).isNull();
+		// when & then
+		assertThatThrownBy(() -> ragSummaryClient.initialSummary(1L, 100L, "Title", "URL", "Memo"))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		assertThat(counterCount("initial", "failure")).isEqualTo(1.0);
 	}
 
@@ -130,17 +131,30 @@ public class RagSummaryClientTest {
 	}
 
 	@Test
-	@DisplayName("요약 재생성 요청 중 예외 발생 시 null을 반환한다")
-	void shouldReturnNullWhenRegenerateSummaryThrowsException() {
+	@DisplayName("요약 재생성 요청 중 예외 발생 시 통신 오류 예외로 전환하고 failure 로 집계한다")
+	void shouldThrowCommunicationError_WhenRegenerateSummaryThrowsException() {
 		// given
 		given(ragSummaryFeign.requestRegenerateSummary(any(RagRegenerateSummaryReq.class)))
 			.willThrow(new RuntimeException("Connection Timeout"));
 
-		// when
-		RagRegenerateSummaryRes result = ragSummaryClient.regenerateSummary(1L, 100L, "URL", "Old");
-
-		// then
-		assertThat(result).isNull();
+		// when & then
+		assertThatThrownBy(() -> ragSummaryClient.regenerateSummary(1L, 100L, "URL", "Old"))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
 		assertThat(counterCount("regenerate", "failure")).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("요약 재생성 요청 시 응답이 비어있으면 EmptyAiResponseException 을 던지고 empty 로 집계한다")
+	void shouldThrowEmptyResponse_WhenRegenerateSummaryResponseIsEmpty() {
+		// given
+		given(ragSummaryFeign.requestRegenerateSummary(any(RagRegenerateSummaryReq.class)))
+			.willReturn(Collections.emptyList());
+
+		// when & then
+		assertThatThrownBy(() -> ragSummaryClient.regenerateSummary(1L, 100L, "URL", "Old"))
+			.isInstanceOf(EmptyAiResponseException.class);
+		assertThat(counterCount("regenerate", "empty")).isEqualTo(1.0);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -29,6 +29,7 @@ import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -276,8 +277,8 @@ class SummaryWorkerTest {
 	}
 
 	@Test
-	@DisplayName("AI 응답이 null일 경우 예외가 발생하여 FAILED 이벤트를 발행함")
-	void shouldPublishFailedEvent_WhenAiResponseIsNull() {
+	@DisplayName("AI 응답이 비어있어 EmptyAiResponseException 이 발생하면 FAILED 이벤트를 발행함")
+	void shouldPublishFailedEvent_WhenAiResponseIsEmpty() {
 		// given
 		given(summaryQueue.pollTaskFromQueue())
 			.willReturn(Optional.of(task(1L)))
@@ -285,8 +286,8 @@ class SummaryWorkerTest {
 
 		given(summaryWorkerFacade.getLinkWithMember(1L)).willReturn(mockLink);
 
-		// AI 응답이 null이면 callAiServerWithRetry 내에서 RuntimeException 발생
-		given(summaryClient.initialSummary(anyLong(), anyLong(), any(), any(), any())).willReturn(null);
+		given(summaryClient.initialSummary(anyLong(), anyLong(), any(), any(), any()))
+			.willThrow(new EmptyAiResponseException());
 
 		// when
 		summaryWorker.startWorker();


### PR DESCRIPTION
## 관련 이슈

- close #256

## PR 설명
비동기 처리의 자원 사용을 제어하고, AI 연동 실패를 null 반환에서 명시적 예외로
전환하여 실패 흐름을 명확하게 만들었습니다. 부하 시 자원 통제와 실패 추적의 기반을 마련합니다.

### 배경
- @Async 가 자원 제한 없이 동작하여 부하 시 스레드가 무제한 생성될 수 있었습니다.
- AI 연동 실패가 null 반환으로 처리되어, 호출부에서 잠재적 NPE 가 발생하고 실패 원인을 추적하기 어려웠습니다.
- 비동기 작업 최종 실패 메트릭이 실제 실패와 무관하게 매 작업마다 집계되는 버그가 있었습니다.

### 변경 사항

**1. 비동기 Executor 안정화**
- @Async 전용 Executor 에 거부 정책과 graceful shutdown 을 추가했습니다.
- 풀 사이즈는 보수적으로 설정(core 5 / max 20 / queue 100)했습니다. 트래픽 특성을 모르는 초기 단계이므로 작게 시작하고, 관측성 메트릭을 모니터링하며 추후 튜닝할 계획입니다.
- 거부 정책은 `CallerRunsPolicy` 를 선택했습니다. AI 동기화·요약 작업은 유실되면 안 되므로, 큐·풀이 포화되면 작업을 버리는 대신 호출 스레드가 직접 처리하여 백프레셔로 처리량을 자연스럽게 조절합니다.
- graceful shutdown(진행 중 작업 30초 대기)으로 종료 시 작업이 중간에 끊기지 않도록 했습니다.

**2. AI 연동 실패 → typed exception 전환**
- AI 클라이언트(summary/answer)의 null 반환을 명시적 예외로 전환했습니다.
  - 통신 오류 → `EXTERNAL_API_COMMUNICATION_ERROR`
  - 빈 응답 → `EmptyAiResponseException` (신규)
- 기존 null 반환은 호출부에서 NPE 로 이어졌으나, 명시적 예외로 전환하여 실패 원인이 로그·예외 타입으로 드러나도록 했습니다.
- Feign ErrorDecoder 가 변환한 도메인 예외(BusinessException)는 그대로 전파하여 기존 에러 의미를 보존합니다.

**3. 빈 응답 재시도 제외**
- 통신 오류와 빈 응답의 성격을 구분했습니다.
  - 통신 오류: 일시적 장애일 가능성이 높아 재시도 유지
  - 빈 응답: 입력 콘텐츠 자체가 요약 불가한 경우가 많아, 재시도해도 동일한 결과가 나오기 쉬움
- 빈 응답 전용 예외(`EmptyAiResponseException`)를 별도 타입으로 분리하고 `@Retryable` 의 `noRetryFor` 에 지정하여, 불필요한 재시도 비용과 외부 서버 부하를 줄였습니다.

**4. (버그 수정) 비동기 작업 실패 메트릭 집계 위치**
- `async.task.failures` 카운터가 try 진입 전에 무조건 증가되어, 성공·실패와 무관하게 모든 작업을 실패로 집계하던 버그를 수정했습니다.
- 재시도까지 소진된 최종 실패(catch) 시점에만 집계되도록 위치를 이동했습니다.

**5. Async Executor 포화 관측**
- executor를 bounded(core5/max20/queue100)로 만들면서 생긴 포화 리스크를 관측 가능하도록 대시보드·알림 추가. (자동계측된 `executor_*` 지표 사용, 애플리케이션 코드 변경 없음)
- Grafana(AI/Async 대시보드): 큐 대기(capacity 100, 80/100 임계선) / 스레드 active·pool·max / 큐 사용률 게이지 패널 추가.
- Prometheus 알림 룰: `AsyncExecutorQueueSaturation`(큐 대기 ≥ 80, 2m), `AsyncExecutorPoolExhausted`(풀 = max, 2m). 지속 포화 시 CallerRunsPolicy 발동(요청/이벤트 스레드 직접 실행)을 사전 감지.
- 워크로드별 executor 분리는 별도 이슈(#NNN)로 트래킹 — 포화 지표로 실제 점유율 관측 후 근거 기반 설계 예정.

**6. 정책상 변경하지 않은 클라이언트 (의도적)**
- `RagTitleClient`: 제목 생성 실패 시 기본 제목(truncate) fallback 을 유지합니다. 제목은 부가 기능이므로 예외로 전환하면 채팅 생성 자체가 실패합니다. 부가 기능 실패가 주요 흐름을 막지 않도록 fallback 을 유지했습니다.
- `RagLinkSyncClient`: void 반환이며 이미 예외를 전파하고, 호출부(LinkSyncEventListener)가 @Retryable·@Recover 로 최종 실패 처리까지 갖추고 있어 변경하지 않았습니다.
