### PR TITLE
[Analytics] 서버 이벤트용 client_id 전달 계약 추가 (#270)

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/controller/ChatController.java
@@ -55,7 +55,7 @@ public class ChatController implements ChatApi {
 	@Override
 	@MessageMapping("/send")
 	public void sendMessage(@Payload AnswerReq req, @AuthMember Member member) {
-		chatFacade.generateAnswer(req.chatId(), member, req.message());
+		chatFacade.generateAnswer(req.chatId(), member, req.message(), req.clientId());
 	}
 
 	@Override

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
@@ -14,4 +14,7 @@ public record AnswerReq(
 	@Schema(description = "GA4 client_id")
 	String clientId
 ) {
+	public AnswerReq(Long chatId, String message) {
+		this(chatId, message, null);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
@@ -4,17 +4,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sofa.linkiving.global.config.jackson.HashidsDeserializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 public record AnswerReq(
-	@Schema(description = "Chat ID")
+	@Schema(description = "채팅방 ID")
 	@JsonDeserialize(using = HashidsDeserializer.class)
 	Long chatId,
-	@Schema(description = "User message")
+	@Schema(description = "유저 질문 내용")
 	String message,
 	@Schema(description = "GA4 client_id")
+	@Size(max = 128, message = "clientId는 128자를 초과할 수 없습니다")
 	String clientId
 ) {
-	public AnswerReq(Long chatId, String message) {
-		this(chatId, message, null);
-	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/request/AnswerReq.java
@@ -6,10 +6,12 @@ import com.sofa.linkiving.global.config.jackson.HashidsDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AnswerReq(
-	@Schema(description = "채팅방 ID")
+	@Schema(description = "Chat ID")
 	@JsonDeserialize(using = HashidsDeserializer.class)
 	Long chatId,
-	@Schema(description = "유저 질문 내용")
-	String message
+	@Schema(description = "User message")
+	String message,
+	@Schema(description = "GA4 client_id")
+	String clientId
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -66,7 +66,7 @@ public class ChatFacade {
 	}
 
 	@Transactional
-	public void generateAnswer(Long chatId, Member member, String message) {
+	public void generateAnswer(Long chatId, Member member, String message, String clientId) {
 
 		CompletableFuture<AnswerRes> task = ragChatService.generateAnswer(chatId, member, message);
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -97,6 +97,11 @@ public class ChatFacade {
 		});
 	}
 
+	@Transactional
+	public void generateAnswer(Long chatId, Member member, String message) {
+		generateAnswer(chatId, member, message, null);
+	}
+
 	private void sendNotification(Long chatId, Member member, AnswerRes res) {
 		messagingTemplate.convertAndSendToUser(
 			member.getEmail(),

--- a/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/controller/LinkController.java
@@ -29,6 +29,7 @@ import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.facade.LinkFacade;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
 import com.sofa.linkiving.global.common.BaseResponse;
 import com.sofa.linkiving.global.config.annotation.DecodeHash;
 import com.sofa.linkiving.security.annotation.AuthMember;
@@ -73,7 +74,8 @@ public class LinkController implements LinkApi {
 			request.url(),
 			request.title(),
 			request.memo(),
-			request.imageUrl()
+			request.imageUrl(),
+			AnalyticsContext.of(request.clientId(), request.source())
 		);
 		return BaseResponse.success(response, "링크 생성 완료");
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
@@ -5,20 +5,26 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LinkCreateReq(
-	@Schema(description = "링크 URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotBlank(message = "URL은 필수입니다")
-	@Size(max = 2048, message = "URL은 2048자를 초과할 수 없습니다")
+	@Schema(description = "Link URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "URL is required")
+	@Size(max = 2048, message = "URL must be 2048 characters or less")
 	String url,
 
-	@Schema(description = "링크 제목", example = "유용한 개발 자료", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotBlank(message = "제목은 필수입니다")
-	@Size(max = 100, message = "제목은 100자를 초과할 수 없습니다")
+	@Schema(description = "Link title", example = "Useful development resource", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "Title is required")
+	@Size(max = 100, message = "Title must be 100 characters or less")
 	String title,
 
-	@Schema(description = "메모", example = "나중에 읽어볼 것")
+	@Schema(description = "Memo", example = "Read later")
 	String memo,
 
-	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
-	String imageUrl
+	@Schema(description = "Image URL", example = "https://example.com/image.jpg")
+	String imageUrl,
+
+	@Schema(description = "GA4 client_id", example = "1234567890.1234567890")
+	String clientId,
+
+	@Schema(description = "Link save source", example = "web")
+	String source
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
@@ -10,7 +10,11 @@ public record LinkCreateReq(
 	@Size(max = 2048, message = "URL must be 2048 characters or less")
 	String url,
 
-	@Schema(description = "Link title", example = "Useful development resource", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(
+		description = "Link title",
+		example = "Useful development resource",
+		requiredMode = Schema.RequiredMode.REQUIRED
+	)
 	@NotBlank(message = "Title is required")
 	@Size(max = 100, message = "Title must be 100 characters or less")
 	String title,
@@ -27,4 +31,7 @@ public record LinkCreateReq(
 	@Schema(description = "Link save source", example = "web")
 	String source
 ) {
+	public LinkCreateReq(String url, String title, String memo, String imageUrl) {
+		this(url, title, memo, imageUrl, null, null);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
@@ -2,36 +2,36 @@ package com.sofa.linkiving.domain.link.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record LinkCreateReq(
-	@Schema(description = "Link URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotBlank(message = "URL is required")
-	@Size(max = 2048, message = "URL must be 2048 characters or less")
+	@Schema(description = "링크 URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "URL은 필수입니다")
+	@Size(max = 2048, message = "URL은 2048자를 초과할 수 없습니다")
 	String url,
 
 	@Schema(
-		description = "Link title",
-		example = "Useful development resource",
+		description = "링크 제목",
+		example = "유용한 개발 자료",
 		requiredMode = Schema.RequiredMode.REQUIRED
 	)
-	@NotBlank(message = "Title is required")
-	@Size(max = 100, message = "Title must be 100 characters or less")
+	@NotBlank(message = "제목은 필수입니다")
+	@Size(max = 100, message = "제목은 100자를 초과할 수 없습니다")
 	String title,
 
-	@Schema(description = "Memo", example = "Read later")
+	@Schema(description = "메모", example = "나중에 읽어볼 것")
 	String memo,
 
-	@Schema(description = "Image URL", example = "https://example.com/image.jpg")
+	@Schema(description = "이미지 URL", example = "https://example.com/image.jpg")
 	String imageUrl,
 
 	@Schema(description = "GA4 client_id", example = "1234567890.1234567890")
+	@Size(max = 128, message = "clientId는 128자를 초과할 수 없습니다")
 	String clientId,
 
-	@Schema(description = "Link save source", example = "web")
+	@Schema(description = "링크 저장 출처", example = "web", allowableValues = {"web", "extension"})
+	@Pattern(regexp = "web|extension", message = "source는 web 또는 extension만 허용됩니다")
 	String source
 ) {
-	public LinkCreateReq(String url, String title, String memo, String imageUrl) {
-		this(url, title, memo, imageUrl, null, null);
-	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/dto/request/LinkCreateReq.java
@@ -34,4 +34,7 @@ public record LinkCreateReq(
 	@Pattern(regexp = "web|extension", message = "source는 web 또는 extension만 허용됩니다")
 	String source
 ) {
+	public LinkCreateReq(String url, String title, String memo, String imageUrl) {
+		this(url, title, memo, imageUrl, null, null);
+	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -29,6 +29,7 @@ import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,14 @@ public class LinkFacade {
 	private final ApplicationEventPublisher eventPublisher;
 	private final SummaryClient summaryClient;
 
-	public LinkRes createLink(Member member, String url, String title, String memo, String imageUrl) {
+	public LinkRes createLink(
+		Member member,
+		String url,
+		String title,
+		String memo,
+		String imageUrl,
+		AnalyticsContext analyticsContext
+	) {
 		String storedImageUrl = processImageUpload(imageUrl);
 		Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -63,6 +63,16 @@ public class LinkFacade {
 		return LinkRes.from(link);
 	}
 
+	public LinkRes createLink(
+		Member member,
+		String url,
+		String title,
+		String memo,
+		String imageUrl
+	) {
+		return createLink(member, url, title, memo, imageUrl, AnalyticsContext.of(null, null));
+	}
+
 	public LinkRes updateLink(Long linkId, Member member, String title, String memo, String imageUrl) {
 		String storedImageUrl = null;
 		if (imageUrl != null) {

--- a/src/main/java/com/sofa/linkiving/global/analytics/AnalyticsContext.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/AnalyticsContext.java
@@ -1,0 +1,10 @@
+package com.sofa.linkiving.global.analytics;
+
+public record AnalyticsContext(
+	String clientId,
+	String source
+) {
+	public static AnalyticsContext of(String clientId, String source) {
+		return new AnalyticsContext(clientId, source);
+	}
+}


### PR DESCRIPTION
## 관련이슈
- Close #270

## 요약
- 링크 저장 요청에 `clientId`, `source`를 받을 수 있도록 DTO 계약을 추가했습니다.
- 채팅 답변 요청에 `clientId`를 받을 수 있도록 DTO 계약을 추가했습니다.
- 기존 테스트/호출부 호환을 위해 기존 생성자 및 메서드 오버로드를 유지했습니다.

## Stack
- Base: #276

## 테스트
- `./gradlew.bat compileJava` 통과
- 전체 testClasses는 기존 미추적 `LinkSyncUpdateReqTest`가 현재 DTO와 맞지 않아 실패합니다.