### PR TITLE
circuit-open 전용 에러코드 분리 (EXTERNAL_API_UNAVAILABLE, 503)

### DIFF
--- a/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiErrorCode.java
@@ -13,7 +13,8 @@ public enum ExternalApiErrorCode implements ErrorCode {
 	EXTERNAL_API_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "E_000", "외부 API 통신 중 오류가 발생했습니다."),
 	EXTERNAL_API_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "E_001", "외부 API 응답 시간이 초과되었습니다."),
 	EXTERNAL_API_INVALID_RESPONSE(HttpStatus.BAD_GATEWAY, "E_002", "외부 API 응답 포맷이 올바르지 않습니다."),
-	EXTERNAL_API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E_003", "외부 API 인증에 실패했습니다.");
+	EXTERNAL_API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E_003", "외부 API 인증에 실패했습니다."),
+	EXTERNAL_API_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E_004", "외부 API가 일시적으로 차단되어 요청을 처리할 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiSupport.java
+++ b/src/main/java/com/sofa/linkiving/infra/feign/ExternalApiSupport.java
@@ -5,9 +5,11 @@ import java.util.concurrent.ExecutionException;
 
 import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableException;
 
+import com.sofa.linkiving.global.error.code.ErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.global.logging.ExternalApiLogger;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.micrometer.core.instrument.Counter;
 
 public final class ExternalApiSupport {
@@ -18,23 +20,29 @@ public final class ExternalApiSupport {
 	public static BusinessException handleFailure(String client, String operation, Long linkId,
 		Counter failureCounter, long startNanos, Throwable throwable) {
 		Throwable cause = unwrap(throwable);
-		BusinessException businessException = (cause instanceof BusinessException be) ? be : null;
+		BusinessException businessException = (cause instanceof BusinessException be)
+			? be
+			: new BusinessException(mapErrorCode(cause));
 
 		failureCounter.increment();
 		ExternalApiLogger.client(client, operation)
 			.detail("linkId", linkId)
 			.elapsedMs(elapsedMs(startNanos))
-			.errorCode(businessException != null ? businessException.getErrorCode().getCode() : null)
+			.errorCode(businessException.getErrorCode().getCode())
 			.cause(cause)
 			.failure();
 
-		return businessException != null
-			? businessException
-			: new BusinessException(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+		return businessException;
 	}
 
 	public static long elapsedMs(long startNanos) {
 		return (System.nanoTime() - startNanos) / 1_000_000L;
+	}
+
+	private static ErrorCode mapErrorCode(Throwable cause) {
+		return (cause instanceof CallNotPermittedException)
+			? ExternalApiErrorCode.EXTERNAL_API_UNAVAILABLE
+			: ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR;
 	}
 
 	private static Throwable unwrap(Throwable throwable) {

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
@@ -30,7 +30,7 @@ import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:admin-deadletter-test;DB_CLOSE_DELAY=-1")
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -350,8 +350,11 @@ class SummaryWorkerTest {
 		summaryWorker.startWorker();
 
 		// then
+		// 파이프라인이 끝(저장 시도)까지 도달한 것을 먼저 보장 → 스텁 소비 완료 후 검증 (레이스 제거)
+		verify(summaryWorkerFacade, timeout(1000)).createInitialSummaryAndUpdateStatus(anyLong(), anyString());
+
 		ArgumentCaptor<SummaryStatusEvent> captor = ArgumentCaptor.forClass(SummaryStatusEvent.class);
-		verify(eventPublisher, timeout(1000).times(1)).publishEvent(captor.capture());
+		verify(eventPublisher, after(300).times(1)).publishEvent(captor.capture());
 
 		assertThat(captor.getValue().response().status()).isEqualTo(SummaryStatus.PROCESSING);
 	}

--- a/src/test/java/com/sofa/linkiving/infra/feign/ExternalApiSupportTest.java
+++ b/src/test/java/com/sofa/linkiving/infra/feign/ExternalApiSupportTest.java
@@ -11,6 +11,8 @@ import org.springframework.cloud.client.circuitbreaker.NoFallbackAvailableExcept
 
 import com.sofa.linkiving.global.error.exception.BusinessException;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -42,6 +44,32 @@ class ExternalApiSupportTest {
 			"summary", "op", 1L, failureCounter, System.nanoTime(), new RuntimeException("boom"));
 
 		assertThat(result.getErrorCode()).isEqualTo(ExternalApiErrorCode.EXTERNAL_API_COMMUNICATION_ERROR);
+	}
+
+	@Test
+	@DisplayName("원인이 CallNotPermittedException(circuit-open)이면 일시 차단(503)으로 변환한다")
+	void handleFailure_circuitOpenCause() {
+		CallNotPermittedException circuitOpen = CallNotPermittedException.createCallNotPermittedException(
+			CircuitBreaker.ofDefaults("testCircuitBreaker"));
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"summary", "op", 1L, failureCounter, System.nanoTime(), circuitOpen);
+
+		assertThat(result.getErrorCode()).isEqualTo(ExternalApiErrorCode.EXTERNAL_API_UNAVAILABLE);
+		assertThat(failureCounter.count()).isEqualTo(1.0);
+	}
+
+	@Test
+	@DisplayName("NoFallbackAvailableException 으로 감싼 CallNotPermittedException 도 일시 차단(503)으로 변환한다")
+	void handleFailure_unwrapsCircuitOpen() {
+		CallNotPermittedException circuitOpen = CallNotPermittedException.createCallNotPermittedException(
+			CircuitBreaker.ofDefaults("testCircuitBreaker"));
+		Throwable wrapped = new NoFallbackAvailableException("no fallback", circuitOpen);
+
+		BusinessException result = ExternalApiSupport.handleFailure(
+			"answer", "generateAnswer", null, failureCounter, System.nanoTime(), wrapped);
+
+		assertThat(result.getErrorCode()).isEqualTo(ExternalApiErrorCode.EXTERNAL_API_UNAVAILABLE);
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈
- close #264

## PR 설명
Circuit Breaker 가 open 되어 차단된 호출을 실제 통신 실패와 구분해 전용 에러코드(503)로 응답합니다. (#255 에서 보류했던 후속 작업, CB prod 승격에 따라 진행)

### 배경
기존에는 서킷 open 으로 **호출 자체가 차단된 경우**도 실제 통신 실패와 동일하게 `EXTERNAL_API_COMMUNICATION_ERROR`(502)로 응답됐습니다. 두 상황은 의미가 다릅니다.

| | 통신 오류 (E_000, 502) | circuit-open (E_004, 503) |
| --- | --- | --- |
| 상황 | 이번 호출이 실제로 실패 | 호출 자체를 하지 않음(차단) |
| 클라이언트 관점 | 재시도해볼 만함 | 당분간(open 30s) 재시도 무의미 |

구분 없이 뭉치면 프론트가 "일시 중단" UX 로 분기할 수 없고, 로그에서도 장애의 원인 실패와 차단된 후속 요청이 섞여 분석이 부정확해집니다.

### 변경 사항
- `ExternalApiErrorCode` 에 `EXTERNAL_API_UNAVAILABLE`(E_004, `SERVICE_UNAVAILABLE`) 추가
- `ExternalApiSupport.handleFailure`: 언랩된 원인이 `CallNotPermittedException` 이면 `EXTERNAL_API_UNAVAILABLE` 로 매핑. 기존 언랩 루프가 `NoFallbackAvailableException` 래핑을 이미 벗기므로 CB 경유 케이스도 자동 커버됩니다. 변경 지점은 유틸 한 곳이며 클라이언트 코드는 수정이 없습니다.
- 구조화 로그 개선: `errorCode` 필드가 매핑된 최종 코드를 항상 기록합니다(기존엔 원인이 `BusinessException` 일 때만 기록). 이제 `errorCode=E_004` 필터로 circuit-open 건을 즉시 조회할 수 있습니다.
- `ExternalApiSupportTest`: circuit-open 직접/래핑 케이스 2건 추가 (기존 6케이스 유지)

