### PR TITLE
[Analytics] 링크 저장 서버 이벤트 발화 (#271)

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -87,16 +87,6 @@ public class LinkFacade {
 		return createLink(member, url, title, memo, imageUrl, AnalyticsContext.of(null, null));
 	}
 
-	public LinkRes createLink(
-		Member member,
-		String url,
-		String title,
-		String memo,
-		String imageUrl
-	) {
-		return createLink(member, url, title, memo, imageUrl, AnalyticsContext.of(null, null));
-	}
-
 	public LinkRes updateLink(Long linkId, Member member, String title, String memo, String imageUrl) {
 		String storedImageUrl = null;
 		if (imageUrl != null) {

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -60,7 +60,7 @@ public class LinkFacade {
 		String imageUrl,
 		AnalyticsContext analyticsContext
 	) {
-		publishBookmarkSaveAttempt(member, analyticsContext);
+		publishLinkSaveAttempt(member, analyticsContext);
 
 		try {
 			String storedImageUrl = processImageUpload(imageUrl);
@@ -68,11 +68,11 @@ public class LinkFacade {
 
 			eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail(), LogContext.snapshot()));
 			eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
-			publishBookmarkSaveSuccess(member, analyticsContext, link);
+			publishLinkSaveSuccess(member, analyticsContext, link);
 
 			return LinkRes.from(link);
 		} catch (RuntimeException exception) {
-			publishBookmarkSaveFail(member, analyticsContext, exception);
+			publishLinkSaveFail(member, analyticsContext, exception);
 			throw exception;
 		}
 	}
@@ -181,28 +181,28 @@ public class LinkFacade {
 		return imageUploader.uploadFromUrl(imageUrl);
 	}
 
-	private void publishBookmarkSaveAttempt(Member member, AnalyticsContext analyticsContext) {
-		publishBookmarkEvent(member, analyticsContext, "bookmark_save_attempt", Map.of(
+	private void publishLinkSaveAttempt(Member member, AnalyticsContext analyticsContext) {
+		publishLinkEvent(member, analyticsContext, "link_save_attempt", Map.of(
 			"source", analyticsSource(analyticsContext)
 		));
 	}
 
-	private void publishBookmarkSaveSuccess(Member member, AnalyticsContext analyticsContext, Link link) {
-		publishBookmarkEvent(member, analyticsContext, "bookmark_save_success", Map.of(
+	private void publishLinkSaveSuccess(Member member, AnalyticsContext analyticsContext, Link link) {
+		publishLinkEvent(member, analyticsContext, "link_save_success", Map.of(
 			"source", analyticsSource(analyticsContext),
 			"domain", extractHost(link.getUrl()),
 			"has_memo", link.getMemo() != null && !link.getMemo().isBlank()
 		));
 	}
 
-	private void publishBookmarkSaveFail(Member member, AnalyticsContext analyticsContext, RuntimeException exception) {
-		publishBookmarkEvent(member, analyticsContext, "bookmark_save_fail", Map.of(
+	private void publishLinkSaveFail(Member member, AnalyticsContext analyticsContext, RuntimeException exception) {
+		publishLinkEvent(member, analyticsContext, "link_save_fail", Map.of(
 			"source", analyticsSource(analyticsContext),
 			"error_type", exception.getClass().getSimpleName()
 		));
 	}
 
-	private void publishBookmarkEvent(Member member, AnalyticsContext analyticsContext, String eventName,
+	private void publishLinkEvent(Member member, AnalyticsContext analyticsContext, String eventName,
 		Map<String, Object> params) {
 		if (analyticsContext == null || analyticsContext.clientId() == null || analyticsContext.clientId().isBlank()) {
 			return;

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -35,6 +35,7 @@ import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.analytics.AnalyticsContext;
 import com.sofa.linkiving.global.analytics.Ga4Event;
 import com.sofa.linkiving.global.analytics.Ga4Publisher;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
@@ -198,7 +199,7 @@ public class LinkFacade {
 	private void publishLinkSaveFail(Member member, AnalyticsContext analyticsContext, RuntimeException exception) {
 		publishLinkEvent(member, analyticsContext, "link_save_fail", Map.of(
 			"source", analyticsSource(analyticsContext),
-			"error_type", exception.getClass().getSimpleName()
+			"error_type", analyticsErrorType(exception)
 		));
 	}
 
@@ -213,9 +214,16 @@ public class LinkFacade {
 
 	private String analyticsSource(AnalyticsContext analyticsContext) {
 		if (analyticsContext == null || analyticsContext.source() == null || analyticsContext.source().isBlank()) {
-			return "web";
+			return AnalyticsContext.DEFAULT_SOURCE;
 		}
 		return analyticsContext.source();
+	}
+
+	private String analyticsErrorType(RuntimeException exception) {
+		if (exception instanceof BusinessException businessException) {
+			return businessException.getErrorCode().getCode();
+		}
+		return exception.getClass().getSimpleName();
 	}
 
 	private String extractHost(String url) {

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -1,5 +1,8 @@
 package com.sofa.linkiving.domain.link.facade;
 
+import java.net.URI;
+import java.util.Map;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +33,8 @@ import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.analytics.AnalyticsContext;
+import com.sofa.linkiving.global.analytics.Ga4Event;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
@@ -45,6 +50,7 @@ public class LinkFacade {
 	private final ImageUploader imageUploader;
 	private final ApplicationEventPublisher eventPublisher;
 	private final SummaryClient summaryClient;
+	private final Ga4Publisher ga4Publisher;
 
 	public LinkRes createLink(
 		Member member,
@@ -54,13 +60,31 @@ public class LinkFacade {
 		String imageUrl,
 		AnalyticsContext analyticsContext
 	) {
-		String storedImageUrl = processImageUpload(imageUrl);
-		Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
+		publishBookmarkSaveAttempt(member, analyticsContext);
 
-		eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail(), LogContext.snapshot()));
-		eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
+		try {
+			String storedImageUrl = processImageUpload(imageUrl);
+			Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 
-		return LinkRes.from(link);
+			eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail(), LogContext.snapshot()));
+			eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
+			publishBookmarkSaveSuccess(member, analyticsContext, link);
+
+			return LinkRes.from(link);
+		} catch (RuntimeException exception) {
+			publishBookmarkSaveFail(member, analyticsContext, exception);
+			throw exception;
+		}
+	}
+
+	public LinkRes createLink(
+		Member member,
+		String url,
+		String title,
+		String memo,
+		String imageUrl
+	) {
+		return createLink(member, url, title, memo, imageUrl, AnalyticsContext.of(null, null));
 	}
 
 	public LinkRes createLink(
@@ -165,6 +189,55 @@ public class LinkFacade {
 			return null;
 		}
 		return imageUploader.uploadFromUrl(imageUrl);
+	}
+
+	private void publishBookmarkSaveAttempt(Member member, AnalyticsContext analyticsContext) {
+		publishBookmarkEvent(member, analyticsContext, "bookmark_save_attempt", Map.of(
+			"source", analyticsSource(analyticsContext)
+		));
+	}
+
+	private void publishBookmarkSaveSuccess(Member member, AnalyticsContext analyticsContext, Link link) {
+		publishBookmarkEvent(member, analyticsContext, "bookmark_save_success", Map.of(
+			"source", analyticsSource(analyticsContext),
+			"domain", extractHost(link.getUrl()),
+			"has_memo", link.getMemo() != null && !link.getMemo().isBlank()
+		));
+	}
+
+	private void publishBookmarkSaveFail(Member member, AnalyticsContext analyticsContext, RuntimeException exception) {
+		publishBookmarkEvent(member, analyticsContext, "bookmark_save_fail", Map.of(
+			"source", analyticsSource(analyticsContext),
+			"error_type", exception.getClass().getSimpleName()
+		));
+	}
+
+	private void publishBookmarkEvent(Member member, AnalyticsContext analyticsContext, String eventName,
+		Map<String, Object> params) {
+		if (analyticsContext == null || analyticsContext.clientId() == null || analyticsContext.clientId().isBlank()) {
+			return;
+		}
+		String userId = member.getId() == null ? null : String.valueOf(member.getId());
+		ga4Publisher.publish(analyticsContext.clientId(), userId, new Ga4Event(eventName, params));
+	}
+
+	private String analyticsSource(AnalyticsContext analyticsContext) {
+		if (analyticsContext == null || analyticsContext.source() == null || analyticsContext.source().isBlank()) {
+			return "web";
+		}
+		return analyticsContext.source();
+	}
+
+	private String extractHost(String url) {
+		try {
+			String host = URI.create(url).getHost();
+			if (host == null || host.isBlank()) {
+				return "unknown";
+			}
+			return host.startsWith("www.") ? host.substring(4) : host;
+		} catch (IllegalArgumentException exception) {
+			return "unknown";
+		}
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/sofa/linkiving/global/analytics/AnalyticsContext.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/AnalyticsContext.java
@@ -4,6 +4,10 @@ public record AnalyticsContext(
 	String clientId,
 	String source
 ) {
+	public static final String SOURCE_WEB = "web";
+	public static final String SOURCE_EXTENSION = "extension";
+	public static final String DEFAULT_SOURCE = SOURCE_WEB;
+
 	public static AnalyticsContext of(String clientId, String source) {
 		return new AnalyticsContext(clientId, source);
 	}

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -42,6 +42,8 @@ import com.sofa.linkiving.domain.link.service.LinkService;
 import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,10 +71,13 @@ class LinkFacadeTest {
 	@Mock
 	private ApplicationEventPublisher eventPublisher;
 
+	@Mock
+	private Ga4Publisher ga4Publisher;
+
 	@BeforeEach
 	void setUp() {
 		linkFacade = new LinkFacade(linkService, ogTagCrawler, summaryService, imageUploader, eventPublisher,
-			summaryClient);
+			summaryClient, ga4Publisher);
 	}
 
 	@Test
@@ -236,7 +241,8 @@ class LinkFacadeTest {
 		given(linkService.createLink(member, url, title, memo, storedImageUrl)).willReturn(savedLink);
 
 		// when
-		LinkRes result = linkFacade.createLink(member, url, title, memo, originalImageUrl);
+		LinkRes result = linkFacade.createLink(member, url, title, memo, originalImageUrl,
+			AnalyticsContext.of("1234567890.1234567890", "web"));
 
 		// then
 		assertThat(result).isNotNull();
@@ -245,6 +251,7 @@ class LinkFacadeTest {
 		verify(imageUploader, times(1)).uploadFromUrl(originalImageUrl);
 		verify(linkService, times(1)).createLink(member, url, title, memo, storedImageUrl);
 		verify(eventPublisher, times(1)).publishEvent(any(LinkCreatedEvent.class));
+		verify(ga4Publisher, times(2)).publish(eq("1234567890.1234567890"), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -43,6 +44,7 @@ import com.sofa.linkiving.domain.link.service.SummaryService;
 import com.sofa.linkiving.domain.link.util.OgTagCrawler;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.analytics.AnalyticsContext;
+import com.sofa.linkiving.global.analytics.Ga4Event;
 import com.sofa.linkiving.global.analytics.Ga4Publisher;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 
@@ -263,9 +265,11 @@ class LinkFacadeTest {
 			.email("test@example.com")
 			.password("password")
 			.build();
+		ReflectionTestUtils.setField(member, "id", 1L);
 		String url = "https://example.com";
 		String originalImageUrl = "https://original.com/image.jpg";
 		String storedImageUrl = "https://s3-bucket.com/stored-image.jpg";
+		AnalyticsContext context = AnalyticsContext.of("1234567890.1234567890", "web");
 
 		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(storedImageUrl);
 		given(linkService.createLink(member, url, "테스트 링크", null, storedImageUrl))
@@ -273,12 +277,18 @@ class LinkFacadeTest {
 
 		// when & then
 		assertThatThrownBy(() -> linkFacade.createLink(
-			member, url, "테스트 링크", null, originalImageUrl
+			member, url, "테스트 링크", null, originalImageUrl, context
 		))
 			.isInstanceOf(BusinessException.class)
 			.hasFieldOrPropertyWithValue("errorCode", LinkErrorCode.DUPLICATE_URL);
 
 		verify(eventPublisher, never()).publishEvent(any());
+		ArgumentCaptor<Ga4Event> captor = ArgumentCaptor.forClass(Ga4Event.class);
+		verify(ga4Publisher, times(2)).publish(eq("1234567890.1234567890"), eq("1"), captor.capture());
+		assertThat(captor.getAllValues()).extracting(Ga4Event::name)
+			.containsExactly("link_save_attempt", "link_save_fail");
+		assertThat(captor.getAllValues().get(1).params())
+			.containsEntry("error_type", LinkErrorCode.DUPLICATE_URL.getCode());
 	}
 
 	@Test


### PR DESCRIPTION
## 관련이슈
- Close #271

## 요약
- 링크 저장 시 `link_save_attempt`, `link_save_success`, `link_save_fail` GA4 서버 이벤트를 발화합니다.
- URL 원문은 GA로 보내지 않고 domain만 추출해 전송합니다.
- `clientId`가 없으면 GA4 전송을 생략해 기존 요청 흐름을 유지합니다.

## Stack
- Base: #277

## 테스트
- `./gradlew.bat compileJava checkstyleMain test --tests "com.sofa.linkiving.domain.link.facade.LinkFacadeTest"` 통과
- 링크 저장 성공 케이스에 GA publisher 호출 검증을 추가했습니다.