### PR TITLE
[Analytics] RAG 응답 메타데이터 수신 필드 추가 (#273)

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/RagAnswerRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/RagAnswerRes.java
@@ -7,8 +7,21 @@ public record RagAnswerRes(
 	List<String> linkIds,
 	List<ReasoningStep> reasoningSteps,
 	List<String> relatedLinks,
-	boolean isFallback
+	boolean isFallback,
+	Integer retrievedCount,
+	Integer selectedCount,
+	Double topSimilarity
 ) {
+	public RagAnswerRes(
+		String answer,
+		List<String> linkIds,
+		List<ReasoningStep> reasoningSteps,
+		List<String> relatedLinks,
+		boolean isFallback
+	) {
+		this(answer, linkIds, reasoningSteps, relatedLinks, isFallback, null, null, null);
+	}
+
 	public record ReasoningStep(
 		String step,
 		List<String> linkIds


### PR DESCRIPTION
## 관련이슈
- Close #273

## 요약
- AI 서버 응답 DTO에 `retrievedCount`, `selectedCount`, `topSimilarity` 선택 필드를 추가했습니다.
- 기존 응답/테스트 생성자 호환을 유지했습니다.
- 실제 `query_response_complete` 발화는 #272에서 처리합니다.

## 응답 계약 주의
- 이 PR은 백엔드 DTO가 `retrievedCount`, `selectedCount`, `topSimilarity`를 받을 수 있게 열어두는 작업입니다.
- 현재 확인된 기존 n8n `/webhook/chat-answer` 응답 로그에는 위 3개 필드가 포함되어 있지 않습니다.
- 따라서 실제 GA의 `retrieved_count`, `top_similarity`를 채우려면 n8n 응답 스펙 추가가 별도로 필요합니다.
- `selected_count`는 #272에서 AI 응답의 `selectedCount`가 없을 경우 백엔드가 조회한 selected link 개수로 fallback합니다.
- n8n이 snake_case(`retrieved_count`, `selected_count`, `top_similarity`)로 내려주는 경우 현재 camelCase DTO와 매핑 정책을 맞춰야 합니다.

## Stack
- Base: #278

## 테스트
- `./gradlew.bat compileJava` 통과