### PR TITLE
워크로드별 async executor 분리 (AI 연동 / 이벤트 후속 처리)

### DIFF
--- a/docker/alerting/alert.rules.yml
+++ b/docker/alerting/alert.rules.yml
@@ -69,26 +69,31 @@ groups:
           description: "task '{{ $labels.task }}' 의 action '{{ $labels.action }}' 에서 재시도 소진 후 최종 실패가 발생했습니다. 수동 복구가 필요할 수 있습니다."
 
       # ── 비동기 executor 큐 포화 임박 ──────────────────────
-      # applicationTaskExecutor 큐(capacity 100)의 80% 이상(=80건)이 2분 지속되면 경고.
-      # 큐가 가득 차고 풀도 max면 CallerRunsPolicy가 발동해 호출/이벤트 스레드가 작업을 직접 실행하게 됨.
+      # executor별 큐 용량이 다르므로(app 100 / ai 30) 절대값 대신 사용률 기반으로 감지.
+      # 큐 사용률 80% 이상이 2분 지속되면 경고. 큐가 가득 차고 풀도 max면
+      # CallerRunsPolicy가 발동해 호출/이벤트 스레드가 작업을 직접 실행하게 됨.
       - alert: AsyncExecutorQueueSaturation
-        expr: executor_queued_tasks{name="applicationTaskExecutor"} >= 80
+        expr: |
+          executor_queued_tasks{name=~"applicationTaskExecutor|aiTaskExecutor"}
+          / (executor_queued_tasks{name=~"applicationTaskExecutor|aiTaskExecutor"}
+             + executor_queue_remaining_tasks{name=~"applicationTaskExecutor|aiTaskExecutor"})
+          >= 0.8
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "async executor 큐 포화 임박"
-          description: "applicationTaskExecutor 대기 작업이 큐 용량(100)의 80%를 2분 이상 초과했습니다 (현재 대기 {{ $value }}건). 큐가 가득 차면 CallerRunsPolicy로 호출 스레드가 작업을 직접 실행하여 응답 지연이 발생할 수 있습니다."
+          summary: "async executor 큐 포화 임박: {{ $labels.name }}"
+          description: "executor '{{ $labels.name }}' 큐 사용률이 2분 이상 80%를 초과했습니다 (현재 {{ $value | humanizePercentage }}). 큐가 가득 차면 CallerRunsPolicy로 호출 스레드가 작업을 직접 실행하여 응답 지연이 발생할 수 있습니다."
 
       # ── 비동기 executor 스레드 풀 max 도달 ────────────────
-      # 현재 풀 스레드 수가 max(20)에 도달한 상태가 2분 지속되면 경고 (큐까지 차면 포화).
+      # 현재 풀 스레드 수가 max에 도달한 상태가 2분 지속되면 경고 (큐까지 차면 포화).
       - alert: AsyncExecutorPoolExhausted
         expr: |
-          executor_pool_size_threads{name="applicationTaskExecutor"}
-          >= executor_pool_max_threads{name="applicationTaskExecutor"}
+          executor_pool_size_threads{name=~"applicationTaskExecutor|aiTaskExecutor"}
+          >= executor_pool_max_threads{name=~"applicationTaskExecutor|aiTaskExecutor"}
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "async executor 스레드 풀 max 도달"
-          description: "applicationTaskExecutor 풀이 max({{ $value }})에 2분 이상 도달했습니다. 큐까지 가득 차면 CallerRunsPolicy로 호출/이벤트 스레드가 작업을 직접 실행하게 됩니다."
+          summary: "async executor 스레드 풀 max 도달: {{ $labels.name }}"
+          description: "executor '{{ $labels.name }}' 풀이 max({{ $value }})에 2분 이상 도달했습니다. 큐까지 가득 차면 CallerRunsPolicy로 호출/이벤트 스레드가 작업을 직접 실행하게 됩니다."

--- a/docker/grafana/dashboards/linkiving-ai-async-overview.json
+++ b/docker/grafana/dashboards/linkiving-ai-async-overview.json
@@ -38,7 +38,7 @@
   "timezone": "",
   "title": "Linkiving AI / Async Overview",
   "uid": "linkiving-ai-async-overview",
-  "version": 3,
+  "version": 4,
   "panels": [
     {
       "id": 1,
@@ -347,7 +347,7 @@
     },
     {
       "id": 6,
-      "title": "Async Executor 큐 대기 (capacity 100)",
+      "title": "Async Executor 큐 사용률 (executor별)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -361,9 +361,9 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "percentunit",
           "min": 0,
-          "max": 100,
+          "max": 1,
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 15,
@@ -381,11 +381,11 @@
               },
               {
                 "color": "orange",
-                "value": 80
+                "value": 0.8
               },
               {
                 "color": "red",
-                "value": 100
+                "value": 1
               }
             ]
           }
@@ -411,15 +411,15 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "executor_queued_tasks{name=\"applicationTaskExecutor\"}",
-          "legendFormat": "queued",
+          "expr": "executor_queued_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"} / (executor_queued_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"} + executor_queue_remaining_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"})",
+          "legendFormat": "{{name}}",
           "refId": "A"
         }
       ]
     },
     {
       "id": 7,
-      "title": "Async Executor 스레드 (active / pool / max)",
+      "title": "Async Executor 스레드 (executor별 active / pool / max)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -444,8 +444,8 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "max"
+              "id": "byRegexp",
+              "options": ".*max"
             },
             "properties": [
               {
@@ -488,8 +488,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "executor_active_threads{name=\"applicationTaskExecutor\"}",
-          "legendFormat": "active",
+          "expr": "executor_active_threads{name=~\"applicationTaskExecutor|aiTaskExecutor\"}",
+          "legendFormat": "{{name}} active",
           "refId": "A"
         },
         {
@@ -497,8 +497,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "executor_pool_size_threads{name=\"applicationTaskExecutor\"}",
-          "legendFormat": "pool",
+          "expr": "executor_pool_size_threads{name=~\"applicationTaskExecutor|aiTaskExecutor\"}",
+          "legendFormat": "{{name}} pool",
           "refId": "B"
         },
         {
@@ -506,15 +506,15 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "executor_pool_max_threads{name=\"applicationTaskExecutor\"}",
-          "legendFormat": "max",
+          "expr": "executor_pool_max_threads{name=~\"applicationTaskExecutor|aiTaskExecutor\"}",
+          "legendFormat": "{{name}} max",
           "refId": "C"
         }
       ]
     },
     {
       "id": 8,
-      "title": "큐 사용률 (현재)",
+      "title": "큐 사용률 (현재, executor별)",
       "type": "gauge",
       "datasource": {
         "type": "prometheus",
@@ -528,9 +528,9 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "percentunit",
           "min": 0,
-          "max": 100,
+          "max": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -540,11 +540,11 @@
               },
               {
                 "color": "orange",
-                "value": 80
+                "value": 0.8
               },
               {
                 "color": "red",
-                "value": 100
+                "value": 1
               }
             ]
           }
@@ -568,8 +568,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "executor_queued_tasks{name=\"applicationTaskExecutor\"}",
-          "legendFormat": "queued",
+          "expr": "executor_queued_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"} / (executor_queued_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"} + executor_queue_remaining_tasks{name=~\"applicationTaskExecutor|aiTaskExecutor\"})",
+          "legendFormat": "{{name}}",
           "refId": "A"
         }
       ]

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -36,7 +36,7 @@ public class RagChatService {
 	private final LinkQueryService linkQueryService;
 	private final ChatQueryService chatQueryService;
 
-	@Async
+	@Async("aiTaskExecutor")
 	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public CompletableFuture<AnswerRes> generateAnswer(Long chatId, Member member, String userMessage) {
 		try (LogContext.MdcScope memberScope = LogContext.withMemberId(member.getId());

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkSyncEventListener.java
@@ -50,7 +50,7 @@ public class LinkSyncEventListener {
 		};
 	}
 
-	@Async
+	@Async("aiTaskExecutor")
 	@Retryable(
 		retryFor = Exception.class,
 		maxAttempts = 3,
@@ -74,9 +74,9 @@ public class LinkSyncEventListener {
 	public void recover(Exception exception, LinkSyncEvent event) {
 		try (LogContext.MdcScope ignored = LogContext.restore(event.logContext());
 			LogContext.MdcScope linkScope = LogContext.withLinkId(event.req().linkId())) {
+			failureCounters.get(event.action()).increment();
 			log.error("[CRITICAL] AI 서버 동기화 최종 실패. 수동 복구 필요 - action: {}, linkId: {}",
 				event.action(), event.req().linkId(), exception);
-			failureCounters.get(event.action()).increment();
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
@@ -22,6 +22,11 @@ public class AsyncConfig implements AsyncConfigurer {
 		this.taskDecorator = taskDecorator;
 	}
 
+	/**
+	 * 기본 async executor. 이름 없는 @Async 가 여기로 온다.
+	 * 빠른 이벤트 후속 처리(웹소켓 푸시 등) 용도이며, 느린 AI 연동 작업은
+	 * aiTaskExecutor 로 명시 지정(opt-in)한다.
+	 */
 	@Bean
 	public ThreadPoolTaskExecutor applicationTaskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -31,6 +36,33 @@ public class AsyncConfig implements AsyncConfigurer {
 		executor.setQueueCapacity(100);
 		executor.setThreadNamePrefix("async-");
 
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(30);
+
+		executor.setTaskDecorator(taskDecorator);
+
+		executor.initialize();
+		return executor;
+	}
+
+	/**
+	 * AI 연동 전용 executor. AI 서버 호출(Feign, 최대 60s)처럼 느린 작업만 태운다.
+	 * AI 호출은 스레드가 아니라 AI 서버 처리량이 병목이므로 동시성을 낮게(max 8) 잡고
+	 * 큐(30)로 흡수한다 — 스레드를 늘려봐야 AI 서버에 동시 요청만 몰려 타임아웃을 유발한다.
+	 * 느린 AI 작업이 기본 executor 를 점유해 빠른 이벤트 처리(웹소켓 푸시)를 지연시키는 것을 격리.
+	 */
+	@Bean
+	public ThreadPoolTaskExecutor aiTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+		executor.setCorePoolSize(3);
+		executor.setMaxPoolSize(8);
+		executor.setQueueCapacity(30);
+		executor.setThreadNamePrefix("ai-async-");
+
+		// 유실 불가 정합성 작업(link-sync 등)이므로 드롭 대신 백프레셔 유지
 		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
 
 		executor.setWaitForTasksToCompleteOnShutdown(true);


### PR DESCRIPTION
## 관련 이슈
- close #260

## PR 설명
느린 AI 연동 작업과 빠른 이벤트 후속 처리가 단일 전역 executor 를 공유하던 구조를 분리했습니다. AI 전용 executor(`aiTaskExecutor`)를 신설해 느린 작업을 격리하고, 포화 관측(대시보드·알림)을 executor별로 확장했습니다. (#256 PR 리뷰에서 도출)

### 배경
- 모든 `@Async` 작업이 단일 `applicationTaskExecutor`(core5/max20/queue100)를 공유했습니다.
- AI 서버 호출(Feign, 최대 60s)과 웹소켓 푸시(ms 단위)가 같은 풀·큐를 쓰므로, AI 호출이 풀을 점유하면 실시간성이 중요한 푸시가 큐에서 대기하고, 포화 시 CallerRunsPolicy 로 호출/이벤트 스레드가 느린 작업을 직접 실행하게 됩니다.
- #256에서 추가한 executor 포화 지표로 관측 기반은 갖춰졌고, 이번에 구조적 격리를 진행합니다.

### 워크로드 인벤토리 (@Async 전수 조사)

| 지점 | 하는 일 | 소요 | 배치 |
| --- | --- | --- | --- |
| `LinkSyncEventListener.handleLinkSyncEvent` | link-sync AI 동기화 (Feign + 재시도) | 최대 60s × 3 | **aiTaskExecutor** |
| `RagChatService.generateAnswer` | 채팅 답변 AI 생성 (Feign) | 최대 60s | **aiTaskExecutor** |
| `SummaryStatusEventListener.handleSummaryStatusEvent` | 웹소켓 푸시 | ms | applicationTaskExecutor (유지) |

`LinkEventListener`(동기, @Async 없음)와 `SummaryWorker`(전용 스레드)는 executor 를 타지 않아 대상이 아닙니다.

### 변경 사항

**1. `aiTaskExecutor` 신설**
- `core 3 / max 8 / queue 30`, prefix `ai-async-`
- **사이징 근거**: AI 호출은 스레드가 아니라 **AI 서버 처리량이 병목**입니다. 동시성을 낮게(max 8) 잡고 큐(30)로 흡수합니다 — 스레드를 늘리면 AI 서버에 동시 요청만 몰려 타임아웃을 유발합니다. 초기값이며 포화 지표 관측 후 튜닝합니다(#256 컨벤션 동일).
- `CallerRunsPolicy` 유지: link-sync 는 유실 불가 정합성 작업(백프레셔 필요), 채팅 답변은 caller-runs 로 동기 강등되어도 사용자가 어차피 응답을 기다리는 요청이라 수용 가능합니다.
- `MdcTaskDecorator`·graceful shutdown(30s) 동일 적용. awaitTermination 은 AI 호출(60s)보다 짧지만, 종료 시 잘린 작업은 기존 `@Recover`/dead-letter 경로로 수습되는 구조이므로 배포 속도를 위해 30s 를 유지했습니다.

**2. 기본 executor 는 opt-in 구조로 유지**
- 이름 없는 `@Async` 는 계속 `applicationTaskExecutor`(빠른 작업)로 갑니다. 느린 작업만 `@Async("aiTaskExecutor")` 로 **명시 지정**합니다.
- 지정을 누락하면 빠른 풀로 가는데, 이는 포화 지표로 관측되며 반대 방향(빠른 작업이 AI 풀에 섞임)보다 피해가 작습니다.

**3. 포화 관측 executor별 확장**
- 큐 포화 알림을 절대값(`queued >= 80`)에서 **사용률 기반**(`queued / (queued + remaining) >= 0.8`)으로 일반화 — executor별 큐 용량(100/30)이 달라도 룰 하나로 커버되고, executor 가 늘어도 정규식에 이름만 추가하면 됩니다.
- 풀 max 알림·대시보드 패널(큐 사용률/스레드)을 `name` 라벨로 executor별 분리 표시.

### 확인
- `./gradlew test` 전체 통과
- 앱 기동 후 `/actuator/prometheus` 에서 `executor_*{name="aiTaskExecutor"}` 지표 노출 확인
- link-sync·채팅 답변 요청 시 로그 스레드명이 `ai-async-*` 인 것 확인, 웹소켓 푸시는 `async-*` 유지 확인
- Prometheus Status→Rules 에서 확장된 포화 룰 2종 로드 확인, Grafana 패널에서 executor별 분리 표시 확인

### 참고
- 코드 내 설명 주석은 main 머지 시 전부 삭제 예정이며, 설계 근거(사이징·CallerRunsPolicy 유지·opt-in 구조)는 본 PR 본문을 기록으로 남깁니다.
- executor별 사이징 재조정은 운영 포화 지표 축적 후 후속으로 진행합니다.