### PR TITLE
메트릭 등록 팩토리 우회 금지 아키텍처 규칙 추가 (ArchUnit)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testImplementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
 
     // Jsoup (HTML parsing for OG tag crawling)
     implementation 'org.jsoup:jsoup:1.18.3'

--- a/src/test/java/com/sofa/linkiving/architecture/MetricsArchitectureTest.java
+++ b/src/test/java/com/sofa/linkiving/architecture/MetricsArchitectureTest.java
@@ -1,0 +1,26 @@
+package com.sofa.linkiving.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import io.micrometer.core.instrument.Counter;
+
+@AnalyzeClasses(
+	packages = "com.sofa.linkiving",
+	importOptions = ImportOption.DoNotIncludeTests.class
+)
+class MetricsArchitectureTest {
+
+	@ArchTest
+	static final ArchRule counterBuilderIsOnlyCalledFromMetricsFactories =
+		noClasses()
+			.that().resideOutsideOfPackage("..global.metrics..")
+			.should().callMethod(Counter.class, "builder", String.class)
+			.because("메트릭 등록은 전용 팩토리(AiClientMetrics, AsyncTaskMetrics)를 경유해야 "
+				+ "태그 키셋이 컴파일 타임에 강제된다. Counter.builder 직접 호출은 "
+				+ "동일 메트릭 이름에 다른 태그 키셋이 등록되는 문제를 재발시킨다 (#261, #263)");
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/integration/AdminSummaryDeadLetterApiIntegrationTest.java
@@ -30,7 +30,7 @@ import com.sofa.linkiving.global.util.HashidsUtils;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:admin-deadletter-test;DB_CLOSE_DELAY=-1")
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")


### PR DESCRIPTION
## 관련 이슈
- close #263

## PR 설명
#261 에서 도입한 메트릭 등록 팩토리(`AiClientMetrics`, `AsyncTaskMetrics`)의 우회를 아키텍처 규칙으로 차단합니다.

### 배경
팩토리는 태그 키셋을 메서드 시그니처로 고정하지만, 팩토리 사용 자체를 강제하는 장치는 없었습니다. `Counter.builder` 를 직접 호출하면 컴파일·기존 테스트를 모두 통과하면서 #259 에서 교정한 키셋 불일치가 조용히 재발할 수 있습니다. 이로써 재발 방지가 3중으로 완성됩니다:

- 1중: 팩토리 — 태그 키셋을 시그니처로 고정 (#261)
- 2중: `MetricsTagConsistencyTest` — 등록된 키셋의 수렴 검증 (#261)
- 3중: ArchUnit — 팩토리 우회 자체를 차단 (본 PR)

### 변경 사항
- `archunit-junit5:1.3.0` 의존성 추가 (testImplementation — 프로덕션 빌드에 미포함)
- `architecture` 테스트 패키지 신설, `MetricsArchitectureTest` 추가
  - 규칙: `global.metrics` 패키지 외부에서 `Counter.builder(String)` 호출 금지
  - `DoNotIncludeTests`: 검사 대상은 main 코드만 (테스트 코드는 검증 목적의 직접 등록 허용)
  - 위반 시 실패 메시지(`because`)에 팩토리 경유 이유와 재발 메커니즘 명시 → 위반자가 메시지만으로 해결 방법을 알 수 있음
- `architecture` 패키지는 향후 아키텍처 규칙(레이어 의존 등)의 확장 지점으로 사용

### 참고
- Timer/Gauge 등 다른 미터 타입 규칙 확장은 필요 시 별도 이슈로 다룹니다.