### PR TITLE
[Analytics] 질의/응답 서버 이벤트 발화 (#272)

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
@@ -19,6 +19,8 @@ public record AnswerRes(
 	@Schema(description = "메세지 ID")
 	@JsonSerialize(using = HashidsSerializer.class)
 	Long messageId,
+	@Schema(description = "GA query_id")
+	String queryId,
 	@Schema(description = "답변 내용")
 	String content,
 	@Schema(description = "스텝 목록")
@@ -31,6 +33,7 @@ public record AnswerRes(
 			true,
 			chatId,
 			message.getId(),
+			message.getQueryId(),
 			message.getContent(),
 			step,
 			linkDtos.stream().map(LinkCardRes::from).toList()
@@ -41,6 +44,7 @@ public record AnswerRes(
 		return new AnswerRes(
 			false,
 			chatId,
+			null,
 			null,
 			content,
 			null,

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/AnswerRes.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.domain.chat.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sofa.linkiving.domain.chat.entity.Message;
 import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
@@ -19,6 +20,7 @@ public record AnswerRes(
 	@Schema(description = "메세지 ID")
 	@JsonSerialize(using = HashidsSerializer.class)
 	Long messageId,
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@Schema(description = "GA query_id")
 	String queryId,
 	@Schema(description = "답변 내용")

--- a/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessageRes.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/dto/response/MessageRes.java
@@ -23,6 +23,10 @@ public record MessageRes(
 	@Schema(description = "메시지 내용")
 	String content,
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@Schema(description = "GA query_id")
+	String queryId,
+
 	@Schema(description = "발신자 타입 (USER / AI)")
 	Type type,
 
@@ -43,6 +47,7 @@ public record MessageRes(
 		return new MessageRes(
 			message.getId(),
 			message.getContent(),
+			message.getQueryId(),
 			message.getType(),
 			message.getSentimentOrDefault(),
 			message.getCreatedAt(),

--- a/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/entity/Message.java
@@ -38,6 +38,9 @@ public class Message extends BaseEntity {
 	@Column(columnDefinition = "text", nullable = false)
 	private String content;
 
+	@Column(name = "query_id")
+	private String queryId;
+
 	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(
 		name = "message_link",
@@ -50,10 +53,11 @@ public class Message extends BaseEntity {
 	private Feedback feedback;
 
 	@Builder
-	public Message(Chat chat, Type type, String content, List<Link> links) {
+	public Message(Chat chat, Type type, String content, String queryId, List<Link> links) {
 		this.chat = chat;
 		this.type = type;
 		this.content = content;
+		this.queryId = queryId;
 		this.links = (links != null) ? links : new ArrayList<>();
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -68,7 +68,9 @@ public class ChatFacade {
 	@Transactional
 	public void generateAnswer(Long chatId, Member member, String message, String clientId) {
 
-		CompletableFuture<AnswerRes> task = ragChatService.generateAnswer(chatId, member, message);
+		CompletableFuture<AnswerRes> task = clientId == null || clientId.isBlank()
+			? ragChatService.generateAnswer(chatId, member, message)
+			: ragChatService.generateAnswer(chatId, member, message, clientId);
 
 		taskManager.put(chatId, task);
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/facade/ChatFacade.java
@@ -68,9 +68,7 @@ public class ChatFacade {
 	@Transactional
 	public void generateAnswer(Long chatId, Member member, String message, String clientId) {
 
-		CompletableFuture<AnswerRes> task = clientId == null || clientId.isBlank()
-			? ragChatService.generateAnswer(chatId, member, message)
-			: ragChatService.generateAnswer(chatId, member, message, clientId);
+		CompletableFuture<AnswerRes> task = ragChatService.generateAnswer(chatId, member, message, clientId);
 
 		taskManager.put(chatId, task);
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
@@ -35,10 +35,6 @@ public class MessageCommandService {
 		return messageRepository.save(message);
 	}
 
-	public Message saveAiMessage(Chat chat, String content, List<Link> links) {
-		return saveAiMessage(chat, content, null, links);
-	}
-
 	public Message saveAiMessage(Chat chat, String content, String queryId, List<Link> links) {
 		Message message = Message.builder()
 			.chat(chat)

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
@@ -36,10 +36,15 @@ public class MessageCommandService {
 	}
 
 	public Message saveAiMessage(Chat chat, String content, List<Link> links) {
+		return saveAiMessage(chat, content, null, links);
+	}
+
+	public Message saveAiMessage(Chat chat, String content, String queryId, List<Link> links) {
 		Message message = Message.builder()
 			.chat(chat)
 			.type(Type.AI)
 			.content(content)
+			.queryId(queryId)
 			.links(links)
 			.build();
 

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -26,6 +26,7 @@ import com.sofa.linkiving.domain.link.service.LinkQueryService;
 import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.global.analytics.Ga4Event;
 import com.sofa.linkiving.global.analytics.Ga4Publisher;
+import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
@@ -44,12 +45,6 @@ public class RagChatService {
 
 	@Async("aiTaskExecutor")
 	@Transactional(propagation = Propagation.NOT_SUPPORTED)
-	public CompletableFuture<AnswerRes> generateAnswer(Long chatId, Member member, String userMessage) {
-		return generateAnswer(chatId, member, userMessage, null);
-	}
-
-	@Async("aiTaskExecutor")
-	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public CompletableFuture<AnswerRes> generateAnswer(
 		Long chatId,
 		Member member,
@@ -58,49 +53,52 @@ public class RagChatService {
 	) {
 		String queryId = UUID.randomUUID().toString();
 		long startNanos = System.nanoTime();
+		Long memberId = Objects.requireNonNull(member.getId(), "memberId must not be null");
 
-		try (LogContext.MdcScope memberScope = LogContext.withMemberId(member.getId());
+		try (LogContext.MdcScope memberScope = LogContext.withMemberId(memberId);
 			LogContext.MdcScope chatScope = LogContext.withChatId(chatId)) {
-
-			if (hasAnalyticsClient(clientId)) {
-				long linkCountAtQuery = linkQueryService.countByMemberAndIsDeleteFalse(member);
-				publishQuerySubmit(member, clientId, queryId, linkCountAtQuery);
-			}
 
 			Chat chat = chatQueryService.findChat(chatId, member);
 
-			Message question = messageCommandService.saveUserMessage(chat, userMessage);
-			List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
-				question.getId(), chat);
-			Collections.reverse(history);
+			try {
+				if (hasAnalyticsClient(clientId)) {
+					long linkCountAtQuery = linkQueryService.countByMemberAndIsDeleteFalse(member);
+					publishQuerySubmit(member, clientId, queryId, linkCountAtQuery);
+				}
 
-			RagAnswerReq request = RagAnswerReq.of(
-				member.getId(),
-				userMessage,
-				history,
-				Mode.DETAILED
-			);
+				Message question = messageCommandService.saveUserMessage(chat, userMessage);
+				List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
+					question.getId(), chat);
+				Collections.reverse(history);
 
-			RagAnswerRes res = answerClient.generateAnswer(request);
+				RagAnswerReq request = RagAnswerReq.of(
+					memberId,
+					userMessage,
+					history,
+					Mode.DETAILED
+				);
 
-			String fullAnswer = res.answer();
+				RagAnswerRes res = answerClient.generateAnswer(request);
 
-			List<Long> linkIds = parseLinkIds(res.linkIds());
-			List<LinkDto> linkDtos = linkQueryService.findAllByIdInWithSummary(linkIds, member);
-			List<Link> links = linkDtos.stream().map(LinkDto::link).toList();
+				String fullAnswer = res.answer();
 
-			List<String> steps = res.reasoningSteps().stream().map(RagAnswerRes.ReasoningStep::step).toList();
+				List<Long> linkIds = parseLinkIds(res.linkIds());
+				List<LinkDto> linkDtos = linkQueryService.findAllByIdInWithSummary(linkIds, member);
+				List<Link> links = linkDtos.stream().map(LinkDto::link).toList();
 
-			Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, queryId, links);
+				List<String> steps = res.reasoningSteps().stream().map(RagAnswerRes.ReasoningStep::step).toList();
 
-			AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
-			publishQueryResponseComplete(member, clientId, queryId, startNanos, false, null, res, linkDtos);
+				Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, queryId, links);
 
-			return CompletableFuture.completedFuture(payload);
-		} catch (RuntimeException exception) {
-			publishQueryResponseComplete(member, clientId, queryId, startNanos, true,
-				exception.getClass().getSimpleName(), null, List.of());
-			throw exception;
+				AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
+				publishQueryResponseComplete(member, clientId, queryId, startNanos, false, null, res, linkDtos);
+
+				return CompletableFuture.completedFuture(payload);
+			} catch (RuntimeException exception) {
+				publishQueryResponseComplete(member, clientId, queryId, startNanos, true,
+					analyticsErrorType(exception), null, List.of());
+				throw exception;
+			}
 		}
 
 	}
@@ -158,8 +156,15 @@ public class RagChatService {
 		if (!hasAnalyticsClient(clientId)) {
 			return;
 		}
-		String userId = member.getId() == null ? null : String.valueOf(member.getId());
+		String userId = String.valueOf(Objects.requireNonNull(member.getId(), "memberId must not be null"));
 		ga4Publisher.publish(clientId, userId, new Ga4Event(eventName, params));
+	}
+
+	private String analyticsErrorType(RuntimeException exception) {
+		if (exception instanceof BusinessException businessException) {
+			return businessException.getErrorCode().getCode();
+		}
+		return "UNKNOWN";
 	}
 
 	private boolean hasAnalyticsClient(String clientId) {

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -1,8 +1,11 @@
 package com.sofa.linkiving.domain.chat.service;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.springframework.scheduling.annotation.Async;
@@ -21,6 +24,8 @@ import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.service.LinkQueryService;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.Ga4Event;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.RequiredArgsConstructor;
@@ -35,12 +40,32 @@ public class RagChatService {
 	private final MessageQueryService messageQueryService;
 	private final LinkQueryService linkQueryService;
 	private final ChatQueryService chatQueryService;
+	private final Ga4Publisher ga4Publisher;
 
 	@Async("aiTaskExecutor")
 	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public CompletableFuture<AnswerRes> generateAnswer(Long chatId, Member member, String userMessage) {
+		return generateAnswer(chatId, member, userMessage, null);
+	}
+
+	@Async("aiTaskExecutor")
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
+	public CompletableFuture<AnswerRes> generateAnswer(
+		Long chatId,
+		Member member,
+		String userMessage,
+		String clientId
+	) {
+		String queryId = UUID.randomUUID().toString();
+		long startNanos = System.nanoTime();
+
 		try (LogContext.MdcScope memberScope = LogContext.withMemberId(member.getId());
 			LogContext.MdcScope chatScope = LogContext.withChatId(chatId)) {
+
+			if (hasAnalyticsClient(clientId)) {
+				long bookmarkCountAtQuery = linkQueryService.countByMemberAndIsDeleteFalse(member);
+				publishQuerySubmit(member, clientId, queryId, bookmarkCountAtQuery);
+			}
 
 			Chat chat = chatQueryService.findChat(chatId, member);
 
@@ -69,8 +94,13 @@ public class RagChatService {
 			Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, links);
 
 			AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
+			publishQueryResponseComplete(member, clientId, queryId, startNanos, false, null, res, linkDtos);
 
 			return CompletableFuture.completedFuture(payload);
+		} catch (RuntimeException exception) {
+			publishQueryResponseComplete(member, clientId, queryId, startNanos, true,
+				exception.getClass().getSimpleName(), null, List.of());
+			throw exception;
 		}
 
 	}
@@ -90,5 +120,63 @@ public class RagChatService {
 			})
 			.filter(Objects::nonNull)
 			.toList();
+	}
+
+	private void publishQuerySubmit(Member member, String clientId, String queryId, long bookmarkCountAtQuery) {
+		publishQueryEvent(member, clientId, "query_submit", Map.of(
+			"query_id", queryId,
+			"bookmark_count_at_query", bookmarkCountAtQuery
+		));
+	}
+
+	private void publishQueryResponseComplete(
+		Member member,
+		String clientId,
+		String queryId,
+		long startNanos,
+		boolean isError,
+		String errorType,
+		RagAnswerRes ragAnswer,
+		List<LinkDto> selectedLinks
+	) {
+		Map<String, Object> params = new HashMap<>();
+		params.put("query_id", queryId);
+		params.put("is_error", isError);
+		params.put("latency_ms", elapsedMillis(startNanos));
+
+		if (ragAnswer != null) {
+			params.put("selected_count", firstNonNull(ragAnswer.selectedCount(), selectedLinks.size()));
+			putIfPresent(params, "retrieved_count", ragAnswer.retrievedCount());
+			putIfPresent(params, "top_similarity", ragAnswer.topSimilarity());
+		}
+		putIfPresent(params, "error_type", errorType);
+
+		publishQueryEvent(member, clientId, "query_response_complete", params);
+	}
+
+	private void publishQueryEvent(Member member, String clientId, String eventName, Map<String, Object> params) {
+		if (!hasAnalyticsClient(clientId)) {
+			return;
+		}
+		String userId = member.getId() == null ? null : String.valueOf(member.getId());
+		ga4Publisher.publish(clientId, userId, new Ga4Event(eventName, params));
+	}
+
+	private boolean hasAnalyticsClient(String clientId) {
+		return clientId != null && !clientId.isBlank();
+	}
+
+	private void putIfPresent(Map<String, Object> params, String key, Object value) {
+		if (value != null) {
+			params.put(key, value);
+		}
+	}
+
+	private Integer firstNonNull(Integer value, int fallback) {
+		return value == null ? fallback : value;
+	}
+
+	private long elapsedMillis(long startNanos) {
+		return (System.nanoTime() - startNanos) / 1_000_000;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -63,8 +63,8 @@ public class RagChatService {
 			LogContext.MdcScope chatScope = LogContext.withChatId(chatId)) {
 
 			if (hasAnalyticsClient(clientId)) {
-				long bookmarkCountAtQuery = linkQueryService.countByMemberAndIsDeleteFalse(member);
-				publishQuerySubmit(member, clientId, queryId, bookmarkCountAtQuery);
+				long linkCountAtQuery = linkQueryService.countByMemberAndIsDeleteFalse(member);
+				publishQuerySubmit(member, clientId, queryId, linkCountAtQuery);
 			}
 
 			Chat chat = chatQueryService.findChat(chatId, member);
@@ -91,7 +91,7 @@ public class RagChatService {
 
 			List<String> steps = res.reasoningSteps().stream().map(RagAnswerRes.ReasoningStep::step).toList();
 
-			Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, links);
+			Message answer = messageCommandService.saveAiMessage(chat, fullAnswer, queryId, links);
 
 			AnswerRes payload = AnswerRes.of(chat.getId(), answer, steps, linkDtos);
 			publishQueryResponseComplete(member, clientId, queryId, startNanos, false, null, res, linkDtos);
@@ -122,10 +122,10 @@ public class RagChatService {
 			.toList();
 	}
 
-	private void publishQuerySubmit(Member member, String clientId, String queryId, long bookmarkCountAtQuery) {
+	private void publishQuerySubmit(Member member, String clientId, String queryId, long linkCountAtQuery) {
 		publishQueryEvent(member, clientId, "query_submit", Map.of(
 			"query_id", queryId,
-			"bookmark_count_at_query", bookmarkCountAtQuery
+			"link_count_at_query", linkCountAtQuery
 		));
 	}
 

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -25,7 +25,10 @@ public abstract class SecurityConstants {
 		"/oauth2/**",
 
 		/* auth */
-		"/v1/auth/reissue"
+		"/v1/auth/reissue",
+
+		/* websocket handshake */
+		"/ws/**"
 	};
 
 	public static final String[] ADMIN_URLS = {

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -28,7 +28,7 @@ public abstract class SecurityConstants {
 		"/v1/auth/reissue",
 
 		/* websocket handshake */
-		"/ws/**"
+		"/ws/chat/**", "/ws/link/**"
 	};
 
 	public static final String[] ADMIN_URLS = {

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -20,6 +20,7 @@ import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.security.jwt.JwtKeys;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+import com.sofa.linkiving.security.jwt.error.CustomJwtException;
 import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -65,17 +66,18 @@ public class StompHandler implements ChannelInterceptor {
 						throw new BusinessException(JwtErrorCode.EMPTY_TOKEN);
 					}
 
-					if (jwtTokenProvider.validateAccessToken(token)) {
+					if (!jwtTokenProvider.validateAccessToken(token)) {
+						throw new CustomJwtException(JwtErrorCode.INVALID_JWT_TOKEN);
+					}
 
-						if (StompCommand.CONNECT.equals(command)) {
-							String memberStatus = jwtTokenProvider.getClaim(token, JwtKeys.Claims.MEMBER_STATUS);
-							if (MemberStatus.PENDING_TERMS.name().equals(memberStatus)) {
-								throw new BusinessException(MemberErrorCode.TERMS_AGREEMENT_REQUIRED);
-							}
-
-							Authentication authentication = jwtTokenProvider.getAuthentication(token);
-							accessor.setUser(authentication);
+					if (StompCommand.CONNECT.equals(command)) {
+						String memberStatus = jwtTokenProvider.getClaim(token, JwtKeys.Claims.MEMBER_STATUS);
+						if (MemberStatus.PENDING_TERMS.name().equals(memberStatus)) {
+							throw new BusinessException(MemberErrorCode.TERMS_AGREEMENT_REQUIRED);
 						}
+
+						Authentication authentication = jwtTokenProvider.getAuthentication(token);
+						accessor.setUser(authentication);
 					}
 
 				} catch (BusinessException e) {

--- a/src/test/java/com/sofa/linkiving/domain/chat/facade/ChatFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/facade/ChatFacadeTest.java
@@ -166,7 +166,7 @@ public class ChatFacadeTest {
 
 		CompletableFuture<AnswerRes> future = new CompletableFuture<>();
 
-		given(ragChatService.generateAnswer(chatId, member, userMessage)).willReturn(future);
+		given(ragChatService.generateAnswer(chatId, member, userMessage, null)).willReturn(future);
 
 		// when
 		chatFacade.generateAnswer(chatId, member, userMessage);
@@ -196,7 +196,7 @@ public class ChatFacadeTest {
 		given(member.getEmail()).willReturn("test@test.com");
 
 		CompletableFuture<AnswerRes> future = new CompletableFuture<>();
-		given(ragChatService.generateAnswer(chatId, member, userMessage)).willReturn(future);
+		given(ragChatService.generateAnswer(chatId, member, userMessage, null)).willReturn(future);
 
 		// when
 		chatFacade.generateAnswer(chatId, member, userMessage);
@@ -228,7 +228,7 @@ public class ChatFacadeTest {
 		given(member.getEmail()).willReturn("test@test.com");
 
 		CompletableFuture<AnswerRes> future = new CompletableFuture<>();
-		given(ragChatService.generateAnswer(chatId, member, userMessage)).willReturn(future);
+		given(ragChatService.generateAnswer(chatId, member, userMessage, null)).willReturn(future);
 
 		// when
 		chatFacade.generateAnswer(chatId, member, userMessage);

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
@@ -90,7 +90,7 @@ public class MessageCommandServiceTest {
 		given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
 
 		// when
-		Message savedMessage = messageCommandService.saveAiMessage(chat, content, links);
+		Message savedMessage = messageCommandService.saveAiMessage(chat, content, null, links);
 
 		// then
 		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
@@ -103,7 +103,7 @@ public class RagChatServiceTest {
 		Message answerMsg = mock(Message.class);
 		given(answerMsg.getId()).willReturn(51L);
 		given(answerMsg.getContent()).willReturn("AI 답변입니다.");
-		given(messageCommandService.saveAiMessage(eq(chat), anyString(), anyList()))
+		given(messageCommandService.saveAiMessage(eq(chat), anyString(), anyString(), anyList()))
 			.willReturn(answerMsg);
 
 		// when
@@ -121,7 +121,7 @@ public class RagChatServiceTest {
 		verify(messageCommandService).saveUserMessage(chat, userMessage);
 		verify(answerClient).generateAnswer(any(RagAnswerReq.class));
 		verify(linkQueryService).findAllByIdInWithSummary(eq(List.of(10L, 20L)), eq(member));
-		verify(messageCommandService).saveAiMessage(chat, "AI 답변입니다.", List.of(link1));
+		verify(messageCommandService).saveAiMessage(eq(chat), eq("AI 답변입니다."), anyString(), eq(List.of(link1)));
 	}
 
 	@Test
@@ -197,7 +197,7 @@ public class RagChatServiceTest {
 		Message answerMsg = mock(Message.class);
 		given(answerMsg.getId()).willReturn(51L);
 		given(answerMsg.getContent()).willReturn("AI answer");
-		given(messageCommandService.saveAiMessage(eq(chat), anyString(), anyList()))
+		given(messageCommandService.saveAiMessage(eq(chat), anyString(), anyString(), anyList()))
 			.willReturn(answerMsg);
 
 		// when
@@ -212,7 +212,7 @@ public class RagChatServiceTest {
 		Ga4Event complete = events.get(1);
 
 		assertThat(submit.name()).isEqualTo("query_submit");
-		assertThat(submit.params()).containsEntry("bookmark_count_at_query", 7L);
+		assertThat(submit.params()).containsEntry("link_count_at_query", 7L);
 		assertThat(complete.name()).isEqualTo("query_response_complete");
 		assertThat(complete.params()).containsEntry("is_error", false);
 		assertThat(complete.params()).containsEntry("retrieved_count", 9);

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +28,8 @@ import com.sofa.linkiving.domain.link.dto.internal.LinkDto;
 import com.sofa.linkiving.domain.link.entity.Link;
 import com.sofa.linkiving.domain.link.service.LinkQueryService;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.Ga4Event;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RagChatService 단위 테스트")
@@ -46,6 +49,8 @@ public class RagChatServiceTest {
 	private LinkQueryService linkQueryService;
 	@Mock
 	private ChatQueryService chatQueryService;
+	@Mock
+	private Ga4Publisher ga4Publisher;
 	private Member member;
 	private Chat chat;
 
@@ -154,5 +159,106 @@ public class RagChatServiceTest {
 		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage("AI Service Unavailable");
+	}
+
+	@Test
+	void shouldPublishQueryAnalyticsEvents_WhenClientIdExists()
+		throws ExecutionException, InterruptedException {
+		// given
+		String clientId = "123.456";
+		given(linkQueryService.countByMemberAndIsDeleteFalse(member)).willReturn(7L);
+		given(chatQueryService.findChat(chatId, member)).willReturn(chat);
+
+		Message questionMsg = mock(Message.class);
+		given(questionMsg.getId()).willReturn(50L);
+		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+
+		given(messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(50L, chat))
+			.willReturn(Collections.emptyList());
+
+		RagAnswerRes ragRes = new RagAnswerRes(
+			"AI answer",
+			List.of("10", "20"),
+			List.of(new RagAnswerRes.ReasoningStep("reasoning", List.of("10"))),
+			List.of("10", "20"),
+			false,
+			9,
+			2,
+			0.91
+		);
+		given(answerClient.generateAnswer(any(RagAnswerReq.class))).willReturn(ragRes);
+
+		LinkDto linkDto1 = mock(LinkDto.class);
+		Link link1 = mock(Link.class);
+		given(linkDto1.link()).willReturn(link1);
+		given(linkQueryService.findAllByIdInWithSummary(eq(List.of(10L, 20L)), eq(member)))
+			.willReturn(List.of(linkDto1));
+
+		Message answerMsg = mock(Message.class);
+		given(answerMsg.getId()).willReturn(51L);
+		given(answerMsg.getContent()).willReturn("AI answer");
+		given(messageCommandService.saveAiMessage(eq(chat), anyString(), anyList()))
+			.willReturn(answerMsg);
+
+		// when
+		ragChatService.generateAnswer(chatId, member, userMessage, clientId).get();
+
+		// then
+		ArgumentCaptor<Ga4Event> eventCaptor = ArgumentCaptor.forClass(Ga4Event.class);
+		verify(ga4Publisher, times(2)).publish(eq(clientId), eq("100"), eventCaptor.capture());
+
+		List<Ga4Event> events = eventCaptor.getAllValues();
+		Ga4Event submit = events.get(0);
+		Ga4Event complete = events.get(1);
+
+		assertThat(submit.name()).isEqualTo("query_submit");
+		assertThat(submit.params()).containsEntry("bookmark_count_at_query", 7L);
+		assertThat(complete.name()).isEqualTo("query_response_complete");
+		assertThat(complete.params()).containsEntry("is_error", false);
+		assertThat(complete.params()).containsEntry("retrieved_count", 9);
+		assertThat(complete.params()).containsEntry("selected_count", 2);
+		assertThat(complete.params()).containsEntry("top_similarity", 0.91);
+		assertThat(complete.params()).containsKey("latency_ms");
+		assertThat(complete.params().get("query_id")).isEqualTo(submit.params().get("query_id"));
+		assertThat(complete.params()).doesNotContainValue(userMessage);
+		assertThat(complete.params()).doesNotContainValue("AI answer");
+	}
+
+	@Test
+	void shouldPublishErrorQueryAnalyticsEvent_WhenAiClientFails() {
+		// given
+		String clientId = "123.456";
+		given(linkQueryService.countByMemberAndIsDeleteFalse(member)).willReturn(7L);
+		given(chatQueryService.findChat(chatId, member)).willReturn(chat);
+
+		Message questionMsg = mock(Message.class);
+		given(questionMsg.getId()).willReturn(50L);
+		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+
+		given(messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(anyLong(), any()))
+			.willReturn(Collections.emptyList());
+
+		given(answerClient.generateAnswer(any()))
+			.willThrow(new RuntimeException("AI Service Unavailable"));
+
+		// when & then
+		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage, clientId))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("AI Service Unavailable");
+
+		ArgumentCaptor<Ga4Event> eventCaptor = ArgumentCaptor.forClass(Ga4Event.class);
+		verify(ga4Publisher, times(2)).publish(eq(clientId), eq("100"), eventCaptor.capture());
+
+		List<Ga4Event> events = eventCaptor.getAllValues();
+		Ga4Event submit = events.get(0);
+		Ga4Event complete = events.get(1);
+
+		assertThat(submit.name()).isEqualTo("query_submit");
+		assertThat(complete.name()).isEqualTo("query_response_complete");
+		assertThat(complete.params()).containsEntry("is_error", true);
+		assertThat(complete.params()).containsEntry("error_type", "RuntimeException");
+		assertThat(complete.params()).containsKey("latency_ms");
+		assertThat(complete.params().get("query_id")).isEqualTo(submit.params().get("query_id"));
+		assertThat(complete.params()).doesNotContainValue(userMessage);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
@@ -107,7 +107,7 @@ public class RagChatServiceTest {
 			.willReturn(answerMsg);
 
 		// when
-		CompletableFuture<AnswerRes> future = ragChatService.generateAnswer(chatId, member, userMessage);
+		CompletableFuture<AnswerRes> future = ragChatService.generateAnswer(chatId, member, userMessage, null);
 
 		// then
 		AnswerRes result = future.get();
@@ -132,11 +132,12 @@ public class RagChatServiceTest {
 			.willThrow(new RuntimeException("Chat Not Found"));
 
 		// when & then
-		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage))
+		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage, "123.456"))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage("Chat Not Found");
 
 		verifyNoInteractions(answerClient);
+		verifyNoInteractions(ga4Publisher);
 	}
 
 	@Test
@@ -156,7 +157,7 @@ public class RagChatServiceTest {
 			.willThrow(new RuntimeException("AI Service Unavailable"));
 
 		// when & then
-		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage))
+		assertThatThrownBy(() -> ragChatService.generateAnswer(chatId, member, userMessage, null))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage("AI Service Unavailable");
 	}
@@ -256,7 +257,7 @@ public class RagChatServiceTest {
 		assertThat(submit.name()).isEqualTo("query_submit");
 		assertThat(complete.name()).isEqualTo("query_response_complete");
 		assertThat(complete.params()).containsEntry("is_error", true);
-		assertThat(complete.params()).containsEntry("error_type", "RuntimeException");
+		assertThat(complete.params()).containsEntry("error_type", "UNKNOWN");
 		assertThat(complete.params()).containsKey("latency_ms");
 		assertThat(complete.params().get("query_id")).isEqualTo(submit.params().get("query_id"));
 		assertThat(complete.params()).doesNotContainValue(userMessage);

--- a/src/test/java/com/sofa/linkiving/security/config/StompHandlerTest.java
+++ b/src/test/java/com/sofa/linkiving/security/config/StompHandlerTest.java
@@ -3,11 +3,14 @@ package com.sofa.linkiving.security.config;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.HashMap;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -21,7 +24,10 @@ import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 class StompHandlerTest {
 
 	@Mock
-	JwtTokenProvider jwtTokenProvider;
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private MessageChannel messageChannel;
 
 	@Test
 	void shouldBlockPendingTermsMemberOnConnect() {
@@ -35,15 +41,32 @@ class StompHandlerTest {
 			.willReturn(MemberStatus.PENDING_TERMS.name());
 
 		// when & then
-		assertThatThrownBy(() -> stompHandler.preSend(message, mock()))
+		assertThatThrownBy(() -> stompHandler.preSend(message, messageChannel))
 			.isInstanceOf(MessagingException.class);
 
 		verify(jwtTokenProvider, never()).getAuthentication(token);
 	}
 
+	@Test
+	void preSend_blocksConnectWhenTokenIsNotAccessToken() {
+		// given
+		StompHandler handler = new StompHandler(jwtTokenProvider);
+		String token = "refresh.token";
+		Message<byte[]> message = connectMessage(token);
+
+		given(jwtTokenProvider.validateAccessToken(token)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> handler.preSend(message, messageChannel))
+			.isInstanceOf(MessagingException.class);
+
+		then(jwtTokenProvider).should(never()).getAuthentication(anyString());
+	}
+
 	private Message<byte[]> connectMessage(String token) {
 		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
-		accessor.setNativeHeader(JwtKeys.Headers.AUTHORIZATION, JwtKeys.Headers.BEARER_PREFIX + token);
+		accessor.setSessionAttributes(new HashMap<>());
+		accessor.addNativeHeader(JwtKeys.Headers.AUTHORIZATION, JwtKeys.Headers.BEARER_PREFIX + token);
 		return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 	}
 }


### PR DESCRIPTION
## 관련이슈
- Close #272

## 요약
- 채팅 질문 처리 시 `query_submit`과 `query_response_complete` GA4 서버 이벤트를 발화합니다.
- `query_id`는 UUID로 생성해 S1/S2와 프론트 B3/B4 이벤트를 연결합니다.
- 소켓 응답과 메시지 히스토리 응답에 `queryId`를 포함합니다.
- `link_count_at_query`는 질의 접수 시점의 사용자 저장 링크 수로 측정합니다.
- `latency_ms`는 서버가 질문 요청을 접수한 시점부터 일괄 AI 응답을 받아 클라이언트로 반환/전송하기 직전까지 측정합니다.
- 질문 원문과 AI 답변 원문은 GA params에 포함하지 않습니다.
- 실패 시에도 `query_response_complete`를 `is_error=true`와 `error_type`으로 발화합니다.

## RAG 메타데이터 주의
- `retrieved_count`, `top_similarity`는 `RagAnswerRes.retrievedCount`, `RagAnswerRes.topSimilarity`가 있을 때만 GA payload에 포함됩니다.
- 현재 확인된 기존 n8n `/webhook/chat-answer` 응답 로그에는 `retrievedCount`, `selectedCount`, `topSimilarity`가 포함되어 있지 않습니다.
- 따라서 n8n 응답 스펙이 추가되기 전까지 `retrieved_count`, `top_similarity`는 실제 이벤트에서 비어 있을 수 있습니다.
- `selected_count`는 AI 응답의 `selectedCount`가 없으면 백엔드가 `linkIds`로 조회한 selected link 개수로 fallback합니다.
- n8n이 snake_case로 내려주는 경우 camelCase DTO와 매핑 정책을 별도로 맞춰야 합니다.

## Stack
- Base: #279

## 테스트
- `./gradlew.bat compileJava checkstyleMain test --tests "com.sofa.linkiving.domain.chat.service.RagChatServiceTest" --tests "com.sofa.linkiving.domain.chat.service.MessageCommandServiceTest"` 통과
- `RagChatServiceTest`에 성공/실패 GA 이벤트 발화 검증을 추가했습니다.