### PR TITLE
Use changelog for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ✨ Checkout repository
+        uses: actions/checkout@v5
+
+      - name: 📝 Build release notes from changelog
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          awk -v tag="${TAG_NAME}" '
+            $0 == "## [" tag "]" || $0 ~ "^## \\[" tag "\\] " {
+              capture = 1
+              next
+            }
+            capture && (/^## \[/ || /^\[[^]]+\]: /) {
+              exit
+            }
+            capture {
+              print
+            }
+          ' CHANGELOG.md > release-notes.md
+
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            {
+              echo "Could not find release notes for ${TAG_NAME} in CHANGELOG.md."
+              echo "Please add a ## [${TAG_NAME}] section before creating the tag."
+            } >&2
+            exit 1
+          fi
+
+      - name: 📦 Upload release notes
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+
   backend-docker-build-and-push:
     runs-on: ubuntu-latest
+    needs: [ build-release-notes ]
 
     steps:
       - name: ✨ Checkout repository
@@ -102,38 +142,14 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [ backend-docker-pull-and-run ]
-    if: ${{ needs.backend-docker-pull-and-run.result == 'success' }}
+    needs: [ build-release-notes, backend-docker-pull-and-run ]
+    if: ${{ needs.build-release-notes.result == 'success' && needs.backend-docker-pull-and-run.result == 'success' }}
 
     steps:
-      - name: ✨ Checkout repository
-        uses: actions/checkout@v5
-
-      - name: 📝 Build release notes from changelog
-        shell: bash
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          awk -v tag="${TAG_NAME}" '
-            $0 == "## [" tag "]" || $0 ~ "^## \\[" tag "\\] " {
-              capture = 1
-              next
-            }
-            capture && /^## \[/ {
-              exit
-            }
-            capture {
-              print
-            }
-          ' CHANGELOG.md | sed '/^[[:space:]]*$/d' > release-notes.md
-
-          if [ ! -s release-notes.md ]; then
-            {
-              echo "Could not find release notes for ${TAG_NAME} in CHANGELOG.md."
-              echo "Please add a ## [${TAG_NAME}] section before creating the tag."
-            } >&2
-            exit 1
-          fi
+      - name: 📦 Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
 
       - name: 📝 Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,36 @@ jobs:
     if: ${{ needs.backend-docker-pull-and-run.result == 'success' }}
 
     steps:
+      - name: ✨ Checkout repository
+        uses: actions/checkout@v5
+
+      - name: 📝 Build release notes from changelog
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          awk -v tag="${TAG_NAME}" '
+            $0 == "## [" tag "]" || $0 ~ "^## \\[" tag "\\] " {
+              capture = 1
+              next
+            }
+            capture && /^## \[/ {
+              exit
+            }
+            capture {
+              print
+            }
+          ' CHANGELOG.md | sed '/^[[:space:]]*$/d' > release-notes.md
+
+          if [ ! -s release-notes.md ]; then
+            {
+              echo "Could not find release notes for ${TAG_NAME} in CHANGELOG.md."
+              echo "Please add a ## [${TAG_NAME}] section before creating the tag."
+            } >&2
+            exit 1
+          fi
+
       - name: 📝 Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Before creating a release tag, add a section whose heading matches the tag name.
+For example, tag `v1.2.3` must have a `## [v1.2.3]` section.
+
+## [Unreleased]


### PR DESCRIPTION
## 관련 이슈

- close #267

## PR 설명

- 백엔드 릴리즈 워크플로우에서 GitHub 자동 생성 릴리즈 노트 사용을 제거했습니다.
- `CHANGELOG.md`에서 현재 태그에 해당하는 섹션을 추출해 `release-notes.md`를 생성하도록 수정했습니다.
- 해당 태그의 changelog 섹션이 없으면 릴리즈 생성 전에 명확한 에러 메시지와 함께 실패하도록 처리했습니다.