### PR TITLE
비동기 AI 처리 회복탄력성 강화 (Circuit Breaker · 외부 API 구조화 로그 · Dead-Letter)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
     //Encryption
     implementation 'org.hashids:hashids:1.0.3'
+
+    //Resilience4j Circuit Breaker (Spring Cloud CircuitBreaker)
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 }
 
 dependencyManagement {

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
@@ -7,21 +7,22 @@ import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
-import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.ExternalApiLogger;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
-import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
+import com.sofa.linkiving.infra.feign.ExternalApiSupport;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @Profile("!test")
 @RequiredArgsConstructor
 public class RagAnswerClient implements AnswerClient {
+
+	private static final String CLIENT = "answer";
+	private static final String OPERATION = "generateAnswer";
 
 	private final RagAnswerFeign ragAnswerFeign;
 	private final MeterRegistry meterRegistry;
@@ -46,22 +47,19 @@ public class RagAnswerClient implements AnswerClient {
 
 	@Override
 	public RagAnswerRes generateAnswer(RagAnswerReq request) {
+		long startNanos = System.nanoTime();
 		List<RagAnswerRes> ragAnswerRes;
 		try {
 			ragAnswerRes = ragAnswerFeign.generateAnswer(request);
-		} catch (BusinessException e) {
-			failureCounter.increment();
-			log.warn("[AI Server] generateAnswer failed - code={}", e.getErrorCode().getCode());
-			throw e;
 		} catch (Exception e) {
-			failureCounter.increment();
-			log.warn("[AI Server] generateAnswer failed - reason={}", e.getMessage());
-			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+			throw ExternalApiSupport.handleFailure(CLIENT, OPERATION, null, failureCounter, startNanos, e);
 		}
 
 		if (ragAnswerRes == null || ragAnswerRes.isEmpty()) {
 			emptyCounter.increment();
-			log.warn("[AI Server] generateAnswer empty response");
+			ExternalApiLogger.client(CLIENT, OPERATION)
+				.elapsedMs(ExternalApiSupport.elapsedMs(startNanos))
+				.empty();
 			throw new EmptyAiResponseException();
 		}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/MockLinkSyncClient.java
@@ -10,16 +10,13 @@ import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
 public class MockLinkSyncClient implements LinkSyncClient {
 	@Override
 	public void syncCreate(LinkSyncUpdateReq req) {
-		return;
 	}
 
 	@Override
 	public void syncUpdate(LinkSyncUpdateReq req) {
-		return;
 	}
 
 	@Override
 	public void syncDelete(Long linkId) {
-		return;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
@@ -9,21 +9,21 @@ import com.sofa.linkiving.domain.link.dto.request.RagInitialSummaryReq;
 import com.sofa.linkiving.domain.link.dto.request.RagRegenerateSummaryReq;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
-import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.ExternalApiLogger;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
-import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
+import com.sofa.linkiving.infra.feign.ExternalApiSupport;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @Profile("!test")
 @RequiredArgsConstructor
 public class RagSummaryClient implements SummaryClient {
+
+	private static final String CLIENT = "summary";
 
 	private final RagSummaryFeign ragSummaryFeign;
 	private final MeterRegistry meterRegistry;
@@ -54,53 +54,48 @@ public class RagSummaryClient implements SummaryClient {
 
 	@Override
 	public RagInitialSummaryRes initialSummary(Long linkId, Long userId, String title, String url, String memo) {
+		String operation = "initialSummary";
+		long startNanos = System.nanoTime();
 		List<RagInitialSummaryRes> response;
 		try {
 			RagInitialSummaryReq req = new RagInitialSummaryReq(linkId, userId, title, url, memo);
 			response = ragSummaryFeign.requestInitialSummary(req);
-		} catch (BusinessException e) {
-			initialFailure.increment();
-			log.warn("[AI Server] Initial summary failed - linkId={}, code={}", linkId, e.getErrorCode().getCode());
-			throw e;
 		} catch (Exception e) {
-			initialFailure.increment();
-			log.warn("[AI Server] Initial summary failed - linkId={}, reason={}", linkId, e.getMessage());
-			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+			throw ExternalApiSupport.handleFailure(CLIENT, operation, linkId, initialFailure, startNanos, e);
 		}
 
-		if (response == null || response.isEmpty()) {
-			initialEmpty.increment();
-			log.warn("[AI Server] Initial summary empty response - linkId={}", linkId);
-			throw new EmptyAiResponseException();
-		}
-
+		RagInitialSummaryRes result = firstOrThrowEmpty(response, operation, linkId, initialEmpty, startNanos);
 		initialSuccess.increment();
-		return response.get(0);
+		return result;
 	}
 
 	@Override
 	public RagRegenerateSummaryRes regenerateSummary(Long linkId, Long userId, String url, String existingSummary) {
+		String operation = "regenerateSummary";
+		long startNanos = System.nanoTime();
 		List<RagRegenerateSummaryRes> response;
 		try {
 			RagRegenerateSummaryReq req = new RagRegenerateSummaryReq(linkId, userId, url, existingSummary);
 			response = ragSummaryFeign.requestRegenerateSummary(req);
-		} catch (BusinessException e) {
-			regenerateFailure.increment();
-			log.warn("[AI Server] Regenerate summary failed - linkId={}, code={}", linkId, e.getErrorCode().getCode());
-			throw e;
 		} catch (Exception e) {
-			regenerateFailure.increment();
-			log.warn("[AI Server] Regenerate summary failed - linkId={}, reason={}", linkId, e.getMessage());
-			throw new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+			throw ExternalApiSupport.handleFailure(CLIENT, operation, linkId, regenerateFailure, startNanos, e);
 		}
 
-		if (response == null || response.isEmpty()) {
-			regenerateEmpty.increment();
-			log.warn("[AI Server] Regenerate summary empty response - linkId={}", linkId);
-			throw new EmptyAiResponseException();
-		}
-
+		RagRegenerateSummaryRes result = firstOrThrowEmpty(response, operation, linkId, regenerateEmpty, startNanos);
 		regenerateSuccess.increment();
-		return response.get(0);
+		return result;
+	}
+
+	private <T> T firstOrThrowEmpty(List<T> response, String operation, Long linkId, Counter emptyCounter,
+		long startNanos) {
+		if (response != null && !response.isEmpty()) {
+			return response.get(0);
+		}
+		emptyCounter.increment();
+		ExternalApiLogger.client(CLIENT, operation)
+			.detail("linkId", linkId)
+			.elapsedMs(ExternalApiSupport.elapsedMs(startNanos))
+			.empty();
+		throw new EmptyAiResponseException();
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/AdminSummaryDeadLetterController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/AdminSummaryDeadLetterController.java
@@ -1,0 +1,48 @@
+package com.sofa.linkiving.domain.link.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sofa.linkiving.domain.link.dto.response.SummaryDeadLetterRes;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+import com.sofa.linkiving.domain.link.service.SummaryDeadLetterService;
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.config.annotation.DecodeHash;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/admin/summary/dead-letters")
+@RequiredArgsConstructor
+public class AdminSummaryDeadLetterController {
+
+	private final SummaryDeadLetterService summaryDeadLetterService;
+
+	@GetMapping
+	public BaseResponse<Page<SummaryDeadLetterRes>> getDeadLetters(
+		@RequestParam(required = false) DeadLetterStatus status,
+		@PageableDefault(size = 20) Pageable pageable) {
+		Page<SummaryDeadLetterRes> result = summaryDeadLetterService.getDeadLetters(status, pageable)
+			.map(SummaryDeadLetterRes::from);
+		return BaseResponse.success(result, "데드레터 목록을 조회했습니다.");
+	}
+
+	@PostMapping("/{id}/reprocess")
+	public BaseResponse<String> reprocess(@PathVariable @DecodeHash Long id) {
+		summaryDeadLetterService.reprocess(id);
+		return BaseResponse.noContent("데드레터 재처리를 요청했습니다.");
+	}
+
+	@PostMapping("/{id}/ignore")
+	public BaseResponse<String> ignore(@PathVariable @DecodeHash Long id) {
+		summaryDeadLetterService.ignore(id);
+		return BaseResponse.noContent("데드레터를 무시 처리했습니다.");
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryDeadLetterRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/response/SummaryDeadLetterRes.java
@@ -1,0 +1,36 @@
+package com.sofa.linkiving.domain.link.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.sofa.linkiving.domain.link.entity.SummaryDeadLetter;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+
+public record SummaryDeadLetterRes(
+	Long id,
+	Long linkId,
+	Long memberId,
+	String errorCode,
+	String exceptionType,
+	String failureReason,
+	String requestId,
+	String traceId,
+	DeadLetterStatus status,
+	LocalDateTime createdAt,
+	LocalDateTime reprocessedAt
+) {
+	public static SummaryDeadLetterRes from(SummaryDeadLetter entity) {
+		return new SummaryDeadLetterRes(
+			entity.getId(),
+			entity.getLinkId(),
+			entity.getMemberId(),
+			entity.getErrorCode(),
+			entity.getExceptionType(),
+			entity.getFailureReason(),
+			entity.getRequestId(),
+			entity.getTraceId(),
+			entity.getStatus(),
+			entity.getCreatedAt(),
+			entity.getReprocessedAt()
+		);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/entity/SummaryDeadLetter.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/entity/SummaryDeadLetter.java
@@ -1,0 +1,70 @@
+package com.sofa.linkiving.domain.link.entity;
+
+import java.time.LocalDateTime;
+
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+import com.sofa.linkiving.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SummaryDeadLetter extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long linkId;
+
+	private Long memberId;
+
+	@Column(length = 32)
+	private String errorCode;
+
+	@Column(length = 128)
+	private String exceptionType;
+
+	@Column(length = 1000)
+	private String failureReason;
+
+	@Column(length = 64)
+	private String requestId;
+
+	@Column(length = 64)
+	private String traceId;
+
+	@Column(nullable = false)
+	private DeadLetterStatus status;
+
+	private LocalDateTime reprocessedAt;
+
+	@Builder
+	public SummaryDeadLetter(Long linkId, Long memberId, String errorCode, String exceptionType,
+		String failureReason, String requestId, String traceId) {
+		this.linkId = linkId;
+		this.memberId = memberId;
+		this.errorCode = errorCode;
+		this.exceptionType = exceptionType;
+		this.failureReason = failureReason;
+		this.requestId = requestId;
+		this.traceId = traceId;
+		this.status = DeadLetterStatus.PENDING;
+	}
+
+	public void markReprocessed() {
+		this.status = DeadLetterStatus.REPROCESSED;
+		this.reprocessedAt = LocalDateTime.now();
+	}
+
+	public void markIgnored() {
+		this.status = DeadLetterStatus.IGNORED;
+	}
+
+	public boolean isReprocessable() {
+		return this.status == DeadLetterStatus.PENDING;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/enums/DeadLetterStatus.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/enums/DeadLetterStatus.java
@@ -1,0 +1,23 @@
+package com.sofa.linkiving.domain.link.enums;
+
+import com.sofa.linkiving.global.converter.AbstractCodeEnumConverter;
+import com.sofa.linkiving.global.converter.CodeEnum;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DeadLetterStatus implements CodeEnum<Integer> {
+	PENDING(0), REPROCESSED(1), IGNORED(2);
+
+	private final Integer code;
+
+	@Converter(autoApply = true)
+	static class DeadLetterStatusConverter extends AbstractCodeEnumConverter<DeadLetterStatus, Integer> {
+		public DeadLetterStatusConverter() {
+			super(DeadLetterStatus.class);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/error/SummaryErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/error/SummaryErrorCode.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 public enum SummaryErrorCode implements ErrorCode {
 
 	SUMMARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "S-001", "요약 정보를 찾을 수 없습니다."),
-	ALREADY_PROCESSING(HttpStatus.CONFLICT, "S-002", "요약 작업이 진행중입니다.");
+	ALREADY_PROCESSING(HttpStatus.CONFLICT, "S-002", "요약 작업이 진행중입니다."),
+	DEAD_LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "S-003", "데드레터를 찾을 수 없습니다."),
+	DEAD_LETTER_NOT_REPROCESSABLE(HttpStatus.CONFLICT, "S-004", "재처리할 수 없는 데드레터 상태입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
@@ -65,9 +65,9 @@ public class LinkSyncEventListener {
 	public void recover(Exception exception, LinkSyncEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
 			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
+			failureCounters.get(event.action()).increment();
 			log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
 				event.action(), event.req().linkId(), exception);
-			failureCounters.get(event.action()).increment();
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/repository/SummaryDeadLetterRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/repository/SummaryDeadLetterRepository.java
@@ -1,0 +1,13 @@
+package com.sofa.linkiving.domain.link.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sofa.linkiving.domain.link.entity.SummaryDeadLetter;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+
+public interface SummaryDeadLetterRepository extends JpaRepository<SummaryDeadLetter, Long> {
+
+	Page<SummaryDeadLetter> findAllByStatus(DeadLetterStatus status, Pageable pageable);
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/service/SummaryDeadLetterService.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/service/SummaryDeadLetterService.java
@@ -1,0 +1,113 @@
+package com.sofa.linkiving.domain.link.service;
+
+import org.slf4j.MDC;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.sofa.linkiving.domain.link.entity.SummaryDeadLetter;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.domain.link.error.SummaryErrorCode;
+import com.sofa.linkiving.domain.link.repository.SummaryDeadLetterRepository;
+import com.sofa.linkiving.domain.link.worker.SummaryQueue;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.LogContext;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SummaryDeadLetterService {
+
+	private static final int MAX_REASON_LENGTH = 1000;
+
+	private final SummaryDeadLetterRepository deadLetterRepository;
+	private final SummaryQueue summaryQueue;
+	private final LinkService linkService;
+
+	/**
+	 * 요약 작업이 영구 실패했을 때 dead-letter 로 적재한다. (워커 스레드에서 호출)
+	 */
+	@Transactional
+	public void record(Long linkId, Long memberId, Throwable cause) {
+		String errorCode = null;
+		if (cause instanceof BusinessException businessException) {
+			errorCode = businessException.getErrorCode().getCode();
+		}
+
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder()
+			.linkId(linkId)
+			.memberId(memberId)
+			.errorCode(errorCode)
+			.exceptionType(cause != null ? cause.getClass().getSimpleName() : null)
+			.failureReason(truncate(cause != null ? cause.getMessage() : null))
+			.requestId(MDC.get(LogContext.REQUEST_ID))
+			.traceId(MDC.get(LogContext.TRACE_ID))
+			.build();
+
+		deadLetterRepository.save(deadLetter);
+		log.info("Summary dead-letter recorded - linkId={}, code={}", linkId, errorCode);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<SummaryDeadLetter> getDeadLetters(DeadLetterStatus status, Pageable pageable) {
+		if (status == null) {
+			return deadLetterRepository.findAll(pageable);
+		}
+		return deadLetterRepository.findAllByStatus(status, pageable);
+	}
+
+	/**
+	 * PENDING 상태의 dead-letter 를 재처리한다. 링크 상태를 PENDING 으로 되돌리고,
+	 * 커밋 이후 요약 큐에 재적재한다(워커가 커밋 전 상태를 읽는 레이스 방지).
+	 */
+	@Transactional
+	public void reprocess(Long id) {
+		SummaryDeadLetter deadLetter = deadLetterRepository.findById(id)
+			.orElseThrow(() -> new BusinessException(SummaryErrorCode.DEAD_LETTER_NOT_FOUND));
+
+		if (!deadLetter.isReprocessable()) {
+			throw new BusinessException(SummaryErrorCode.DEAD_LETTER_NOT_REPROCESSABLE);
+		}
+
+		Long linkId = deadLetter.getLinkId();
+		linkService.updateSummaryStatus(linkId, SummaryStatus.PENDING);
+		deadLetter.markReprocessed();
+		enqueueAfterCommit(linkId);
+
+		log.info("Summary dead-letter reprocess requested - id={}, linkId={}", id, linkId);
+	}
+
+	@Transactional
+	public void ignore(Long id) {
+		SummaryDeadLetter deadLetter = deadLetterRepository.findById(id)
+			.orElseThrow(() -> new BusinessException(SummaryErrorCode.DEAD_LETTER_NOT_FOUND));
+		deadLetter.markIgnored();
+	}
+
+	private void enqueueAfterCommit(Long linkId) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					summaryQueue.addToQueue(linkId);
+				}
+			});
+		} else {
+			summaryQueue.addToQueue(linkId);
+		}
+	}
+
+	private String truncate(String value) {
+		if (value == null) {
+			return null;
+		}
+		return value.length() > MAX_REASON_LENGTH ? value.substring(0, MAX_REASON_LENGTH) : value;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -19,6 +19,7 @@ import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
+import com.sofa.linkiving.domain.link.service.SummaryDeadLetterService;
 import com.sofa.linkiving.global.logging.LogContext;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
@@ -42,6 +43,7 @@ public class SummaryWorker {
 	private final ApplicationEventPublisher eventPublisher;
 	private final ObjectProvider<SummaryWorker> selfProvider;
 	private final MeterRegistry meterRegistry;
+	private final SummaryDeadLetterService summaryDeadLetterService;
 	private Counter generateFailureCounter;
 	private volatile boolean running = true;
 	private Thread workerThread;
@@ -125,12 +127,16 @@ public class SummaryWorker {
 				generateFailureCounter.increment();
 				log.error("Failed to generate summary for linkId: {}", linkId, e);
 
+				Long failedMemberId = null;
 				try {
 					Link linkToFail = summaryWorkerFacade.getLinkWithMember(linkId);
+					failedMemberId = linkToFail.getMember().getId();
 					summaryWorkerFacade.updateSummaryStatus(linkToFail.getId(), SummaryStatus.FAILED);
 				} catch (Exception innerEx) {
 					log.error("Failed to update status to FAILED - linkId: {}", linkId, innerEx);
 				}
+
+				recordDeadLetter(linkId, failedMemberId, e);
 
 				if (userEmail != null) {
 					eventPublisher.publishEvent(new SummaryStatusEvent(
@@ -142,6 +148,14 @@ public class SummaryWorker {
 					));
 				}
 			}
+		}
+	}
+
+	private void recordDeadLetter(Long linkId, Long memberId, Throwable cause) {
+		try {
+			summaryDeadLetterService.record(linkId, memberId, cause);
+		} catch (Exception e) {
+			log.error("Failed to record summary dead-letter - linkId: {}", linkId, e);
 		}
 	}
 

--- a/src/main/java/com/sofa/linkiving/global/logging/ExternalApiLogger.java
+++ b/src/main/java/com/sofa/linkiving/global/logging/ExternalApiLogger.java
@@ -1,0 +1,107 @@
+package com.sofa.linkiving.global.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ExternalApiLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger("EXTERNAL_API");
+	private static final String CATEGORY = "external";
+	private static final int MAX_REASON_LENGTH = 300;
+
+	private ExternalApiLogger() {
+	}
+
+	public static Entry client(String client, String operation) {
+		return new Entry(client, operation);
+	}
+
+	private static String sanitize(String value) {
+		if (value == null) {
+			return null;
+		}
+		String cleaned = value.replaceAll("\\s+", " ").trim();
+		if (cleaned.length() > MAX_REASON_LENGTH) {
+			cleaned = cleaned.substring(0, MAX_REASON_LENGTH) + "...";
+		}
+		return cleaned;
+	}
+
+	public static final class Entry {
+		private final String client;
+		private final String operation;
+		private final StringBuilder details = new StringBuilder();
+		private long elapsedMs = -1L;
+		private String errorCode;
+		private String exceptionType;
+		private String reason;
+
+		private Entry(String client, String operation) {
+			this.client = client;
+			this.operation = operation;
+		}
+
+		public Entry elapsedMs(long elapsedMs) {
+			this.elapsedMs = elapsedMs;
+			return this;
+		}
+
+		public Entry errorCode(String errorCode) {
+			this.errorCode = errorCode;
+			return this;
+		}
+
+		public Entry cause(Throwable throwable) {
+			if (throwable != null) {
+				this.exceptionType = throwable.getClass().getSimpleName();
+				this.reason = sanitize(throwable.getMessage());
+			}
+			return this;
+		}
+
+		public Entry detail(String key, Object value) {
+			if (value != null) {
+				details.append(' ').append(key).append('=').append(sanitize(String.valueOf(value)));
+			}
+			return this;
+		}
+
+		public void failure() {
+			write("FAILURE");
+		}
+
+		public void empty() {
+			write("EMPTY");
+		}
+
+		private void write(String outcome) {
+			String message = build(outcome);
+			try (LogContext.MdcScope ignored = LogContext.withLogCategory(CATEGORY)) {
+				LOG.warn(message);
+			}
+		}
+
+		private String build(String outcome) {
+			StringBuilder sb = new StringBuilder(64);
+			sb.append("outcome=").append(outcome)
+				.append(" client=").append(client)
+				.append(" operation=").append(operation);
+			if (!details.isEmpty()) {
+				sb.append(details);
+			}
+			if (errorCode != null) {
+				sb.append(" code=").append(errorCode);
+			}
+			if (exceptionType != null) {
+				sb.append(" exception=").append(exceptionType);
+			}
+			if (elapsedMs >= 0L) {
+				sb.append(" elapsedMs=").append(elapsedMs);
+			}
+			if (reason != null) {
+				sb.append(" reason=\"").append(reason).append('"');
+			}
+			return sb.toString();
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiSupport.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiSupport.java
@@ -1,0 +1,51 @@
+package com.sofa.linkiving.infra.feign;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.global.logging.ExternalApiLogger;
+
+import io.micrometer.core.instrument.Counter;
+
+public final class ExternalApiSupport {
+
+	private ExternalApiSupport() {
+	}
+
+	public static BusinessException handleFailure(String client, String operation, Long linkId,
+		Counter failureCounter, long startNanos, Throwable throwable) {
+		Throwable cause = unwrap(throwable);
+		BusinessException businessException = (cause instanceof BusinessException be) ? be : null;
+
+		failureCounter.increment();
+		ExternalApiLogger.client(client, operation)
+			.detail("linkId", linkId)
+			.elapsedMs(elapsedMs(startNanos))
+			.errorCode(businessException != null ? businessException.getErrorCode().getCode() : null)
+			.cause(cause)
+			.failure();
+
+		return businessException != null
+			? businessException
+			: new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+	}
+
+	public static long elapsedMs(long startNanos) {
+		return (System.nanoTime() - startNanos) / 1_000_000L;
+	}
+
+	private static Throwable unwrap(Throwable throwable) {
+		Throwable current = throwable;
+		while ((current instanceof NoFallbackAvailableException
+			|| current instanceof ExecutionException
+			|| current instanceof CompletionException)
+			&& current.getCause() != null
+			&& current.getCause() != current) {
+			current = current.getCause();
+		}
+		return current;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -28,6 +28,11 @@ public abstract class SecurityConstants {
 		"/v1/auth/reissue"
 	};
 
+	public static final String[] ADMIN_URLS = {
+		/* admin */
+		"/v1/admin/**"
+	};
+
 	private static final String[] SEMI_PERMIT_URLS = {
 		//GET만 허용해야 하는 URL
 	};

--- a/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
+++ b/src/main/java/com/sofa/linkiving/security/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize ->
 				authorize
 					.requestMatchers(SecurityConstants.PERMIT_URLS).permitAll()
+					.requestMatchers(SecurityConstants.ADMIN_URLS).hasRole("ADMIN")
 					.anyRequest().authenticated()
 			)
 			.oauth2Login(oauth2 -> oauth2

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -50,6 +50,18 @@
         </rollingPolicy>
     </appender>
 
+    <appender name="EXTERNAL_API_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/external-api.log</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/external-api-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
@@ -69,6 +81,10 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="AUDIT_FILE"/>
         </logger>
+        <logger name="EXTERNAL_API" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="EXTERNAL_API_FILE"/>
+        </logger>
         <logger level="DEBUG" name="org.hibernate.SQL"/>
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
     </springProfile>
@@ -86,6 +102,10 @@
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="AUDIT_FILE"/>
         </logger>
+        <logger name="EXTERNAL_API" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="EXTERNAL_API_FILE"/>
+        </logger>
         <logger level="DEBUG" name="org.hibernate.SQL"/>
         <logger level="TRACE" name="org.hibernate.type.descriptor.sql.BasicBinder"/>
     </springProfile>
@@ -102,6 +122,10 @@
         <logger name="AUDIT" level="INFO" additivity="false">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="AUDIT_FILE"/>
+        </logger>
+        <logger name="EXTERNAL_API" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="EXTERNAL_API_FILE"/>
         </logger>
         <logger level="OFF" name="org.hibernate.SQL"/>
         <logger level="OFF" name="org.hibernate.type.descriptor.sql.BasicBinder"/>

--- a/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
@@ -27,7 +27,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 @DisplayName("RagAnswerClient 단위 테스트")
 class RagAnswerClientTest {
 
-
 	@Mock
 	private RagAnswerFeign ragAnswerFeign;
 	private RagAnswerClient ragAnswerClient;
@@ -43,7 +42,6 @@ class RagAnswerClientTest {
 	private double counterCount(String result) {
 		return meterRegistry.counter("ai.client.calls", "client", "answer", "result", result).count();
 	}
-
 
 	@Test
 	@DisplayName("Feign 응답이 정상일 경우 리스트의 첫 번째 요소를 반환한다")

--- a/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/integration/WebSocketChatIntegrationTest.java
@@ -40,7 +40,6 @@ import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sofa.linkiving.domain.chat.ai.AnswerClient;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
 import com.sofa.linkiving.domain.chat.entity.Chat;

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
@@ -1,0 +1,197 @@
+package com.sofa.linkiving.domain.link.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.link.entity.Link;
+import com.sofa.linkiving.domain.link.entity.SummaryDeadLetter;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+import com.sofa.linkiving.domain.link.repository.LinkRepository;
+import com.sofa.linkiving.domain.link.repository.SummaryDeadLetterRepository;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.Role;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.util.HashidsUtils;
+import com.sofa.linkiving.infra.redis.RedisService;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+public class AdminSummaryDeadLetterApiIntegrationTest {
+
+	private static final String BASE_URL = "/v1/admin/summary/dead-letters";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private LinkRepository linkRepository;
+
+	@Autowired
+	private SummaryDeadLetterRepository deadLetterRepository;
+
+	@Autowired
+	private HashidsUtils hashidsUtils;
+
+	@MockitoBean
+	private RedisService redisService;
+
+	private UserDetails adminDetails;
+	private UserDetails userDetails;
+	private Member adminMember;
+
+	@BeforeEach
+	void setUp() {
+		adminMember = memberRepository.save(Member.builder()
+			.email("admin@test.com")
+			.password("password")
+			.build());
+		Member normalMember = memberRepository.save(Member.builder()
+			.email("user@test.com")
+			.password("password")
+			.build());
+		adminDetails = new CustomMemberDetail(adminMember, Role.ADMIN);
+		userDetails = new CustomMemberDetail(normalMember, Role.USER);
+	}
+
+	private SummaryDeadLetter saveDeadLetter(Long linkId, DeadLetterStatus status) {
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder()
+			.linkId(linkId)
+			.memberId(adminMember.getId())
+			.errorCode("E_000")
+			.exceptionType("SocketTimeoutException")
+			.failureReason("timeout")
+			.requestId("req-1")
+			.traceId("trace-1")
+			.build();
+		if (status == DeadLetterStatus.REPROCESSED) {
+			deadLetter.markReprocessed();
+		} else if (status == DeadLetterStatus.IGNORED) {
+			deadLetter.markIgnored();
+		}
+		return deadLetterRepository.save(deadLetter);
+	}
+
+	@Test
+	@DisplayName("ADMIN 권한으로 dead-letter 목록을 조회한다")
+	void getDeadLetters_asAdmin() throws Exception {
+		saveDeadLetter(1L, DeadLetterStatus.PENDING);
+		saveDeadLetter(2L, DeadLetterStatus.PENDING);
+
+		mockMvc.perform(get(BASE_URL)
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.totalElements").value(2));
+	}
+
+	@Test
+	@DisplayName("status 필터로 PENDING 상태만 조회한다")
+	void getDeadLetters_filterByStatus() throws Exception {
+		saveDeadLetter(1L, DeadLetterStatus.PENDING);
+		saveDeadLetter(2L, DeadLetterStatus.IGNORED);
+
+		mockMvc.perform(get(BASE_URL)
+				.param("status", "PENDING")
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.totalElements").value(1))
+			.andExpect(jsonPath("$.data.content[0].status").value("PENDING"));
+	}
+
+	@Test
+	@DisplayName("USER 권한은 403 Forbidden")
+	void getDeadLetters_asUser_forbidden() throws Exception {
+		mockMvc.perform(get(BASE_URL)
+				.with(user(userDetails)))
+			.andDo(print())
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("PENDING dead-letter 재처리 시 REPROCESSED 로 변경된다")
+	void reprocess_pending_success() throws Exception {
+		Link link = linkRepository.save(Link.builder()
+			.member(adminMember)
+			.url("https://example.com")
+			.title("t")
+			.build());
+		SummaryDeadLetter deadLetter = saveDeadLetter(link.getId(), DeadLetterStatus.PENDING);
+		String hashId = hashidsUtils.encode(deadLetter.getId());
+
+		mockMvc.perform(post(BASE_URL + "/{id}/reprocess", hashId)
+				.with(csrf())
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		assertThat(deadLetterRepository.findById(deadLetter.getId()).orElseThrow().getStatus())
+			.isEqualTo(DeadLetterStatus.REPROCESSED);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 dead-letter 재처리 시 404")
+	void reprocess_notFound() throws Exception {
+		String hashId = hashidsUtils.encode(999999L);
+		mockMvc.perform(post(BASE_URL + "/{id}/reprocess", hashId)
+				.with(csrf())
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("이미 재처리된 dead-letter 재처리 시 409")
+	void reprocess_alreadyReprocessed_conflict() throws Exception {
+		SummaryDeadLetter deadLetter = saveDeadLetter(1L, DeadLetterStatus.REPROCESSED);
+
+		String hashId = hashidsUtils.encode(deadLetter.getId());
+
+		mockMvc.perform(post(BASE_URL + "/{id}/reprocess", hashId)
+				.with(csrf())
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	@DisplayName("dead-letter 무시 처리 시 IGNORED 로 변경된다")
+	void ignore_success() throws Exception {
+		SummaryDeadLetter deadLetter = saveDeadLetter(1L, DeadLetterStatus.PENDING);
+		String hashId = hashidsUtils.encode(deadLetter.getId());
+
+		mockMvc.perform(post(BASE_URL + "/{id}/ignore", hashId)
+				.with(csrf())
+				.with(user(adminDetails)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		assertThat(deadLetterRepository.findById(deadLetter.getId()).orElseThrow().getStatus())
+			.isEqualTo(DeadLetterStatus.IGNORED);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/LinkApiIntegrationTest.java
@@ -268,7 +268,6 @@ public class LinkApiIntegrationTest {
 		Long linkId = link.getId();
 		String hashLinkId = hashidsUtils.encode(linkId);
 
-
 		// when & then
 		mockMvc.perform(
 				delete(BASE_URL + "/{id}", hashLinkId)
@@ -660,7 +659,6 @@ public class LinkApiIntegrationTest {
 
 		Long linkId = savedLink.getId();
 		String hashLinkId = hashidsUtils.encode(linkId);
-
 
 		summaryRepository.save(Summary.builder()
 			.link(savedLink)

--- a/src/test/java/com/sofa/linkiving/domain/link/service/SummaryDeadLetterServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/service/SummaryDeadLetterServiceTest.java
@@ -1,0 +1,213 @@
+package com.sofa.linkiving.domain.link.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.sofa.linkiving.domain.link.entity.SummaryDeadLetter;
+import com.sofa.linkiving.domain.link.enums.DeadLetterStatus;
+import com.sofa.linkiving.domain.link.enums.SummaryStatus;
+import com.sofa.linkiving.domain.link.error.SummaryErrorCode;
+import com.sofa.linkiving.domain.link.repository.SummaryDeadLetterRepository;
+import com.sofa.linkiving.domain.link.worker.SummaryQueue;
+import com.sofa.linkiving.global.error.exception.BusinessException;
+import com.sofa.linkiving.infra.feign.ExternalApiErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class SummaryDeadLetterServiceTest {
+
+	@Mock
+	private SummaryDeadLetterRepository deadLetterRepository;
+
+	@Mock
+	private SummaryQueue summaryQueue;
+
+	@Mock
+	private LinkService linkService;
+
+	@InjectMocks
+	private SummaryDeadLetterService summaryDeadLetterService;
+
+	@Test
+	@DisplayName("record: BusinessException 원인이면 errorCode 를 추출해 PENDING 으로 적재한다")
+	void record_withBusinessException() {
+		BusinessException cause = new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+
+		summaryDeadLetterService.record(10L, 20L, cause);
+
+		ArgumentCaptor<SummaryDeadLetter> captor = ArgumentCaptor.forClass(SummaryDeadLetter.class);
+		verify(deadLetterRepository).save(captor.capture());
+		SummaryDeadLetter saved = captor.getValue();
+		assertThat(saved.getLinkId()).isEqualTo(10L);
+		assertThat(saved.getMemberId()).isEqualTo(20L);
+		assertThat(saved.getErrorCode()).isEqualTo("E_000");
+		assertThat(saved.getExceptionType()).isEqualTo("BusinessException");
+		assertThat(saved.getStatus()).isEqualTo(DeadLetterStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("record: 일반 예외면 errorCode 는 null, 예외 타입/메시지를 기록한다")
+	void record_withGenericException() {
+		Throwable cause = new RuntimeException("boom");
+
+		summaryDeadLetterService.record(10L, null, cause);
+
+		ArgumentCaptor<SummaryDeadLetter> captor = ArgumentCaptor.forClass(SummaryDeadLetter.class);
+		verify(deadLetterRepository).save(captor.capture());
+		SummaryDeadLetter saved = captor.getValue();
+		assertThat(saved.getErrorCode()).isNull();
+		assertThat(saved.getExceptionType()).isEqualTo("RuntimeException");
+		assertThat(saved.getFailureReason()).isEqualTo("boom");
+		assertThat(saved.getMemberId()).isNull();
+	}
+
+	@Test
+	@DisplayName("record: cause 메시지가 null 이면 failureReason 도 null 이다")
+	void record_withNullMessageCause() {
+		summaryDeadLetterService.record(1L, 2L, new RuntimeException());
+
+		ArgumentCaptor<SummaryDeadLetter> captor = ArgumentCaptor.forClass(SummaryDeadLetter.class);
+		verify(deadLetterRepository).save(captor.capture());
+		assertThat(captor.getValue().getFailureReason()).isNull();
+	}
+
+	@Test
+	@DisplayName("record: 1000자를 넘는 메시지는 1000자로 잘려 저장된다")
+	void record_withLongMessageCause() {
+		String longMessage = "x".repeat(1500);
+
+		summaryDeadLetterService.record(1L, 2L, new RuntimeException(longMessage));
+
+		ArgumentCaptor<SummaryDeadLetter> captor = ArgumentCaptor.forClass(SummaryDeadLetter.class);
+		verify(deadLetterRepository).save(captor.capture());
+		assertThat(captor.getValue().getFailureReason()).hasSize(1000);
+	}
+
+	@Test
+	@DisplayName("getDeadLetters: status 가 null 이면 findAll 을 호출한다")
+	void getDeadLetters_nullStatus() {
+		Pageable pageable = PageRequest.of(0, 20);
+		given(deadLetterRepository.findAll(pageable)).willReturn(new PageImpl<>(List.of()));
+
+		Page<SummaryDeadLetter> result = summaryDeadLetterService.getDeadLetters(null, pageable);
+
+		assertThat(result).isNotNull();
+		verify(deadLetterRepository).findAll(pageable);
+		verify(deadLetterRepository, never()).findAllByStatus(any(), any());
+	}
+
+	@Test
+	@DisplayName("getDeadLetters: status 가 있으면 findAllByStatus 를 호출한다")
+	void getDeadLetters_withStatus() {
+		Pageable pageable = PageRequest.of(0, 20);
+		given(deadLetterRepository.findAllByStatus(DeadLetterStatus.PENDING, pageable))
+			.willReturn(new PageImpl<>(List.of()));
+
+		summaryDeadLetterService.getDeadLetters(DeadLetterStatus.PENDING, pageable);
+
+		verify(deadLetterRepository).findAllByStatus(DeadLetterStatus.PENDING, pageable);
+		verify(deadLetterRepository, never()).findAll(any(Pageable.class));
+	}
+
+	@Test
+	@DisplayName("reprocess: PENDING 이면 링크 상태 PENDING 복귀 + 큐 재적재 + REPROCESSED 로 변경")
+	void reprocess_pending() {
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder().linkId(10L).build();
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.of(deadLetter));
+
+		summaryDeadLetterService.reprocess(1L);
+
+		verify(linkService).updateSummaryStatus(10L, SummaryStatus.PENDING);
+		verify(summaryQueue).addToQueue(10L);
+		assertThat(deadLetter.getStatus()).isEqualTo(DeadLetterStatus.REPROCESSED);
+		assertThat(deadLetter.getReprocessedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("reprocess: 트랜잭션이 활성일 때는 커밋 이후에 큐에 재적재한다")
+	void reprocess_enqueuesAfterCommit() {
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder().linkId(10L).build();
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.of(deadLetter));
+
+		TransactionSynchronizationManager.initSynchronization();
+		try {
+			summaryDeadLetterService.reprocess(1L);
+			// 커밋 전이므로 아직 재적재되지 않아야 한다
+			verify(summaryQueue, never()).addToQueue(anyLong());
+			// 커밋 콜백을 수동으로 실행
+			for (TransactionSynchronization sync : TransactionSynchronizationManager.getSynchronizations()) {
+				sync.afterCommit();
+			}
+		} finally {
+			TransactionSynchronizationManager.clearSynchronization();
+		}
+
+		verify(summaryQueue).addToQueue(10L);
+		assertThat(deadLetter.getStatus()).isEqualTo(DeadLetterStatus.REPROCESSED);
+	}
+
+	@Test
+	@DisplayName("reprocess: 대상이 없으면 DEAD_LETTER_NOT_FOUND")
+	void reprocess_notFound() {
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> summaryDeadLetterService.reprocess(1L))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode").isEqualTo(SummaryErrorCode.DEAD_LETTER_NOT_FOUND);
+		verify(linkService, never()).updateSummaryStatus(anyLong(), any());
+		verify(summaryQueue, never()).addToQueue(anyLong());
+	}
+
+	@Test
+	@DisplayName("reprocess: 이미 REPROCESSED 면 DEAD_LETTER_NOT_REPROCESSABLE, 부수효과 없음")
+	void reprocess_alreadyReprocessed() {
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder().linkId(10L).build();
+		deadLetter.markReprocessed();
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.of(deadLetter));
+
+		assertThatThrownBy(() -> summaryDeadLetterService.reprocess(1L))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode").isEqualTo(SummaryErrorCode.DEAD_LETTER_NOT_REPROCESSABLE);
+		verify(linkService, never()).updateSummaryStatus(anyLong(), any());
+		verify(summaryQueue, never()).addToQueue(anyLong());
+	}
+
+	@Test
+	@DisplayName("ignore: IGNORED 로 변경한다")
+	void ignore_success() {
+		SummaryDeadLetter deadLetter = SummaryDeadLetter.builder().linkId(10L).build();
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.of(deadLetter));
+
+		summaryDeadLetterService.ignore(1L);
+
+		assertThat(deadLetter.getStatus()).isEqualTo(DeadLetterStatus.IGNORED);
+	}
+
+	@Test
+	@DisplayName("ignore: 대상이 없으면 DEAD_LETTER_NOT_FOUND")
+	void ignore_notFound() {
+		given(deadLetterRepository.findById(1L)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> summaryDeadLetterService.ignore(1L))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode").isEqualTo(SummaryErrorCode.DEAD_LETTER_NOT_FOUND);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -28,6 +28,7 @@ import com.sofa.linkiving.domain.link.entity.Summary;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
+import com.sofa.linkiving.domain.link.service.SummaryDeadLetterService;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
@@ -48,21 +49,21 @@ class SummaryWorkerTest {
 	private ApplicationEventPublisher eventPublisher;
 	@Mock
 	private ObjectProvider<SummaryWorker> selfProvider;
+	@Mock
+	private SummaryDeadLetterService summaryDeadLetterService;
 
-	private MeterRegistry meterRegistry;
 	private SummaryWorker summaryWorker;
 	private Link mockLink;
-	private Member mockMember;
 
 	@BeforeEach
 	void setUp() {
-		meterRegistry = new SimpleMeterRegistry();
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
 		SummaryWorkerProperties properties = new SummaryWorkerProperties(Duration.ofMillis(10));
 		summaryWorker = new SummaryWorker(summaryQueue, properties, summaryWorkerFacade, summaryClient, eventPublisher,
-			selfProvider, meterRegistry);
+			selfProvider, meterRegistry, summaryDeadLetterService);
 
 		mockLink = mock(Link.class);
-		mockMember = mock(Member.class);
+		Member mockMember = mock(Member.class);
 
 		lenient().when(mockLink.getId()).thenReturn(1L);
 		lenient().when(mockLink.getMember()).thenReturn(mockMember);

--- a/src/test/java/com/sofa/linkiving/global/logging/ExternalApiLoggerTest.java
+++ b/src/test/java/com/sofa/linkiving/global/logging/ExternalApiLoggerTest.java
@@ -1,0 +1,96 @@
+package com.sofa.linkiving.global.logging;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+class ExternalApiLoggerTest {
+
+	private Logger logger;
+	private ListAppender<ILoggingEvent> appender;
+
+	@BeforeEach
+	void setUp() {
+		logger = (Logger)LoggerFactory.getLogger("EXTERNAL_API");
+		appender = new ListAppender<>();
+		appender.start();
+		logger.addAppender(appender);
+	}
+
+	@AfterEach
+	void tearDown() {
+		logger.detachAppender(appender);
+	}
+
+	private String lastMessage() {
+		return appender.list.get(appender.list.size() - 1).getFormattedMessage();
+	}
+
+	@Test
+	@DisplayName("failure: 모든 필드가 key=value 로 기록된다")
+	void failure_withAllFields() {
+		ExternalApiLogger.client("summary", "initialSummary")
+			.detail("linkId", 42L)
+			.elapsedMs(123L)
+			.errorCode("E_000")
+			.cause(new RuntimeException("boom"))
+			.failure();
+
+		assertThat(lastMessage())
+			.contains("outcome=FAILURE")
+			.contains("client=summary")
+			.contains("operation=initialSummary")
+			.contains("linkId=42")
+			.contains("code=E_000")
+			.contains("exception=RuntimeException")
+			.contains("elapsedMs=123")
+			.contains("reason=\"boom\"");
+	}
+
+	@Test
+	@DisplayName("empty: outcome=EMPTY 로 기록되고 code 는 없다")
+	void empty_outcome() {
+		ExternalApiLogger.client("answer", "generateAnswer")
+			.elapsedMs(10L)
+			.empty();
+
+		assertThat(lastMessage())
+			.contains("outcome=EMPTY")
+			.contains("client=answer")
+			.contains("operation=generateAnswer")
+			.contains("elapsedMs=10")
+			.doesNotContain("code=");
+	}
+
+	@Test
+	@DisplayName("cause 메시지가 null 이면 reason 을 남기지 않는다")
+	void cause_nullMessage_omitsReason() {
+		ExternalApiLogger.client("summary", "op")
+			.cause(new RuntimeException())
+			.failure();
+
+		assertThat(lastMessage())
+			.contains("exception=RuntimeException")
+			.doesNotContain("reason=");
+	}
+
+	@Test
+	@DisplayName("긴 reason 은 잘려서 ... 이 붙는다")
+	void cause_longMessage_truncated() {
+		String longMessage = "x".repeat(500);
+
+		ExternalApiLogger.client("summary", "op")
+			.cause(new RuntimeException(longMessage))
+			.failure();
+
+		assertThat(lastMessage()).contains("...");
+	}
+}

--- a/src/test/java/com/sofa/linkiving/infra/feign/ExternalApiSupportTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/feign/ExternalApiSupportTest.java
@@ -1,0 +1,87 @@
+package com.sofa.linkiving.infra.feign;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
+
+import com.sofa.linkiving.global.error.exception.BusinessException;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class ExternalApiSupportTest {
+
+	private Counter failureCounter;
+
+	@BeforeEach
+	void setUp() {
+		failureCounter = new SimpleMeterRegistry().counter("test.failures");
+	}
+
+	@Test
+	@DisplayName("원인이 BusinessException 이면 그대로 반환하고 카운터를 증가시킨다")
+	void handleFailure_businessExceptionCause() {
+		BusinessException cause = new BusinessException(ExternalApiErrorCode.EXTERNAL_API_UNAUTHORIZED);
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"summary", "initialSummary", 1L, failureCounter, System.nanoTime(), cause);
+
+		assertThat(result).isSameAs(cause);
+		assertThat(failureCounter.count()).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("원인이 일반 예외면 통신 오류로 변환한다")
+	void handleFailure_genericCause() {
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"summary", "op", 1L, failureCounter, System.nanoTime(), new RuntimeException("boom"));
+
+		assertThat(result.getErrorCode()).isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+	}
+
+	@Test
+	@DisplayName("NoFallbackAvailableException 으로 감싼 BusinessException 을 언랩한다")
+	void handleFailure_unwrapsNoFallback() {
+		BusinessException cause = new BusinessException(ExternalApiErrorCode.EXTERNAL_API_TIMEOUT);
+		Throwable wrapped = new NoFallbackAvailableException("no fallback", cause);
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"answer", "generateAnswer", null, failureCounter, System.nanoTime(), wrapped);
+
+		assertThat(result).isSameAs(cause);
+	}
+
+	@Test
+	@DisplayName("이중 래핑(NoFallback → ExecutionException)된 BusinessException 도 끝까지 언랩한다")
+	void handleFailure_unwrapsDoubleWrapped() {
+		BusinessException cause = new BusinessException(ExternalApiErrorCode.EXTERNAL_API_TIMEOUT);
+		Throwable wrapped = new NoFallbackAvailableException("no fallback", new ExecutionException(cause));
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"summary", "op", 1L, failureCounter, System.nanoTime(), wrapped);
+
+		assertThat(result).isSameAs(cause);
+	}
+
+	@Test
+	@DisplayName("래핑된 원인이 일반 예외면 통신 오류로 변환한다")
+	void handleFailure_unwrapsToGeneric() {
+		Throwable wrapped = new NoFallbackAvailableException("no fallback", new RuntimeException("boom"));
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"summary", "op", 1L, failureCounter, System.nanoTime(), wrapped);
+
+		assertThat(result.getErrorCode()).isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+	}
+
+	@Test
+	@DisplayName("elapsedMs 는 0 이상을 반환한다")
+	void elapsedMs_nonNegative() {
+		assertThat(ExternalApiSupport.elapsedMs(System.nanoTime())).isGreaterThanOrEqualTo(0L);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/infra/feign/OpenFeignIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/feign/OpenFeignIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -26,6 +27,7 @@ import okhttp3.mockwebserver.MockWebServer;
 	properties = "spring.main.allow-bean-definition-overriding=true"
 )
 @EnableFeignClients(clients = TestExternalClient.class)
+@ActiveProfiles("test")
 public class OpenFeignIntegrationTest {
 
 	private static MockWebServer mockWebServer;

--- a/src/test/java/com/sofa/linkiving/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/sofa/linkiving/security/config/SecurityConfigTest.java
@@ -1,7 +1,7 @@
 package com.sofa.linkiving.security.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 


### PR DESCRIPTION
## 관련 이슈

- close #255 

## PR 설명
AI 서버 호출의 회복탄력성을 강화했습니다. 반복 실패 시 빠르게 차단하고(Circuit Breaker), 실패 원인을 구조화된 로그로 관측하며, 영구 실패한 요약 작업을 dead-letter로 보존해 관리자가 재처리할 수 있게 만들었습니다.

### 배경
- Circuit Breaker가 없어 AI 서버 장애 시 반복 호출로 장애가 전파될 수 있었습니다.
- 실패가 전부 `EXTERNAL_API_COMMUNICATION_ERROR`로 뭉개져, 타임아웃·서킷오픈·통신오류를 로그에서 구분할 수 없었습니다.
- 요약 작업이 최종 실패하면 링크가 `FAILED`로 방치되고, 재처리할 수단이 없었습니다.

### 변경 사항

**1. Circuit Breaker 적용**
- **연동방식 A**: `spring.cloud.openfeign.circuitbreaker.enabled=true` 로 resilience4j가 **모든 Feign 호출을 프록시 레벨에서 자동으로 래핑**합니다. 따라서 차단/half-open 복구 동작은 클라이언트 코드(`RagSummaryClient` 등)에 **명시적으로 나타나지 않고 설정으로 들어갑니다** — 호출 경로는 Feign 직접 호출처럼 보여도 실제로는 CB로 감싸져 있습니다.
- **설정 위치·파라미터**: `application-local.yml` 의 `resilience4j.circuitbreaker.configs.default`
  - sliding window COUNT_BASED 10 / 최소 5콜 / 실패율 임계 50% / open 유지 30s / half-open 허용 3콜 / open→half-open 자동 전이
  - 즉 연속 실패로 실패율이 50%를 넘으면 **open으로 호출 차단**, 30초 뒤 **half-open으로 복구 시도**, 성공 3콜이면 close로 복귀합니다.
- **코드에 CB가 드러나는 지점**: 별도 `fallbackFactory`를 두지 않아서, circuit-open(`CallNotPermittedException`)을 포함한 예외가 `NoFallbackAvailableException`(경우에 따라 `ExecutionException` 이중 래핑)으로 감싸져 올라옵니다. `ExternalApiSupport.handleFailure` 의 `unwrap` 이 이를 풀어 실제 원인으로 매핑·로깅하는 부분이 **CB 동작과 직접 연결된 유일한 코드**입니다.
- `alphanumeric-ids` 로 CB id/메트릭 태그 정규화(CB id는 `@FeignClient` name이 아니라 `<인터페이스>#<메서드>(<파라미터>)` 패턴이라 `#`,`(`,`)` 포함).
- **동작 검증**: 앱 실행 후 요약/채팅을 한 번 태우면 `GET /actuator/circuitbreakers` 에 실제 생성된 CB 인스턴스와 상태가 뜹니다. AI 서버를 내려두고 5회+ 호출하면 open→(30s)→half-open→close 전이를 `circuitbreakerevents` 로 확인할 수 있습니다.

**2. (함정 대응) TimeLimiter · 예외 래핑**
- CB를 켜면 resilience4j가 호출을 TimeLimiter로 감싸는데 기본값이 `1s`라 read timeout 60s인 AI 호출이 1초에 잘립니다. `timelimiter=70s`(Feign connect 5s + read 60s 위)로 설정해 Feign 타임아웃이 먼저 터지고 기존 typed exception 경로를 유지했습니다.
- CB + fallback 없음 조합에서 Spring Cloud CircuitBreaker가 모든 예외를 `NoFallbackAvailableException`(경우에 따라 `ExecutionException` 이중 래핑)으로 감쌉니다. 이 상태로는 ErrorDecoder 코드가 전부 뭉개지고 구조화 로그 `exception=`이 무의미해지므로, **원인 예외를 언랩**하도록 처리했습니다(`ExternalApiSupport`). 언랩 후 원인이 `BusinessException`이면 코드를 보존해 rethrow, 그 외(서킷오픈 `CallNotPermittedException`, `SocketTimeoutException` 등)는 실제 예외 타입을 로그에 남기고 통신 오류로 변환합니다.
- ThreadPool Bulkhead·CB health indicator를 비활성화해 예상외 throttling과 probe 영향을 막았습니다.

**3. 외부 API 실패 구조화 로그**
- `ExternalApiLogger` 추가(named logger `EXTERNAL_API` + `logCategory=external` → `logs/external-api.log` 분리, #242 컨벤션 동일). `client/operation/code/exception/elapsedMs/reason` 를 `key=value` 로 일관되게 남겨 grep·파싱 가능.
- `exception=` 로 원인 예외 타입이 남아 타임아웃/서킷오픈/통신오류를 구분하고, `elapsedMs=` 로 느린 호출을 탐지합니다.
- `RagSummaryClient`·`RagAnswerClient` 를 구조화 로거로 전환. 두 클라이언트에 중복되던 실패 처리(언랩·카운트·로그·예외 매핑)와 소요시간 계산을 `ExternalApiSupport` 유틸로 추출했습니다.

**4. Dead-Letter 적재 + 재처리 admin API**
- `SummaryDeadLetter` 엔티티로 실패 건을 DB에 영속(요약 큐가 인메모리라 재시작 시 유실 → 보존 필요). `linkId/memberId/errorCode/exceptionType/reason/requestId/traceId/status` 적재.
- `SummaryWorker` 최종 실패 시 dead-letter 기록(기존 `FAILED` 처리·실패 이벤트와 격리).
- 재처리는 링크 상태를 `PENDING` 복귀 + **커밋 이후** 큐에 재적재(워커가 커밋 전 상태를 읽는 레이스 방지). 무시 처리도 지원.
- admin API 3개(`GET` 목록 / `POST reprocess` / `POST ignore`, `/v1/admin/summary/dead-letters`)를 추가하고 `/v1/admin/**` 를 `ROLE_ADMIN` 으로 보호(`SecurityConstants.ADMIN_URLS`).
- `SummaryErrorCode` 에 `DEAD_LETTER_NOT_FOUND`(404), `DEAD_LETTER_NOT_REPROCESSABLE`(409) 추가.

**5. 정책상 변경하지 않은 것 (의도적)**
- `RagTitleClient`: 실패 시 truncate fallback 유지(`catch(Exception)`이라 래핑 예외도 fallback으로 처리됨).
- `RagLinkSyncClient`/`LinkSyncEventListener`: 이미 `@Retryable`/`@Recover` 보유(래핑 예외도 재시도됨) → dead-letter 대상 제외.

### 후속 / 보류
- circuit-open 별도 코드(`EXTERNAL_API_UNAVAILABLE` 503) 구분 → 보류.
- CB 설정 base 승격, per-instance 튜닝(인스턴스 id 런타임 확정 후), Feign read timeout 60s 재검토.
- dead-letter 범위는 summary 한정. admin 목록 응답 `Page` PageImpl 직렬화 경고(동작 무관, 필요 시 페이지 DTO 래핑).