### PR TITLE
[Analytics] GA4 Measurement Protocol 전송 모듈 추가 (#269)

### DIFF
--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Event.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Event.java
@@ -1,0 +1,12 @@
+package com.sofa.linkiving.global.analytics;
+
+import java.util.Map;
+
+public record Ga4Event(
+	String name,
+	Map<String, Object> params
+) {
+	public Ga4Event {
+		params = params == null ? Map.of() : Map.copyOf(params);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
@@ -1,5 +1,6 @@
 package com.sofa.linkiving.global.analytics;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,14 +29,16 @@ public class Ga4MeasurementProtocolClient {
 			return;
 		}
 
-		Map<String, Object> payload = Map.of(
-			"client_id", clientId,
-			"user_id", userId,
-			"events", List.of(Map.of(
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("client_id", clientId);
+		payload.put("events", List.of(Map.of(
 				"name", event.name(),
 				"params", event.params()
-			))
-		);
+		)));
+
+		if (userId != null && !userId.isBlank()) {
+			payload.put("user_id", userId);
+		}
 
 		ga4RestClient.post()
 			.uri(uriBuilder -> uriBuilder

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
@@ -1,0 +1,50 @@
+package com.sofa.linkiving.global.analytics;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Ga4MeasurementProtocolClient {
+
+	private final RestClient ga4RestClient;
+	private final Ga4Properties properties;
+
+	public void send(String clientId, String userId, Ga4Event event) {
+		if (!properties.isReady()) {
+			log.debug("Skip GA4 event because analytics.ga4 is disabled or incomplete - event={}", event.name());
+			return;
+		}
+
+		if (clientId == null || clientId.isBlank()) {
+			log.debug("Skip GA4 event because client_id is missing - event={}", event.name());
+			return;
+		}
+
+		Map<String, Object> payload = Map.of(
+			"client_id", clientId,
+			"user_id", userId,
+			"events", List.of(Map.of(
+				"name", event.name(),
+				"params", event.params()
+			))
+		);
+
+		ga4RestClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.path("/mp/collect")
+				.queryParam("measurement_id", properties.measurementId())
+				.queryParam("api_secret", properties.apiSecret())
+				.build())
+			.body(payload)
+			.retrieve()
+			.toBodilessEntity();
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
@@ -21,4 +21,10 @@ public record Ga4Properties(
 	public boolean isReady() {
 		return enabled && StringUtils.hasText(measurementId) && StringUtils.hasText(apiSecret);
 	}
+
+	@Override
+	public String toString() {
+		return "Ga4Properties[enabled=%s, measurementId=%s, apiSecret=****, endpoint=%s]"
+			.formatted(enabled, measurementId, endpoint);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
@@ -1,0 +1,24 @@
+package com.sofa.linkiving.global.analytics;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties(prefix = "analytics.ga4")
+public record Ga4Properties(
+	boolean enabled,
+	String measurementId,
+	String apiSecret,
+	String endpoint
+) {
+	private static final String DEFAULT_ENDPOINT = "https://www.google-analytics.com";
+
+	public Ga4Properties {
+		if (!StringUtils.hasText(endpoint)) {
+			endpoint = DEFAULT_ENDPOINT;
+		}
+	}
+
+	public boolean isReady() {
+		return enabled && StringUtils.hasText(measurementId) && StringUtils.hasText(apiSecret);
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
@@ -13,12 +13,12 @@ public class Ga4Publisher {
 
 	private final Ga4MeasurementProtocolClient client;
 
-	@Async("applicationTaskExecutor")
+	@Async("analyticsTaskExecutor")
 	public void publish(String clientId, String userId, Ga4Event event) {
 		try {
 			client.send(clientId, userId, event);
 		} catch (Exception exception) {
-			log.warn("Failed to publish GA4 event - event={}", event.name(), exception);
+			log.warn("Failed to publish GA4 event - event={}, reason={}", event.name(), exception.getMessage());
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
@@ -1,0 +1,24 @@
+package com.sofa.linkiving.global.analytics;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Ga4Publisher {
+
+	private final Ga4MeasurementProtocolClient client;
+
+	@Async("applicationTaskExecutor")
+	public void publish(String clientId, String userId, Ga4Event event) {
+		try {
+			client.send(clientId, userId, event);
+		} catch (Exception exception) {
+			log.warn("Failed to publish GA4 event - event={}", event.name(), exception);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/AnalyticsConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AnalyticsConfig.java
@@ -1,8 +1,11 @@
 package com.sofa.linkiving.global.config;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 import com.sofa.linkiving.global.analytics.Ga4Properties;
@@ -12,8 +15,13 @@ import com.sofa.linkiving.global.analytics.Ga4Properties;
 public class AnalyticsConfig {
 
 	@Bean
-	public RestClient ga4RestClient(Ga4Properties properties) {
-		return RestClient.builder()
+	public RestClient ga4RestClient(RestClient.Builder builder, Ga4Properties properties) {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(Duration.ofSeconds(2));
+		requestFactory.setReadTimeout(Duration.ofSeconds(3));
+
+		return builder
+			.requestFactory(requestFactory)
 			.baseUrl(properties.endpoint())
 			.build();
 	}

--- a/src/main/java/com/sofa/linkiving/global/config/AnalyticsConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AnalyticsConfig.java
@@ -1,0 +1,20 @@
+package com.sofa.linkiving.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+import com.sofa.linkiving.global.analytics.Ga4Properties;
+
+@Configuration
+@EnableConfigurationProperties(Ga4Properties.class)
+public class AnalyticsConfig {
+
+	@Bean
+	public RestClient ga4RestClient(Ga4Properties properties) {
+		return RestClient.builder()
+			.baseUrl(properties.endpoint())
+			.build();
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
+++ b/src/main/java/com/sofa/linkiving/global/config/AsyncConfig.java
@@ -74,6 +74,23 @@ public class AsyncConfig implements AsyncConfigurer {
 		return executor;
 	}
 
+	@Bean
+	public ThreadPoolTaskExecutor analyticsTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(2);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("analytics-");
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+
+		executor.setWaitForTasksToCompleteOnShutdown(false);
+		executor.setTaskDecorator(taskDecorator);
+
+		executor.initialize();
+		return executor;
+	}
+
 	@Override
 	public Executor getAsyncExecutor() {
 		return applicationTaskExecutor();

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
@@ -1,0 +1,62 @@
+package com.sofa.linkiving.global.analytics;
+
+import static org.springframework.test.web.client.ExpectedCount.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class Ga4MeasurementProtocolClientTest {
+
+	@Test
+	void send_postsMeasurementProtocolPayload() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
+
+		server.expect(once(), requestTo(
+				"https://www.google-analytics.com/mp/collect?measurement_id=G-TEST&api_secret=secret"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.client_id").value("123.456"))
+			.andExpect(jsonPath("$.user_id").value("42"))
+			.andExpect(jsonPath("$.events[0].name").value("bookmark_save_success"))
+			.andExpect(jsonPath("$.events[0].params.source").value("web"))
+			.andRespond(withSuccess());
+
+		client.send("123.456", "42", new Ga4Event("bookmark_save_success", Map.of("source", "web")));
+
+		server.verify();
+	}
+
+	@Test
+	void send_skipsWhenDisabled() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		Ga4Properties properties = new Ga4Properties(false, "G-TEST", "secret", null);
+		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
+
+		client.send("123.456", "42", new Ga4Event("bookmark_save_success", Map.of()));
+
+		server.verify();
+	}
+
+	@Test
+	void send_skipsWhenClientIdIsMissing() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
+
+		client.send(" ", "42", new Ga4Event("bookmark_save_success", Map.of()));
+
+		server.verify();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
@@ -27,11 +27,11 @@ class Ga4MeasurementProtocolClientTest {
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.client_id").value("123.456"))
 			.andExpect(jsonPath("$.user_id").value("42"))
-			.andExpect(jsonPath("$.events[0].name").value("bookmark_save_success"))
+			.andExpect(jsonPath("$.events[0].name").value("link_save_success"))
 			.andExpect(jsonPath("$.events[0].params.source").value("web"))
 			.andRespond(withSuccess());
 
-		client.send("123.456", "42", new Ga4Event("bookmark_save_success", Map.of("source", "web")));
+		client.send("123.456", "42", new Ga4Event("link_save_success", Map.of("source", "web")));
 
 		server.verify();
 	}
@@ -43,7 +43,7 @@ class Ga4MeasurementProtocolClientTest {
 		Ga4Properties properties = new Ga4Properties(false, "G-TEST", "secret", null);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
-		client.send("123.456", "42", new Ga4Event("bookmark_save_success", Map.of()));
+		client.send("123.456", "42", new Ga4Event("link_save_success", Map.of()));
 
 		server.verify();
 	}
@@ -55,7 +55,7 @@ class Ga4MeasurementProtocolClientTest {
 		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
-		client.send(" ", "42", new Ga4Event("bookmark_save_success", Map.of()));
+		client.send(" ", "42", new Ga4Event("link_save_success", Map.of()));
 
 		server.verify();
 	}

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
@@ -49,6 +49,27 @@ class Ga4MeasurementProtocolClientTest {
 	}
 
 	@Test
+	void send_omitsUserIdWhenMissing() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
+
+		server.expect(once(), requestTo(
+				"https://www.google-analytics.com/mp/collect?measurement_id=G-TEST&api_secret=secret"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.client_id").value("123.456"))
+			.andExpect(jsonPath("$.user_id").doesNotExist())
+			.andExpect(jsonPath("$.events[0].name").value("link_save_success"))
+			.andRespond(withSuccess());
+
+		client.send("123.456", null, new Ga4Event("link_save_success", Map.of("source", "web")));
+
+		server.verify();
+	}
+
+	@Test
 	void send_skipsWhenClientIdIsMissing() {
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
@@ -1,0 +1,34 @@
+package com.sofa.linkiving.global.analytics;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class Ga4PublisherTest {
+
+	@Test
+	void publish_sendsEventToMeasurementProtocolClient() {
+		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
+		Ga4Publisher publisher = new Ga4Publisher(client);
+		Ga4Event event = new Ga4Event("bookmark_save_success", Map.of("source", "web"));
+
+		publisher.publish("123.456", "42", event);
+
+		verify(client).send("123.456", "42", event);
+	}
+
+	@Test
+	void publish_doesNotPropagateClientException() {
+		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
+		Ga4Event event = new Ga4Event("bookmark_save_success", Map.of("source", "web"));
+		willThrow(new RuntimeException("ga4 unavailable")).given(client).send("123.456", "42", event);
+		Ga4Publisher publisher = new Ga4Publisher(client);
+
+		assertThatCode(() -> publisher.publish("123.456", "42", event)).doesNotThrowAnyException();
+
+		verify(client).send("123.456", "42", event);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
@@ -13,7 +13,7 @@ class Ga4PublisherTest {
 	void publish_sendsEventToMeasurementProtocolClient() {
 		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
 		Ga4Publisher publisher = new Ga4Publisher(client);
-		Ga4Event event = new Ga4Event("bookmark_save_success", Map.of("source", "web"));
+		Ga4Event event = new Ga4Event("link_save_success", Map.of("source", "web"));
 
 		publisher.publish("123.456", "42", event);
 
@@ -23,7 +23,7 @@ class Ga4PublisherTest {
 	@Test
 	void publish_doesNotPropagateClientException() {
 		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
-		Ga4Event event = new Ga4Event("bookmark_save_success", Map.of("source", "web"));
+		Ga4Event event = new Ga4Event("link_save_success", Map.of("source", "web"));
 		willThrow(new RuntimeException("ga4 unavailable")).given(client).send("123.456", "42", event);
 		Ga4Publisher publisher = new Ga4Publisher(client);
 


### PR DESCRIPTION
## 관련이슈
- Close #269

## 요약
- GA4 Measurement Protocol 설정/전송 모듈을 추가했습니다.
- `analytics.ga4.enabled`, `measurementId`, `apiSecret`, `endpoint` 설정으로 서버 이벤트 전송을 제어합니다.
- 전송 실패는 비즈니스 흐름에 영향을 주지 않도록 publisher에서 흡수합니다.

## 테스트
- `./gradlew.bat compileJava` 통과
- 관련 클라이언트 테스트 추가
- 전체 testClasses는 기존 미추적 `LinkSyncUpdateReqTest`가 현재 DTO와 맞지 않아 실패합니다.