### PR TITLE
메트릭 태그 키셋 정합성 통일 및 등록 팩토리 도입 (ai.client.calls · async.task.failures)

### DIFF
--- a/docker/alerting/alert.rules.yml
+++ b/docker/alerting/alert.rules.yml
@@ -58,14 +58,15 @@ groups:
 
       # ── 비동기 작업 최종 실패 ──────────────────────────────
       # 재시도 소진 후 최종 실패가 발생하면 즉시 알림 (수동 복구 필요 신호)
+      # async.task.failures 태그 키셋은 task·action 으로 통일되어 action 은 항상 존재한다.
       - alert: AsyncTaskFinalFailure
         expr: increase(async_task_failures_total[10m]) > 0
         for: 0m
         labels:
           severity: critical
         annotations:
-          summary: "비동기 작업 최종 실패: {{ $labels.task }}"
-          description: "task '{{ $labels.task }}'{{ if $labels.action }} (action {{ $labels.action }}){{ end }} 에서 재시도 소진 후 최종 실패가 발생했습니다. 수동 복구가 필요할 수 있습니다."
+          summary: "비동기 작업 최종 실패: {{ $labels.task }} ({{ $labels.action }})"
+          description: "task '{{ $labels.task }}' 의 action '{{ $labels.action }}' 에서 재시도 소진 후 최종 실패가 발생했습니다. 수동 복구가 필요할 수 있습니다."
 
       # ── 비동기 executor 큐 포화 임박 ──────────────────────
       # applicationTaskExecutor 큐(capacity 100)의 80% 이상(=80건)이 2분 지속되면 경고.

--- a/docker/grafana/dashboards/linkiving-ai-async-overview.json
+++ b/docker/grafana/dashboards/linkiving-ai-async-overview.json
@@ -38,7 +38,7 @@
   "timezone": "",
   "title": "Linkiving AI / Async Overview",
   "uid": "linkiving-ai-async-overview",
-  "version": 2,
+  "version": 3,
   "panels": [
     {
       "id": 1,
@@ -231,7 +231,7 @@
     },
     {
       "id": 4,
-      "title": "비동기 작업 최종 실패 (task별, 1h 증가)",
+      "title": "비동기 작업 최종 실패 (task/action별, 1h 증가)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -278,8 +278,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (task) (increase(async_task_failures_total[1h]))",
-          "legendFormat": "{{task}}",
+          "expr": "sum by (task, action) (increase(async_task_failures_total[1h]))",
+          "legendFormat": "{{task}} / {{action}}",
           "refId": "A"
         }
       ]

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClient.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Component;
 import com.sofa.linkiving.domain.chat.dto.request.RagAnswerReq;
 import com.sofa.linkiving.domain.chat.dto.response.RagAnswerRes;
 import com.sofa.linkiving.global.logging.ExternalApiLogger;
+import com.sofa.linkiving.global.metrics.AiClientMetrics;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Client;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Operation;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Result;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 import com.sofa.linkiving.infra.feign.ExternalApiSupport;
 
@@ -21,8 +25,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RagAnswerClient implements AnswerClient {
 
-	private static final String CLIENT = "answer";
-	private static final String OPERATION = "generateAnswer";
+	private static final Client CLIENT = Client.ANSWER;
+	private static final Operation OPERATION = Operation.GENERATE;
 
 	private final RagAnswerFeign ragAnswerFeign;
 	private final MeterRegistry meterRegistry;
@@ -33,16 +37,13 @@ public class RagAnswerClient implements AnswerClient {
 
 	@PostConstruct
 	private void initCounters() {
-		this.successCounter = buildCounter("success");
-		this.emptyCounter = buildCounter("empty");
-		this.failureCounter = buildCounter("failure");
+		this.successCounter = buildCounter(Result.SUCCESS);
+		this.emptyCounter = buildCounter(Result.EMPTY);
+		this.failureCounter = buildCounter(Result.FAILURE);
 	}
 
-	private Counter buildCounter(String result) {
-		return Counter.builder("ai.client.calls")
-			.tag("client", "answer")
-			.tag("result", result)
-			.register(meterRegistry);
+	private Counter buildCounter(Result result) {
+		return AiClientMetrics.counter(meterRegistry, CLIENT, OPERATION, result);
 	}
 
 	@Override
@@ -52,12 +53,13 @@ public class RagAnswerClient implements AnswerClient {
 		try {
 			ragAnswerRes = ragAnswerFeign.generateAnswer(request);
 		} catch (Exception e) {
-			throw ExternalApiSupport.handleFailure(CLIENT, OPERATION, null, failureCounter, startNanos, e);
+			throw ExternalApiSupport.handleFailure(CLIENT.getValue(), OPERATION.getValue(), null, failureCounter,
+				startNanos, e);
 		}
 
 		if (ragAnswerRes == null || ragAnswerRes.isEmpty()) {
 			emptyCounter.increment();
-			ExternalApiLogger.client(CLIENT, OPERATION)
+			ExternalApiLogger.client(CLIENT.getValue(), OPERATION.getValue())
 				.elapsedMs(ExternalApiSupport.elapsedMs(startNanos))
 				.empty();
 			throw new EmptyAiResponseException();

--- a/src/main/java/com/sofa/linkiving/domain/chat/ai/RagTitleClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/ai/RagTitleClient.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.chat.dto.request.TitleGenerateReq;
 import com.sofa.linkiving.domain.chat.dto.response.TitleGenerateRes;
+import com.sofa.linkiving.global.metrics.AiClientMetrics;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Client;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Operation;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Result;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -21,6 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 public class RagTitleClient implements TitleClient {
 
 	private static final int MAX_TITLE_LENGTH = 100;
+	private static final Client CLIENT = Client.TITLE;
+	private static final Operation OPERATION = Operation.GENERATE;
+
 	private final RagTitleFeign ragTitleFeign;
 	private final MeterRegistry meterRegistry;
 
@@ -30,16 +37,13 @@ public class RagTitleClient implements TitleClient {
 
 	@PostConstruct
 	private void initCounters() {
-		this.successCounter = buildCounter("success");
-		this.emptyCounter = buildCounter("empty");
-		this.failureCounter = buildCounter("failure");
+		this.successCounter = buildCounter(Result.SUCCESS);
+		this.emptyCounter = buildCounter(Result.EMPTY);
+		this.failureCounter = buildCounter(Result.FAILURE);
 	}
 
-	private Counter buildCounter(String result) {
-		return Counter.builder("ai.client.calls")
-			.tag("client", "title")
-			.tag("result", result)
-			.register(meterRegistry);
+	private Counter buildCounter(Result result) {
+		return AiClientMetrics.counter(meterRegistry, CLIENT, OPERATION, result);
 	}
 
 	@Override

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/RagLinkSyncClient.java
@@ -5,6 +5,10 @@ import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.link.dto.request.LinkSyncDeleteReq;
 import com.sofa.linkiving.domain.link.dto.request.LinkSyncUpdateReq;
+import com.sofa.linkiving.global.metrics.AiClientMetrics;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Client;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Operation;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Result;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -18,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RagLinkSyncClient implements LinkSyncClient {
 
+	private static final Client CLIENT = Client.LINK_SYNC;
+
 	private final LinkSyncFeign linkSyncFeign;
 	private final MeterRegistry meterRegistry;
 	private Counter createSuccess;
@@ -27,22 +33,23 @@ public class RagLinkSyncClient implements LinkSyncClient {
 	private Counter deleteSuccess;
 	private Counter deleteFailure;
 
+	/*
+	 * link-sync 는 void 반환이라 '빈 응답' 결과가 도메인에 존재하지 않는다.
+	 * 따라서 result 값은 success/failure 2종만 사용한다(의도적).
+	 * 통일 대상은 태그 키셋(client·operation·result)이며, 값 도메인은 각 클라이언트 성격에 따른다.
+	 */
 	@PostConstruct
 	private void initCounters() {
-		this.createSuccess = buildCounter("create", "success");
-		this.createFailure = buildCounter("create", "failure");
-		this.updateSuccess = buildCounter("update", "success");
-		this.updateFailure = buildCounter("update", "failure");
-		this.deleteSuccess = buildCounter("delete", "success");
-		this.deleteFailure = buildCounter("delete", "failure");
+		this.createSuccess = buildCounter(Operation.CREATE, Result.SUCCESS);
+		this.createFailure = buildCounter(Operation.CREATE, Result.FAILURE);
+		this.updateSuccess = buildCounter(Operation.UPDATE, Result.SUCCESS);
+		this.updateFailure = buildCounter(Operation.UPDATE, Result.FAILURE);
+		this.deleteSuccess = buildCounter(Operation.DELETE, Result.SUCCESS);
+		this.deleteFailure = buildCounter(Operation.DELETE, Result.FAILURE);
 	}
 
-	private Counter buildCounter(String operation, String result) {
-		return Counter.builder("ai.client.calls")
-			.tag("client", "link-sync")
-			.tag("operation", operation)
-			.tag("result", result)
-			.register(meterRegistry);
+	private Counter buildCounter(Operation operation, Result result) {
+		return AiClientMetrics.counter(meterRegistry, CLIENT, operation, result);
 	}
 
 	@Override

--- a/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/ai/RagSummaryClient.java
@@ -10,6 +10,10 @@ import com.sofa.linkiving.domain.link.dto.request.RagRegenerateSummaryReq;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.RagRegenerateSummaryRes;
 import com.sofa.linkiving.global.logging.ExternalApiLogger;
+import com.sofa.linkiving.global.metrics.AiClientMetrics;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Client;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Operation;
+import com.sofa.linkiving.global.metrics.AiClientMetrics.Result;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 import com.sofa.linkiving.infra.feign.ExternalApiSupport;
 
@@ -17,13 +21,15 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @Profile("!test")
 @RequiredArgsConstructor
 public class RagSummaryClient implements SummaryClient {
 
-	private static final String CLIENT = "summary";
+	private static final Client CLIENT = Client.SUMMARY;
 
 	private final RagSummaryFeign ragSummaryFeign;
 	private final MeterRegistry meterRegistry;
@@ -36,32 +42,28 @@ public class RagSummaryClient implements SummaryClient {
 
 	@PostConstruct
 	private void initCounters() {
-		this.initialSuccess = buildCounter("initial", "success");
-		this.initialEmpty = buildCounter("initial", "empty");
-		this.initialFailure = buildCounter("initial", "failure");
-		this.regenerateSuccess = buildCounter("regenerate", "success");
-		this.regenerateEmpty = buildCounter("regenerate", "empty");
-		this.regenerateFailure = buildCounter("regenerate", "failure");
+		this.initialSuccess = buildCounter(Operation.INITIAL, Result.SUCCESS);
+		this.initialEmpty = buildCounter(Operation.INITIAL, Result.EMPTY);
+		this.initialFailure = buildCounter(Operation.INITIAL, Result.FAILURE);
+		this.regenerateSuccess = buildCounter(Operation.REGENERATE, Result.SUCCESS);
+		this.regenerateEmpty = buildCounter(Operation.REGENERATE, Result.EMPTY);
+		this.regenerateFailure = buildCounter(Operation.REGENERATE, Result.FAILURE);
 	}
 
-	private Counter buildCounter(String operation, String result) {
-		return Counter.builder("ai.client.calls")
-			.tag("client", "summary")
-			.tag("operation", operation)
-			.tag("result", result)
-			.register(meterRegistry);
+	private Counter buildCounter(Operation operation, Result result) {
+		return AiClientMetrics.counter(meterRegistry, CLIENT, operation, result);
 	}
 
 	@Override
 	public RagInitialSummaryRes initialSummary(Long linkId, Long userId, String title, String url, String memo) {
-		String operation = "initialSummary";
+		String operation = Operation.INITIAL.getValue();
 		long startNanos = System.nanoTime();
 		List<RagInitialSummaryRes> response;
 		try {
 			RagInitialSummaryReq req = new RagInitialSummaryReq(linkId, userId, title, url, memo);
 			response = ragSummaryFeign.requestInitialSummary(req);
 		} catch (Exception e) {
-			throw ExternalApiSupport.handleFailure(CLIENT, operation, linkId, initialFailure, startNanos, e);
+			throw ExternalApiSupport.handleFailure(CLIENT.getValue(), operation, linkId, initialFailure, startNanos, e);
 		}
 
 		RagInitialSummaryRes result = firstOrThrowEmpty(response, operation, linkId, initialEmpty, startNanos);
@@ -71,14 +73,15 @@ public class RagSummaryClient implements SummaryClient {
 
 	@Override
 	public RagRegenerateSummaryRes regenerateSummary(Long linkId, Long userId, String url, String existingSummary) {
-		String operation = "regenerateSummary";
+		String operation = Operation.REGENERATE.getValue();
 		long startNanos = System.nanoTime();
 		List<RagRegenerateSummaryRes> response;
 		try {
 			RagRegenerateSummaryReq req = new RagRegenerateSummaryReq(linkId, userId, url, existingSummary);
 			response = ragSummaryFeign.requestRegenerateSummary(req);
 		} catch (Exception e) {
-			throw ExternalApiSupport.handleFailure(CLIENT, operation, linkId, regenerateFailure, startNanos, e);
+			throw ExternalApiSupport.handleFailure(CLIENT.getValue(), operation, linkId, regenerateFailure,
+				startNanos, e);
 		}
 
 		RagRegenerateSummaryRes result = firstOrThrowEmpty(response, operation, linkId, regenerateEmpty, startNanos);
@@ -92,7 +95,7 @@ public class RagSummaryClient implements SummaryClient {
 			return response.get(0);
 		}
 		emptyCounter.increment();
-		ExternalApiLogger.client(CLIENT, operation)
+		ExternalApiLogger.client(CLIENT.getValue(), operation)
 			.detail("linkId", linkId)
 			.elapsedMs(ExternalApiSupport.elapsedMs(startNanos))
 			.empty();

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
@@ -14,6 +14,9 @@ import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.link.worker.SummaryQueue;
 import com.sofa.linkiving.global.logging.LogContext;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Action;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Task;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -39,9 +42,7 @@ public class LinkEventListener {
 
 	@PostConstruct
 	private void initCounters() {
-		this.enqueueFailureCounter = Counter.builder("async.task.failures")
-			.tag("task", "summary-enqueue")
-			.register(meterRegistry);
+		this.enqueueFailureCounter = AsyncTaskMetrics.failureCounter(meterRegistry, Task.SUMMARY, Action.ENQUEUE);
 	}
 
 	/**
@@ -50,7 +51,7 @@ public class LinkEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleLinkCreated(LinkCreatedEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
-			LogContext.MdcScope linkScope = LogContext.withLinkId(event.linkId())) {
+			LogContext.MdcScope ignoredLinkScope = LogContext.withLinkId(event.linkId())) {
 			eventPublisher.publishEvent(new SummaryStatusEvent(
 				event.email(),
 				SummaryStatusRes.of(event.linkId(), SummaryStatus.PENDING)
@@ -81,7 +82,7 @@ public class LinkEventListener {
 	@Recover
 	public void recover(Exception exception, LinkCreatedEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
-			LogContext.MdcScope linkScope = LogContext.withLinkId(event.linkId())) {
+			LogContext.MdcScope ignoredLinkScope = LogContext.withLinkId(event.linkId())) {
 			log.error("Final failure to queue link after retries - linkId: {}", event.linkId(), exception);
 			enqueueFailureCounter.increment();
 			summaryWorkerFacade.updateSummaryStatus(event.linkId(), SummaryStatus.FAILED);

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
@@ -14,6 +14,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import com.sofa.linkiving.domain.link.ai.LinkSyncClient;
 import com.sofa.linkiving.domain.link.enums.SyncAction;
 import com.sofa.linkiving.global.logging.LogContext;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Action;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Task;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -33,12 +36,18 @@ public class LinkSyncEventListener {
 
 	@PostConstruct
 	private void initCounters() {
-		for (SyncAction action : SyncAction.values()) {
-			failureCounters.put(action, Counter.builder("async.task.failures")
-				.tag("task", "link-sync")
-				.tag("action", action.name())
-				.register(meterRegistry));
+		for (SyncAction syncAction : SyncAction.values()) {
+			failureCounters.put(syncAction,
+				AsyncTaskMetrics.failureCounter(meterRegistry, Task.LINK_SYNC, toMetricAction(syncAction)));
 		}
+	}
+
+	private Action toMetricAction(SyncAction syncAction) {
+		return switch (syncAction) {
+			case CREATE -> Action.CREATE;
+			case UPDATE -> Action.UPDATE;
+			case DELETE -> Action.DELETE;
+		};
 	}
 
 	@Async
@@ -50,7 +59,7 @@ public class LinkSyncEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleLinkSyncEvent(LinkSyncEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
-			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
+			LogContext.MdcScope ignoredLinkScope = LogContext.withLinkId(event.req().linkId())) {
 			log.info("AI 서버 동기화 비동기 실행 시도 - action: {}, linkId: {}", event.action(), event.req().linkId());
 
 			switch (event.action()) {
@@ -65,9 +74,9 @@ public class LinkSyncEventListener {
 	public void recover(Exception exception, LinkSyncEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
 			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
-			failureCounters.get(event.action()).increment();
 			log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
 				event.action(), event.req().linkId(), exception);
+			failureCounters.get(event.action()).increment();
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -21,6 +21,9 @@ import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.link.service.SummaryDeadLetterService;
 import com.sofa.linkiving.global.logging.LogContext;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Action;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Task;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
 import io.micrometer.core.instrument.Counter;
@@ -50,9 +53,7 @@ public class SummaryWorker {
 
 	@PostConstruct
 	public void startWorker() {
-		this.generateFailureCounter = Counter.builder("async.task.failures")
-			.tag("task", "summary-generate")
-			.register(meterRegistry);
+		this.generateFailureCounter = AsyncTaskMetrics.failureCounter(meterRegistry, Task.SUMMARY, Action.GENERATE);
 
 		workerThread = new Thread(() -> {
 			log.info("Summary worker thread started");
@@ -94,7 +95,7 @@ public class SummaryWorker {
 		SummaryTask task = taskOpt.get();
 		Long linkId = task.linkId();
 		try (LogContext.MdcScope ignored = LogContext.restore(task.logContext());
-			LogContext.MdcScope linkScope = LogContext.withLinkId(linkId)) {
+			LogContext.MdcScope ignoredLinkScope = LogContext.withLinkId(linkId)) {
 			String userEmail = null;
 			log.info("Processing link for summary - linkId: {}", linkId);
 

--- a/src/main/java/com/sofa/linkiving/global/metrics/AiClientMetrics.java
+++ b/src/main/java/com/sofa/linkiving/global/metrics/AiClientMetrics.java
@@ -1,0 +1,65 @@
+package com.sofa.linkiving.global.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * ai.client.calls 메트릭 등록 전용 팩토리.
+ * 태그 키셋(client·operation·result)을 메서드 시그니처로 고정하여 등록 지점별 키셋 일탈을 컴파일 단계에서 차단한다.
+ * 태그 값도 enum 으로 고정해 오타·표기 흔들림을 막는다.
+ */
+public final class AiClientMetrics {
+
+	private static final String METRIC_NAME = "ai.client.calls";
+
+	private static final String TAG_CLIENT = "client";
+	private static final String TAG_OPERATION = "operation";
+	private static final String TAG_RESULT = "result";
+
+	private AiClientMetrics() {
+	}
+
+	public static Counter counter(MeterRegistry registry, Client client, Operation operation, Result result) {
+		return Counter.builder(METRIC_NAME)
+			.tag(TAG_CLIENT, client.getValue())
+			.tag(TAG_OPERATION, operation.getValue())
+			.tag(TAG_RESULT, result.getValue())
+			.register(registry);
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum Client {
+		SUMMARY("summary"),
+		ANSWER("answer"),
+		TITLE("title"),
+		LINK_SYNC("link-sync");
+
+		private final String value;
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum Operation {
+		INITIAL("initial"),
+		REGENERATE("regenerate"),
+		GENERATE("generate"),
+		CREATE("create"),
+		UPDATE("update"),
+		DELETE("delete");
+
+		private final String value;
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum Result {
+		SUCCESS("success"),
+		EMPTY("empty"),
+		FAILURE("failure");
+
+		private final String value;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/metrics/AsyncTaskMetrics.java
+++ b/src/main/java/com/sofa/linkiving/global/metrics/AsyncTaskMetrics.java
@@ -1,0 +1,52 @@
+package com.sofa.linkiving.global.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * async.task.failures 메트릭 등록 전용 팩토리.
+ * 태그 키셋(task·action)을 메서드 시그니처로 고정하여 등록 지점별 키셋 일탈을 컴파일 단계에서 차단한다.
+ *
+ * task 는 작업 계열, action 은 그 계열 안의 동작을 의미하는 서로 다른 차원이므로
+ * 문자열로 뭉치지 않고 2차원 라벨로 유지한다.
+ */
+public final class AsyncTaskMetrics {
+
+	private static final String METRIC_NAME = "async.task.failures";
+
+	private static final String TAG_TASK = "task";
+	private static final String TAG_ACTION = "action";
+
+	private AsyncTaskMetrics() {
+	}
+
+	public static Counter failureCounter(MeterRegistry registry, Task task, Action action) {
+		return Counter.builder(METRIC_NAME)
+			.tag(TAG_TASK, task.getValue())
+			.tag(TAG_ACTION, action.getValue())
+			.register(registry);
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum Task {
+		SUMMARY("summary"),
+		LINK_SYNC("link-sync");
+
+		private final String value;
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum Action {
+		GENERATE("GENERATE"),
+		ENQUEUE("ENQUEUE"),
+		CREATE("CREATE"),
+		UPDATE("UPDATE"),
+		DELETE("DELETE");
+
+		private final String value;
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/ai/RagAnswerClientTest.java
@@ -40,7 +40,8 @@ class RagAnswerClientTest {
 	}
 
 	private double counterCount(String result) {
-		return meterRegistry.counter("ai.client.calls", "client", "answer", "result", result).count();
+		return meterRegistry.counter("ai.client.calls", "client", "answer", "operation", "generate", "result", result)
+			.count();
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/chat/ai/RagTitleClientTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/ai/RagTitleClientTest.java
@@ -39,7 +39,8 @@ class RagTitleClientTest {
 	}
 
 	private double counterCount(String result) {
-		return meterRegistry.counter("ai.client.calls", "client", "title", "result", result).count();
+		return meterRegistry.counter("ai.client.calls", "client", "title", "operation", "generate", "result", result)
+			.count();
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/global/metrics/MetricsTagConsistencyTest.java
+++ b/src/test/java/com/sofa/linkiving/global/metrics/MetricsTagConsistencyTest.java
@@ -1,0 +1,97 @@
+package com.sofa.linkiving.global.metrics;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * 동일 메트릭 이름은 동일 태그 키셋을 가져야 한다.
+ * 키셋이 갈리면 등록 충돌·집계 오류가 발생하므로, 팩토리를 통해 등록된 모든 조합의 키셋 일관성을 검증한다.
+ */
+class MetricsTagConsistencyTest {
+
+	private MeterRegistry registry;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+	}
+
+	private Set<Set<String>> tagKeySetsOf(String metricName) {
+		return registry.getMeters().stream()
+			.filter(meter -> meter.getId().getName().equals(metricName))
+			.map(meter -> meter.getId().getTags().stream()
+				.map(io.micrometer.core.instrument.Tag::getKey)
+				.collect(Collectors.toSet()))
+			.collect(Collectors.toSet());
+	}
+
+	@Test
+	@DisplayName("ai.client.calls: 모든 조합이 client·operation·result 키셋으로 등록된다")
+	void aiClientCalls_hasConsistentTagKeySet() {
+		for (AiClientMetrics.Client client : AiClientMetrics.Client.values()) {
+			for (AiClientMetrics.Operation operation : AiClientMetrics.Operation.values()) {
+				for (AiClientMetrics.Result result : AiClientMetrics.Result.values()) {
+					AiClientMetrics.counter(registry, client, operation, result);
+				}
+			}
+		}
+
+		Set<Set<String>> keySets = tagKeySetsOf("ai.client.calls");
+
+		assertThat(keySets).hasSize(1);
+		assertThat(keySets.iterator().next())
+			.containsExactlyInAnyOrder("client", "operation", "result");
+	}
+
+	@Test
+	@DisplayName("async.task.failures: 모든 조합이 task·action 키셋으로 등록된다")
+	void asyncTaskFailures_hasConsistentTagKeySet() {
+		for (AsyncTaskMetrics.Task task : AsyncTaskMetrics.Task.values()) {
+			for (AsyncTaskMetrics.Action action : AsyncTaskMetrics.Action.values()) {
+				AsyncTaskMetrics.failureCounter(registry, task, action);
+			}
+		}
+
+		Set<Set<String>> keySets = tagKeySetsOf("async.task.failures");
+
+		assertThat(keySets).hasSize(1);
+		assertThat(keySets.iterator().next())
+			.containsExactlyInAnyOrder("task", "action");
+	}
+
+	@Test
+	@DisplayName("동일 태그 조합으로 재등록하면 같은 미터를 반환한다 (중복 등록 없음)")
+	void sameTags_returnSameMeter() {
+		var first = AiClientMetrics.counter(registry, AiClientMetrics.Client.SUMMARY,
+			AiClientMetrics.Operation.INITIAL, AiClientMetrics.Result.SUCCESS);
+		var second = AiClientMetrics.counter(registry, AiClientMetrics.Client.SUMMARY,
+			AiClientMetrics.Operation.INITIAL, AiClientMetrics.Result.SUCCESS);
+
+		assertThat(first).isSameAs(second);
+		assertThat(registry.getMeters().stream()
+			.filter(meter -> meter.getId().getName().equals("ai.client.calls"))
+			.count()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("등록된 미터는 모두 Counter 타입이다")
+	void registeredMeters_areCounters() {
+		AiClientMetrics.counter(registry, AiClientMetrics.Client.ANSWER,
+			AiClientMetrics.Operation.GENERATE, AiClientMetrics.Result.FAILURE);
+		AsyncTaskMetrics.failureCounter(registry, AsyncTaskMetrics.Task.SUMMARY,
+			AsyncTaskMetrics.Action.GENERATE);
+
+		assertThat(registry.getMeters())
+			.allSatisfy(meter -> assertThat(meter.getId().getType()).isEqualTo(Meter.Type.COUNTER));
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- close #259

## PR 설명
동일한 메트릭 이름을 여러 지점에서 등록하는데 태그 키셋이 일치하지 않는 문제를 교정하고, 재발을 구조적으로 차단하기 위해 메트릭 등록 전용 팩토리를 도입했습니다. (#256 PR 리뷰에서 도출)

### 배경
- `ai.client.calls`: `RagAnswerClient` 만 `operation` 태그 없이 `client·result` 로 등록되어, 같은 메트릭을 쓰는 나머지 클라이언트(`client·operation·result`)와 키셋이 갈렸습니다.
- `async.task.failures`: `LinkSyncEventListener` 만 `task·action`, 나머지(`SummaryWorker`, `LinkEventListener`)는 `task` 만 사용해 키셋이 갈렸습니다.
- 같은 메트릭 이름에 서로 다른 태그 키셋이 등록되면 등록 충돌·집계 오류 위험이 있고, `async.task.failures` 는 이미 관측 레이어까지 오염된 상태였습니다 — 알림 룰 description 이 `{{ if $labels.action }}` 조건문으로 태그 유무를 방어하고 있었고, 대시보드의 `sum by (task, action)` 패널에서 action 없는 시계열은 빈 라벨로 표시됐습니다.
- 같은 결함이 두 메트릭에서 연달아 발생한 것은 메트릭 등록 방식에 강제 장치가 없다는 구조적 신호로 판단했습니다.

### 변경 사항

**1. `ai.client.calls` — 키셋을 `client·operation·result` 로 통일**
- `RagAnswerClient` 에 `operation=generate` 추가 (나머지 클라이언트는 이미 정합)

**2. `async.task.failures` — 키셋을 `task·action` 으로 통일**
- `task`(작업 계열)와 `action`(그 안의 동작)은 의미가 다른 차원이므로 문자열로 뭉치지 않고 2차원 라벨로 정렬했습니다.

| 등록 위치 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `SummaryWorker` | `task=summary-generate` | `task=summary`, `action=GENERATE` |
| `LinkEventListener` | `task=summary-enqueue` | `task=summary`, `action=ENQUEUE` |
| `LinkSyncEventListener` | `task=link-sync`, `action=CREATE/UPDATE/DELETE` | 변경 없음 |

**3. 메트릭 등록 팩토리 도입 (재발 방지)**
- `AiClientMetrics.counter(registry, Client, Operation, Result)` / `AsyncTaskMetrics.failureCounter(registry, Task, Action)` 를 추가하고, 7개 등록 지점 전부를 팩토리 경유로 전환했습니다.
- 태그 키셋을 **메서드 시그니처로 고정**하여 키셋 누락·추가가 컴파일 단계에서 불가능합니다. 태그 값도 enum 으로 고정해 오타·표기 흔들림을 막았습니다.
- 부수 효과로, 메트릭 태그와 구조화 로그(`ExternalApiLogger`)의 `client=`/`operation=` 값이 같은 enum 에서 나와 자동으로 일치합니다.

**4. 관측 레이어 정합**
- 알림 룰 `AsyncTaskFinalFailure`: action 이 항상 존재하게 되어 `{{ if $labels.action }}` 조건 분기를 제거하고 summary/description 에 action 을 무조건 표기.
- Grafana AI/Async 대시보드 패널 4: `sum by (task)` → `sum by (task, action)`, legend `{{task}} / {{action}}` 로 변경 (패널 5는 기존 쿼리 유지).

**5. 값 도메인에 대한 의도적 결정 — link-sync 에 `empty` 미추가**
- `RagLinkSyncClient` 는 `void` 반환이라 '빈 응답' 결과가 도메인에 존재하지 않으므로, `result` 값은 `success`/`failure` 2종만 사용합니다(코드 주석으로 명시).
- 통일 대상은 태그 **키셋**이며, 태그 **값**의 도메인은 각 대상의 성격에 따라 다를 수 있습니다. 존재하지 않는 결과를 0으로 등록하면 지표가 도메인을 왜곡하고, 실패율 알림 룰도 link-sync 분모가 `success+failure` 로 정상 계산되므로 왜곡이 없습니다.
- #239 의 "카운터 0 선등록" 원칙은 *발생 가능하지만 아직 안 일어난* 결과의 시계열을 미리 만드는 취지이며, *발생 자체가 불가능한* 결과를 만드는 것이 아닙니다.

**6. 테스트**
- `MetricsTagConsistencyTest` 추가: 두 팩토리의 모든 enum 조합을 등록해 태그 키셋이 단일 키셋으로 수렴하는지, 동일 태그 재등록 시 같은 미터가 반환되는지 검증합니다. 팩토리를 우회하지 않는 한 키셋 일탈이 테스트로 차단됩니다.

### 참고
- 코드 내 설명 주석은 main 머지 시 전부 삭제할 예정입니다. 설계 의도(팩토리의 키셋 강제, link-sync empty 미추가 근거 등)는 본 PR 본문을 기록으로 남깁니다.
- `Counter.builder` 직접 호출 금지를 아키텍처 테스트(ArchUnit)로 강제하는 것은 후속 이슈로 분리합니다.
- `async.task.failures` 의 기존 `task` 값이 변경되어 Prometheus 기존 시계열과 단절됩니다. 운영 초기이므로 지금 바로잡는 비용이 가장 낮다고 판단했습니다.
