### PR TITLE
[Auth] OAuth 최초 가입 약관 동의 흐름 추가 (#282)

### DIFF
--- a/src/main/java/com/sofa/linkiving/LinkivingApplication.java
+++ b/src/main/java/com/sofa/linkiving/LinkivingApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableScheduling
 public class LinkivingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sofa/linkiving/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sofa/linkiving/domain/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.sofa.linkiving.domain.auth.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.auth.dto.internal.TokenDto;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberQueryService;
 import com.sofa.linkiving.security.jwt.JwtProperties;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 
@@ -13,12 +15,14 @@ import lombok.RequiredArgsConstructor;
 public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtProperties jwtProperties;
+	private final MemberQueryService memberQueryService;
 
 	public TokenDto reissue(String refreshToken) {
 
 		String email = jwtTokenProvider.validateRefreshToken(refreshToken);
+		Member member = memberQueryService.getUser(email);
 
-		String newAccessToken = jwtTokenProvider.createAccessToken(email);
+		String newAccessToken = jwtTokenProvider.createAccessToken(member);
 		String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
 
 		int accessExp = (int)(jwtProperties.accessTokenValidTime() / 1000);

--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberApi.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.domain.member.controller;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
+import com.sofa.linkiving.domain.member.dto.request.TermsAgreementReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberProfileRes;
 import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -25,4 +26,7 @@ public interface MemberApi {
 
 	@Operation(summary = "내 프로필 조회", description = "로그인한 사용자의 프로필 정보를 조회합니다.")
 	BaseResponse<MemberProfileRes> getProfile(Member member);
+
+	@Operation(summary = "약관 동의", description = "OAuth 최초 가입 회원의 필수 약관 동의를 처리합니다.")
+	BaseResponse<TokenRes> agreeTerms(Member member, TermsAgreementReq req);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
+import com.sofa.linkiving.domain.member.dto.request.TermsAgreementReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberProfileRes;
 import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -85,5 +86,12 @@ public class MemberController implements MemberApi {
 	public BaseResponse<MemberProfileRes> getProfile(@AuthMember Member member) {
 		MemberProfileRes profile = memberService.getProfile(member);
 		return BaseResponse.success(profile, "프로필 조회에 성공하였습니다.");
+	}
+
+	@Override
+	@PostMapping("/terms-agreement")
+	public BaseResponse<TokenRes> agreeTerms(@AuthMember Member member, @Validated @RequestBody TermsAgreementReq req) {
+		TokenRes token = memberService.agreeTerms(member, req);
+		return BaseResponse.success(token, "약관 동의가 완료되었습니다.");
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/dto/request/TermsAgreementReq.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/dto/request/TermsAgreementReq.java
@@ -1,0 +1,16 @@
+package com.sofa.linkiving.domain.member.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+public record TermsAgreementReq(
+	@AssertTrue
+	boolean termsAgreed,
+	@AssertTrue
+	boolean privacyAgreed,
+	@NotBlank
+	String termsVersion,
+	@NotBlank
+	String privacyVersion
+) {
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -95,6 +95,10 @@ public class Member extends BaseEntity {
 	}
 
 	public void agreeTerms(String termsVersion, String privacyVersion) {
+		if (!needsTermsAgreement()) {
+			throw new BusinessException(MemberErrorCode.TERMS_ALREADY_AGREED);
+		}
+
 		LocalDateTime now = LocalDateTime.now();
 		this.termsAgreedAt = now;
 		this.privacyAgreedAt = now;

--- a/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/entity/Member.java
@@ -1,7 +1,9 @@
 package com.sofa.linkiving.domain.member.entity;
 
+import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.common.BaseEntity;
@@ -9,6 +11,7 @@ import com.sofa.linkiving.global.error.exception.BusinessException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,9 +34,19 @@ public class Member extends BaseEntity {
 	private String profileImageUrl;
 	@Column(nullable = false)
 	private Role role;
+	@Column(nullable = false, columnDefinition = "integer default 2")
+	private MemberStatus status;
+	@Column
+	private LocalDateTime termsAgreedAt;
+	@Column
+	private LocalDateTime privacyAgreedAt;
+	@Column
+	private String termsVersion;
+	@Column
+	private String privacyVersion;
 
 	@Builder
-	public Member(String email, String password, String name, String profileImageUrl) {
+	public Member(String email, String password, String name, String profileImageUrl, MemberStatus status) {
 		if (!isValidEmail(email)) {
 			throw new BusinessException(MemberErrorCode.INVALID_EMAIL_FORMAT);
 		}
@@ -42,10 +55,22 @@ public class Member extends BaseEntity {
 		this.name = name;
 		this.profileImageUrl = profileImageUrl;
 		this.role = Role.USER;
+		this.status = status == null ? MemberStatus.ACTIVE : status;
 	}
 
 	private boolean isValidEmail(String email) {
 		return EMAIL_PATTERN.matcher(email).matches();
+	}
+
+	public MemberStatus getStatus() {
+		return status == null ? MemberStatus.ACTIVE : status;
+	}
+
+	@PrePersist
+	private void setDefaultStatus() {
+		if (status == null) {
+			status = MemberStatus.ACTIVE;
+		}
 	}
 
 	public boolean verifyPassword(String rawPassword) {
@@ -59,5 +84,22 @@ public class Member extends BaseEntity {
 		if (profileImageUrl != null) {
 			this.profileImageUrl = profileImageUrl;
 		}
+	}
+
+	public boolean needsTermsAgreement() {
+		return getStatus() == MemberStatus.PENDING_TERMS;
+	}
+
+	public boolean hasAgreedTerms() {
+		return getStatus() == MemberStatus.ACTIVE;
+	}
+
+	public void agreeTerms(String termsVersion, String privacyVersion) {
+		LocalDateTime now = LocalDateTime.now();
+		this.termsAgreedAt = now;
+		this.privacyAgreedAt = now;
+		this.termsVersion = termsVersion;
+		this.privacyVersion = privacyVersion;
+		this.status = MemberStatus.ACTIVE;
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/enums/MemberStatus.java
@@ -1,0 +1,24 @@
+package com.sofa.linkiving.domain.member.enums;
+
+import com.sofa.linkiving.global.converter.AbstractCodeEnumConverter;
+import com.sofa.linkiving.global.converter.CodeEnum;
+
+import jakarta.persistence.Converter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus implements CodeEnum<Integer> {
+
+	PENDING_TERMS(1), ACTIVE(2);
+
+	private final Integer code;
+
+	@Converter(autoApply = true)
+	static class MemberStatusConverter extends AbstractCodeEnumConverter<MemberStatus, Integer> {
+		public MemberStatusConverter() {
+			super(MemberStatus.class);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/error/MemberErrorCode.java
@@ -14,7 +14,10 @@ public enum MemberErrorCode implements ErrorCode {
 	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M-000", "유효하지 않은 이메일 형식입니다."),
 	DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "M-001", "이미 존재하는 이메일입니다."),
 	USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "M-002", "존재하지 않는 유저입니다."),
-	INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "M-003", "잘못된 비밀번호입니다.");
+	INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "M-003", "잘못된 비밀번호입니다."),
+	TERMS_AGREEMENT_REQUIRED(HttpStatus.FORBIDDEN, "M-004", "약관 동의가 필요합니다."),
+	TERMS_ALREADY_AGREED(HttpStatus.BAD_REQUEST, "M-005", "이미 약관 동의가 완료되었습니다."),
+	INVALID_TERMS_VERSION(HttpStatus.BAD_REQUEST, "M-006", "유효하지 않은 약관 버전입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
@@ -1,15 +1,22 @@
 package com.sofa.linkiving.domain.member.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsMemberByEmail(String email);
 
 	Optional<Member> findByEmail(String email);
+
+	long deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
+		MemberStatus status,
+		LocalDateTime createdAt
+	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -15,8 +18,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByEmail(String email);
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		DELETE FROM Member m
+		WHERE m.status = :status
+			AND m.termsAgreedAt IS NULL
+			AND m.privacyAgreedAt IS NULL
+			AND m.createdAt < :createdAt
+		""")
 	long deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
-		MemberStatus status,
-		LocalDateTime createdAt
+		@Param("status") MemberStatus status,
+		@Param("createdAt") LocalDateTime createdAt
 	);
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberCommandService.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.member.service;
 import org.springframework.stereotype.Service;
 
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ public class MemberCommandService {
 					.password(email)
 					.name(name)
 					.profileImageUrl(profileImageUrl)
+					.status(MemberStatus.PENDING_TERMS)
 					.build();
 
 				return memberRepository.save(newMember);

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.sofa.linkiving.domain.member.service;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,10 @@ public class MemberService {
 	private final MemberQueryService memberQueryService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisService redisService;
+	@Value("${app.member.current-terms-version:2026-08-03}")
+	private String currentTermsVersion;
+	@Value("${app.member.current-privacy-version:2026-08-03}")
+	private String currentPrivacyVersion;
 
 	public TokenRes signup(SignupReq req) {
 
@@ -75,11 +80,20 @@ public class MemberService {
 	}
 
 	public TokenRes agreeTerms(Member member, TermsAgreementReq req) {
-		member.agreeTerms(req.termsVersion(), req.privacyVersion());
+		validateAgreementVersion(req);
 
-		String accessToken = jwtTokenProvider.createAccessToken(member);
-		String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+		Member managed = memberQueryService.getUser(member.getEmail());
+		managed.agreeTerms(req.termsVersion(), req.privacyVersion());
+
+		String accessToken = jwtTokenProvider.createAccessToken(managed);
+		String refreshToken = jwtTokenProvider.createRefreshToken(managed.getEmail());
 
 		return TokenRes.of(accessToken, refreshToken);
+	}
+
+	private void validateAgreementVersion(TermsAgreementReq req) {
+		if (!currentTermsVersion.equals(req.termsVersion()) || !currentPrivacyVersion.equals(req.privacyVersion())) {
+			throw new BusinessException(MemberErrorCode.INVALID_TERMS_VERSION);
+		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
+import com.sofa.linkiving.domain.member.dto.request.TermsAgreementReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberProfileRes;
 import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
@@ -40,7 +41,7 @@ public class MemberService {
 
 		Member member = memberCommandService.addUser(req.email(), encoded);
 
-		String accessToken = jwtTokenProvider.createAccessToken(member.getEmail());
+		String accessToken = jwtTokenProvider.createAccessToken(member);
 		String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
 		return TokenRes.of(accessToken, refreshToken);
@@ -58,7 +59,7 @@ public class MemberService {
 			throw new BusinessException(MemberErrorCode.INCORRECT_PASSWORD);
 		}
 
-		String accessToken = jwtTokenProvider.createAccessToken(member.getEmail());
+		String accessToken = jwtTokenProvider.createAccessToken(member);
 		String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
 		return TokenRes.of(accessToken, refreshToken);
@@ -71,5 +72,14 @@ public class MemberService {
 	@Transactional(readOnly = true)
 	public MemberProfileRes getProfile(Member member) {
 		return MemberProfileRes.from(member);
+	}
+
+	public TokenRes agreeTerms(Member member, TermsAgreementReq req) {
+		member.agreeTerms(req.termsVersion(), req.privacyVersion());
+
+		String accessToken = jwtTokenProvider.createAccessToken(member);
+		String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+
+		return TokenRes.of(accessToken, refreshToken);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupScheduler.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupScheduler.java
@@ -9,7 +9,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.global.logging.AuditLogger;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Action;
+import com.sofa.linkiving.global.metrics.AsyncTaskMetrics.Task;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -17,27 +24,42 @@ import lombok.extern.slf4j.Slf4j;
 public class PendingTermsMemberCleanupScheduler {
 	private final MemberRepository memberRepository;
 	private final int retentionDays;
+	private final MeterRegistry meterRegistry;
+	private Counter cleanupFailureCounter;
 
 	public PendingTermsMemberCleanupScheduler(
 		MemberRepository memberRepository,
-		@Value("${app.member.pending-terms-retention-days:14}") int retentionDays
+		@Value("${app.member.pending-terms-retention-days:14}") int retentionDays,
+		MeterRegistry meterRegistry
 	) {
 		this.memberRepository = memberRepository;
 		this.retentionDays = retentionDays;
+		this.meterRegistry = meterRegistry;
+	}
+
+	@PostConstruct
+	private void initCounters() {
+		this.cleanupFailureCounter = AsyncTaskMetrics.failureCounter(meterRegistry, Task.MEMBER, Action.DELETE);
 	}
 
 	@Scheduled(cron = "${app.member.pending-terms-cleanup-cron:0 0 4 * * *}")
 	@Transactional
 	public void deleteExpiredPendingTermsMembers() {
 		LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
-		long deletedCount = memberRepository
-			.deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
-				MemberStatus.PENDING_TERMS,
-				cutoff
-			);
+		try {
+			long deletedCount = memberRepository
+				.deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
+					MemberStatus.PENDING_TERMS,
+					cutoff
+				);
 
-		if (deletedCount > 0) {
-			log.info("Deleted expired pending terms members - count: {}, cutoff: {}", deletedCount, cutoff);
+			if (deletedCount > 0) {
+				AuditLogger.info("event=pending_terms_cleanup result=SUCCESS deleted={} cutoff={}",
+					deletedCount, cutoff);
+			}
+		} catch (Exception e) {
+			cleanupFailureCounter.increment();
+			log.error("Failed to cleanup expired pending terms members - cutoff: {}", cutoff, e);
 		}
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupScheduler.java
+++ b/src/main/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupScheduler.java
@@ -1,0 +1,43 @@
+package com.sofa.linkiving.domain.member.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class PendingTermsMemberCleanupScheduler {
+	private final MemberRepository memberRepository;
+	private final int retentionDays;
+
+	public PendingTermsMemberCleanupScheduler(
+		MemberRepository memberRepository,
+		@Value("${app.member.pending-terms-retention-days:14}") int retentionDays
+	) {
+		this.memberRepository = memberRepository;
+		this.retentionDays = retentionDays;
+	}
+
+	@Scheduled(cron = "${app.member.pending-terms-cleanup-cron:0 0 4 * * *}")
+	@Transactional
+	public void deleteExpiredPendingTermsMembers() {
+		LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+		long deletedCount = memberRepository
+			.deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
+				MemberStatus.PENDING_TERMS,
+				cutoff
+			);
+
+		if (deletedCount > 0) {
+			log.info("Deleted expired pending terms members - count: {}, cutoff: {}", deletedCount, cutoff);
+		}
+	}
+}

--- a/src/main/java/com/sofa/linkiving/global/metrics/AsyncTaskMetrics.java
+++ b/src/main/java/com/sofa/linkiving/global/metrics/AsyncTaskMetrics.java
@@ -33,7 +33,8 @@ public final class AsyncTaskMetrics {
 	@RequiredArgsConstructor
 	public enum Task {
 		SUMMARY("summary"),
-		LINK_SYNC("link-sync");
+		LINK_SYNC("link-sync"),
+		MEMBER("member");
 
 		private final String value;
 	}

--- a/src/main/java/com/sofa/linkiving/security/auth/config/OAuth2Properties.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/OAuth2Properties.java
@@ -5,6 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app.oauth2")
 public record OAuth2Properties(
 	String successRedirectUrl,
+	String termsRedirectUrl,
 	String failureRedirectUrl
 ) {
+	public OAuth2Properties {
+		if ((termsRedirectUrl == null || termsRedirectUrl.isBlank()) && successRedirectUrl != null) {
+			termsRedirectUrl = successRedirectUrl.replaceFirst("/home/?$", "/terms");
+		}
+	}
 }

--- a/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/config/SecurityConstants.java
@@ -33,6 +33,10 @@ public abstract class SecurityConstants {
 		"/v1/admin/**"
 	};
 
+	public static final String[] PENDING_TERMS_ALLOWED_URLS = {
+		"/v1/member/terms-agreement", "/v1/auth/reissue", "/v1/member/logout"
+	};
+
 	private static final String[] SEMI_PERMIT_URLS = {
 		//GET만 허용해야 하는 URL
 	};

--- a/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/auth/handler/OAuth2SuccessHandler.java
@@ -7,6 +7,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberQueryService;
 import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.global.util.CookieUtils;
 import com.sofa.linkiving.security.auth.config.OAuth2Properties;
@@ -25,6 +27,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final OAuth2Properties oauth2Properties;
 	private final JwtProperties jwtProperties;
 	private final CookieUtils cookieUtils;
+	private final MemberQueryService memberQueryService;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -32,8 +35,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
 		String email = oAuth2User.getAttribute("email");
+		Member member = memberQueryService.getUser(email);
 
-		String accessToken = jwtTokenProvider.createAccessToken(email);
+		String accessToken = jwtTokenProvider.createAccessToken(member);
 		String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
 		int accessExp = (int)(jwtProperties.accessTokenValidTime() / 1000);
@@ -44,7 +48,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		AuditLogger.info("event=oauth2_login result=SUCCESS email={}", email);
 
-		String targetUrl = oauth2Properties.successRedirectUrl();
+		String targetUrl = member.needsTermsAgreement() ? oauth2Properties.termsRedirectUrl() :
+			oauth2Properties.successRedirectUrl();
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
+++ b/src/main/java/com/sofa/linkiving/security/config/StompHandler.java
@@ -14,6 +14,8 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
+import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.global.logging.AuditLogger;
 import com.sofa.linkiving.security.jwt.JwtKeys;
@@ -66,6 +68,11 @@ public class StompHandler implements ChannelInterceptor {
 					if (jwtTokenProvider.validateAccessToken(token)) {
 
 						if (StompCommand.CONNECT.equals(command)) {
+							String memberStatus = jwtTokenProvider.getClaim(token, JwtKeys.Claims.MEMBER_STATUS);
+							if (MemberStatus.PENDING_TERMS.name().equals(memberStatus)) {
+								throw new BusinessException(MemberErrorCode.TERMS_AGREEMENT_REQUIRED);
+							}
+
 							Authentication authentication = jwtTokenProvider.getAuthentication(token);
 							accessor.setUser(authentication);
 						}

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtKeys.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtKeys.java
@@ -14,6 +14,8 @@ public final class JwtKeys {
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static final class Claims {
 		public static final String TOKEN_TYPE = "token_type";
+		public static final String MEMBER_STATUS = "memberStatus";
+		public static final String TERMS_AGREED = "termsAgreed";
 	}
 
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -20,6 +20,7 @@ import com.sofa.linkiving.security.jwt.error.JwtErrorCode;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -56,7 +57,7 @@ public class JwtTokenProvider {
 		this.refreshTokenValidTime = jwtProperties.refreshTokenValidTime();
 	}
 
-	private String createJwtToken(String subject, long validityMillis, String tokenType) {
+	private JwtBuilder baseToken(String subject, long validityMillis, String tokenType) {
 		Date now = new Date();
 		Date exp = new Date(now.getTime() + validityMillis);
 
@@ -65,8 +66,11 @@ public class JwtTokenProvider {
 			.claim(JwtKeys.Claims.TOKEN_TYPE, tokenType)
 			.issuedAt(now)
 			.expiration(exp)
-			.signWith(secretKey, Jwts.SIG.HS256)
-			.compact();
+			.signWith(secretKey, Jwts.SIG.HS256);
+	}
+
+	private String createJwtToken(String subject, long validityMillis, String tokenType) {
+		return baseToken(subject, validityMillis, tokenType).compact();
 	}
 
 	public String createAccessToken(String id) {
@@ -74,17 +78,9 @@ public class JwtTokenProvider {
 	}
 
 	public String createAccessToken(Member member) {
-		Date now = new Date();
-		Date exp = new Date(now.getTime() + accessTokenValidTime);
-
-		return Jwts.builder()
-			.subject(member.getEmail())
-			.claim(JwtKeys.Claims.TOKEN_TYPE, JwtKeys.TokenType.ACCESS)
+		return baseToken(member.getEmail(), accessTokenValidTime, JwtKeys.TokenType.ACCESS)
 			.claim(JwtKeys.Claims.MEMBER_STATUS, member.getStatus().name())
 			.claim(JwtKeys.Claims.TERMS_AGREED, member.hasAgreedTerms())
-			.issuedAt(now)
-			.expiration(exp)
-			.signWith(secretKey, Jwts.SIG.HS256)
 			.compact();
 	}
 
@@ -173,5 +169,9 @@ public class JwtTokenProvider {
 
 		String tokenType = claims.get(JwtKeys.Claims.TOKEN_TYPE, String.class);
 		return JwtKeys.TokenType.ACCESS.equals(tokenType);
+	}
+
+	public String getClaim(String token, String claimName) {
+		return parseClaims(token).get(claimName, String.class);
 	}
 }

--- a/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.WebUtils;
 
+import com.sofa.linkiving.domain.member.entity.Member;
 import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.jwt.error.CustomJwtException;
@@ -70,6 +71,21 @@ public class JwtTokenProvider {
 
 	public String createAccessToken(String id) {
 		return createJwtToken(id, accessTokenValidTime, JwtKeys.TokenType.ACCESS);
+	}
+
+	public String createAccessToken(Member member) {
+		Date now = new Date();
+		Date exp = new Date(now.getTime() + accessTokenValidTime);
+
+		return Jwts.builder()
+			.subject(member.getEmail())
+			.claim(JwtKeys.Claims.TOKEN_TYPE, JwtKeys.TokenType.ACCESS)
+			.claim(JwtKeys.Claims.MEMBER_STATUS, member.getStatus().name())
+			.claim(JwtKeys.Claims.TERMS_AGREED, member.hasAgreedTerms())
+			.issuedAt(now)
+			.expiration(exp)
+			.signWith(secretKey, Jwts.SIG.HS256)
+			.compact();
 	}
 
 	public String createRefreshToken(String id) {

--- a/src/main/java/com/sofa/linkiving/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sofa/linkiving/security/jwt/filter/JwtAuthenticationFilter.java
@@ -9,8 +9,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofa.linkiving.global.common.BaseResponse;
+import com.sofa.linkiving.global.error.code.CommonErrorCode;
 import com.sofa.linkiving.security.auth.config.SecurityConstants;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
+	private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
 	@Override
 	public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -31,9 +37,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		if (token != null && jwtTokenProvider.validateAccessToken(token)) {
 			Authentication authentication = jwtTokenProvider.getAuthentication(token);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
+			if (isPendingTermsMember(authentication) && !isPendingTermsAllowed(request)) {
+				response.setStatus(CommonErrorCode.FORBIDDEN.getStatus().value());
+				response.setContentType("application/json;charset=UTF-8");
+				objectMapper.writeValue(response.getWriter(), BaseResponse.error(CommonErrorCode.FORBIDDEN));
+				return;
+			}
 		}
 
 		filterChain.doFilter(request, response);
+	}
+
+	private boolean isPendingTermsMember(Authentication authentication) {
+		return authentication.getPrincipal() instanceof CustomMemberDetail memberDetail
+			&& memberDetail.member().needsTermsAgreement();
+	}
+
+	private boolean isPendingTermsAllowed(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return Arrays.stream(SecurityConstants.PENDING_TERMS_ALLOWED_URLS)
+			.anyMatch(pattern -> pathMatcher.match(pattern, path));
 	}
 
 	@Override
@@ -41,6 +64,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		String path = request.getRequestURI();
 		// 상수에 정의된 패턴 중 하나라도 일치하면 필터를 건너뜀
 		return Arrays.stream(SecurityConstants.PERMIT_URLS)
-			.anyMatch(pattern -> new AntPathMatcher().match(pattern, path));
+			.anyMatch(pattern -> pathMatcher.match(pattern, path));
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/auth/service/AuthServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sofa.linkiving.domain.auth.dto.internal.TokenDto;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.service.MemberQueryService;
 import com.sofa.linkiving.security.jwt.JwtProperties;
 import com.sofa.linkiving.security.jwt.JwtTokenProvider;
 import com.sofa.linkiving.security.jwt.error.CustomJwtException;
@@ -29,6 +31,9 @@ public class AuthServiceTest {
 	@Mock
 	private JwtProperties jwtProperties;
 
+	@Mock
+	private MemberQueryService memberQueryService;
+
 	@Test
 	@DisplayName("유효한 RefreshToken이 주어지면 새로운 토큰 쌍을 발급한다")
 	void shouldReissueTokensSuccessfully() {
@@ -38,9 +43,14 @@ public class AuthServiceTest {
 
 		String newAccessToken = "new-access-token";
 		String newRefreshToken = "new-refresh-token";
+		Member member = Member.builder()
+			.email("test@test.com")
+			.password("password")
+			.build();
 
 		given(jwtTokenProvider.validateRefreshToken(oldRefreshToken)).willReturn("test@test.com");
-		given(jwtTokenProvider.createAccessToken("test@test.com")).willReturn(newAccessToken);
+		given(memberQueryService.getUser("test@test.com")).willReturn(member);
+		given(jwtTokenProvider.createAccessToken(member)).willReturn(newAccessToken);
 		given(jwtTokenProvider.createRefreshToken("test@test.com")).willReturn(newRefreshToken);
 
 		// 1시간 = 3600000ms, 2주 = 1209600000ms
@@ -58,6 +68,7 @@ public class AuthServiceTest {
 		assertThat(result.refreshExp()).isEqualTo(1209600);
 
 		verify(jwtTokenProvider, times(1)).validateRefreshToken(oldRefreshToken);
+		verify(memberQueryService, times(1)).getUser("test@test.com");
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/entity/MemberTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 
@@ -40,5 +41,27 @@ public class MemberTest {
 			.isInstanceOfSatisfying(BusinessException.class, ex ->
 				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INVALID_EMAIL_FORMAT)
 			);
+	}
+
+	@Test
+	void shouldCreatePendingTermsMemberAndActivateAfterAgreement() {
+		// given
+		Member member = Member.builder()
+			.email("oauth@test.com")
+			.password("oauth@test.com")
+			.status(MemberStatus.PENDING_TERMS)
+			.build();
+
+		// when
+		member.agreeTerms("2026-08-03", "2026-08-03");
+
+		// then
+		assertThat(member.needsTermsAgreement()).isFalse();
+		assertThat(member.hasAgreedTerms()).isTrue();
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.getTermsVersion()).isEqualTo("2026-08-03");
+		assertThat(member.getPrivacyVersion()).isEqualTo("2026-08-03");
+		assertThat(member.getTermsAgreedAt()).isNotNull();
+		assertThat(member.getPrivacyAgreedAt()).isNotNull();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/integration/MemberApiIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -27,19 +28,37 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
+import com.sofa.linkiving.domain.member.dto.request.TermsAgreementReq;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+import com.sofa.linkiving.domain.member.service.MemberService;
 import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
 import com.sofa.linkiving.infra.redis.RedisService;
 import com.sofa.linkiving.security.userdetails.CustomMemberDetail;
+
+import jakarta.persistence.EntityManager;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")
-@TestPropertySource(properties = "app.cookie.domain=linkiving.com")
+@TestPropertySource(properties = {
+	"app.cookie.domain=linkiving.com",
+	"ai.server.url=http://localhost",
+	"test.external.base-url=http://localhost",
+	"security.jwt.secret=0123456789012345678901234567890123456789012345678901234567890123",
+	"security.jwt.access-token-valid-minute=10",
+	"security.jwt.refresh-token-valid-month=1",
+	"spring.cloud.aws.s3.bucket=test-bucket",
+	"spring.cloud.aws.region.static=ap-northeast-2",
+	"summary.worker.sleep-duration=10ms",
+	"hashids.salt=test-salt",
+	"spring.data.redis.host=localhost",
+	"spring.data.redis.port=6379"
+})
 public class MemberApiIntegrationTest {
 
 	private static final String BASE_URL = "/v1/member";
@@ -49,8 +68,14 @@ public class MemberApiIntegrationTest {
 	ObjectMapper objectMapper;
 	@Autowired
 	MemberRepository memberRepository;
+	@Autowired
+	MemberService memberService;
+	@Autowired
+	EntityManager entityManager;
 	@MockitoBean
 	RedisService redisService;
+	@MockitoBean
+	ClientRegistrationRepository clientRegistrationRepository;
 
 	@Test
 	@DisplayName("회원가입 성공 시 DB에 인코딩된 비밀번호가 저장된다")
@@ -280,5 +305,32 @@ public class MemberApiIntegrationTest {
 		assertThat(accessTokenCookie).contains("Secure");
 		assertThat(refreshTokenCookie).contains("HttpOnly");
 		assertThat(refreshTokenCookie).contains("Secure");
+	}
+
+	@Test
+	void shouldPersistTermsAgreementWhenAuthMemberIsDetached() {
+		// given
+		Member saved = memberRepository.save(Member.builder()
+			.email("terms-detached@test.com")
+			.password("password")
+			.status(MemberStatus.PENDING_TERMS)
+			.build());
+		entityManager.flush();
+		entityManager.detach(saved);
+
+		TermsAgreementReq req = new TermsAgreementReq(true, true, "2026-08-03", "2026-08-03");
+
+		// when
+		memberService.agreeTerms(saved, req);
+		entityManager.flush();
+		entityManager.clear();
+
+		// then
+		Member reloaded = memberRepository.findByEmail(saved.getEmail()).orElseThrow();
+		assertThat(reloaded.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(reloaded.getTermsVersion()).isEqualTo("2026-08-03");
+		assertThat(reloaded.getPrivacyVersion()).isEqualTo("2026-08-03");
+		assertThat(reloaded.getTermsAgreedAt()).isNotNull();
+		assertThat(reloaded.getPrivacyAgreedAt()).isNotNull();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -20,9 +20,11 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
+import com.sofa.linkiving.domain.member.dto.request.TermsAgreementReq;
 import com.sofa.linkiving.domain.member.dto.response.MemberProfileRes;
 import com.sofa.linkiving.domain.member.dto.response.TokenRes;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.error.MemberErrorCode;
 import com.sofa.linkiving.global.error.exception.BusinessException;
 import com.sofa.linkiving.infra.redis.RedisService;
@@ -83,7 +85,7 @@ public class MemberServiceTest {
 		when(memberCommandService.addUser(eq(req.email()), eq(expectedEncoded)))
 			.thenReturn(saved);
 
-		given(jwtTokenProvider.createAccessToken(any())).willReturn("mock-access-token");
+		given(jwtTokenProvider.createAccessToken(any(Member.class))).willReturn("mock-access-token");
 		given(jwtTokenProvider.createRefreshToken(any())).willReturn("mock-refresh-token");
 
 		// when
@@ -112,7 +114,7 @@ public class MemberServiceTest {
 		Member member = Member.builder().email(email).password(encoded).build();
 		given(memberQueryService.getUser(email)).willReturn(member);
 
-		given(jwtTokenProvider.createAccessToken(any())).willReturn("mock-access-token");
+		given(jwtTokenProvider.createAccessToken(any(Member.class))).willReturn("mock-access-token");
 		given(jwtTokenProvider.createRefreshToken(any())).willReturn("mock-refresh-token");
 
 		// when
@@ -160,6 +162,36 @@ public class MemberServiceTest {
 
 		// then
 		verify(redisService, times(1)).delete(any(), eq(member.getEmail()));
+	}
+
+	@Test
+	void shouldAgreeTermsAndReturnTokens() {
+		// given
+		Member member = Member.builder()
+			.email("oauth@test.com")
+			.password("pw")
+			.status(MemberStatus.PENDING_TERMS)
+			.build();
+		TermsAgreementReq req = new TermsAgreementReq(true, true, "2026-08-03", "2026-08-03");
+
+		given(jwtTokenProvider.createAccessToken(member)).willReturn("mock-access-token");
+		given(jwtTokenProvider.createRefreshToken(member.getEmail())).willReturn("mock-refresh-token");
+
+		// when
+		TokenRes res = memberService.agreeTerms(member, req);
+
+		// then
+		assertThat(res.accessToken()).isEqualTo("mock-access-token");
+		assertThat(res.refreshToken()).isEqualTo("mock-refresh-token");
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(member.needsTermsAgreement()).isFalse();
+		assertThat(member.getTermsVersion()).isEqualTo("2026-08-03");
+		assertThat(member.getPrivacyVersion()).isEqualTo("2026-08-03");
+		assertThat(member.getTermsAgreedAt()).isNotNull();
+		assertThat(member.getPrivacyAgreedAt()).isNotNull();
+
+		verify(jwtTokenProvider, times(1)).createAccessToken(member);
+		verify(jwtTokenProvider, times(1)).createRefreshToken(member.getEmail());
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/MemberServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sofa.linkiving.domain.member.dto.request.LoginReq;
 import com.sofa.linkiving.domain.member.dto.request.SignupReq;
@@ -172,10 +173,18 @@ public class MemberServiceTest {
 			.password("pw")
 			.status(MemberStatus.PENDING_TERMS)
 			.build();
+		Member managed = Member.builder()
+			.email("oauth@test.com")
+			.password("pw")
+			.status(MemberStatus.PENDING_TERMS)
+			.build();
 		TermsAgreementReq req = new TermsAgreementReq(true, true, "2026-08-03", "2026-08-03");
 
-		given(jwtTokenProvider.createAccessToken(member)).willReturn("mock-access-token");
-		given(jwtTokenProvider.createRefreshToken(member.getEmail())).willReturn("mock-refresh-token");
+		ReflectionTestUtils.setField(memberService, "currentTermsVersion", "2026-08-03");
+		ReflectionTestUtils.setField(memberService, "currentPrivacyVersion", "2026-08-03");
+		given(memberQueryService.getUser(member.getEmail())).willReturn(managed);
+		given(jwtTokenProvider.createAccessToken(managed)).willReturn("mock-access-token");
+		given(jwtTokenProvider.createRefreshToken(managed.getEmail())).willReturn("mock-refresh-token");
 
 		// when
 		TokenRes res = memberService.agreeTerms(member, req);
@@ -183,15 +192,38 @@ public class MemberServiceTest {
 		// then
 		assertThat(res.accessToken()).isEqualTo("mock-access-token");
 		assertThat(res.refreshToken()).isEqualTo("mock-refresh-token");
-		assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
-		assertThat(member.needsTermsAgreement()).isFalse();
-		assertThat(member.getTermsVersion()).isEqualTo("2026-08-03");
-		assertThat(member.getPrivacyVersion()).isEqualTo("2026-08-03");
-		assertThat(member.getTermsAgreedAt()).isNotNull();
-		assertThat(member.getPrivacyAgreedAt()).isNotNull();
+		assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING_TERMS);
+		assertThat(managed.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(managed.needsTermsAgreement()).isFalse();
+		assertThat(managed.getTermsVersion()).isEqualTo("2026-08-03");
+		assertThat(managed.getPrivacyVersion()).isEqualTo("2026-08-03");
+		assertThat(managed.getTermsAgreedAt()).isNotNull();
+		assertThat(managed.getPrivacyAgreedAt()).isNotNull();
 
-		verify(jwtTokenProvider, times(1)).createAccessToken(member);
-		verify(jwtTokenProvider, times(1)).createRefreshToken(member.getEmail());
+		verify(memberQueryService).getUser(member.getEmail());
+		verify(jwtTokenProvider, times(1)).createAccessToken(managed);
+		verify(jwtTokenProvider, times(1)).createRefreshToken(managed.getEmail());
+	}
+
+	@Test
+	void shouldThrowWhenTermsVersionIsInvalid() {
+		// given
+		Member member = Member.builder()
+			.email("oauth-invalid-version@test.com")
+			.password("pw")
+			.status(MemberStatus.PENDING_TERMS)
+			.build();
+		TermsAgreementReq req = new TermsAgreementReq(true, true, "invalid", "2026-08-03");
+
+		ReflectionTestUtils.setField(memberService, "currentTermsVersion", "2026-08-03");
+		ReflectionTestUtils.setField(memberService, "currentPrivacyVersion", "2026-08-03");
+
+		// when & then
+		assertThatThrownBy(() -> memberService.agreeTerms(member, req))
+			.isInstanceOfSatisfying(BusinessException.class, ex ->
+				assertThat(ex.getErrorCode()).isEqualTo(MemberErrorCode.INVALID_TERMS_VERSION));
+
+		verifyNoInteractions(jwtTokenProvider);
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupSchedulerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.sofa.linkiving.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
+import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+class PendingTermsMemberCleanupSchedulerTest {
+
+	@Test
+	void shouldDeleteExpiredPendingTermsMembers() {
+		// given
+		MemberRepository memberRepository = mock(MemberRepository.class);
+		PendingTermsMemberCleanupScheduler scheduler = new PendingTermsMemberCleanupScheduler(memberRepository, 14);
+		ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+		LocalDateTime before = LocalDateTime.now().minusDays(14);
+
+		// when
+		scheduler.deleteExpiredPendingTermsMembers();
+
+		// then
+		LocalDateTime after = LocalDateTime.now().minusDays(14);
+		verify(memberRepository, times(1))
+			.deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
+				eq(MemberStatus.PENDING_TERMS),
+				cutoffCaptor.capture()
+			);
+		assertThat(cutoffCaptor.getValue()).isBetween(before, after);
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupSchedulerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/member/service/PendingTermsMemberCleanupSchedulerTest.java
@@ -7,9 +7,12 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.repository.MemberRepository;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class PendingTermsMemberCleanupSchedulerTest {
 
@@ -17,7 +20,9 @@ class PendingTermsMemberCleanupSchedulerTest {
 	void shouldDeleteExpiredPendingTermsMembers() {
 		// given
 		MemberRepository memberRepository = mock(MemberRepository.class);
-		PendingTermsMemberCleanupScheduler scheduler = new PendingTermsMemberCleanupScheduler(memberRepository, 14);
+		PendingTermsMemberCleanupScheduler scheduler =
+			new PendingTermsMemberCleanupScheduler(memberRepository, 14, new SimpleMeterRegistry());
+		ReflectionTestUtils.invokeMethod(scheduler, "initCounters");
 		ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 		LocalDateTime before = LocalDateTime.now().minusDays(14);
 
@@ -32,5 +37,25 @@ class PendingTermsMemberCleanupSchedulerTest {
 				cutoffCaptor.capture()
 			);
 		assertThat(cutoffCaptor.getValue()).isBetween(before, after);
+	}
+
+	@Test
+	void shouldCountFailureWhenCleanupFails() {
+		// given
+		MemberRepository memberRepository = mock(MemberRepository.class);
+		SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+		PendingTermsMemberCleanupScheduler scheduler =
+			new PendingTermsMemberCleanupScheduler(memberRepository, 14, meterRegistry);
+		ReflectionTestUtils.invokeMethod(scheduler, "initCounters");
+
+		given(memberRepository.deleteByStatusAndTermsAgreedAtIsNullAndPrivacyAgreedAtIsNullAndCreatedAtBefore(
+			any(), any())).willThrow(new RuntimeException("boom"));
+
+		// when
+		scheduler.deleteExpiredPendingTermsMembers();
+
+		// then
+		assertThat(meterRegistry.counter("async.task.failures",
+			"task", "member", "action", "DELETE").count()).isEqualTo(1.0);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
@@ -103,6 +103,7 @@ public class JwtTokenProviderTest {
 		// then
 		assertThat(payload.get(JwtKeys.Claims.MEMBER_STATUS)).isEqualTo(MemberStatus.PENDING_TERMS.name());
 		assertThat(payload.get(JwtKeys.Claims.TERMS_AGREED)).isEqualTo(false);
+		assertThat(provider.getClaim(token, JwtKeys.Claims.MEMBER_STATUS)).isEqualTo(MemberStatus.PENDING_TERMS.name());
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/sofa/linkiving/global/security/jwt/JwtTokenProviderTest.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import javax.crypto.SecretKey;
 
@@ -19,6 +20,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
 import com.sofa.linkiving.domain.member.enums.Role;
 import com.sofa.linkiving.infra.redis.RedisKeyRegistry;
 import com.sofa.linkiving.infra.redis.RedisService;
@@ -79,6 +83,26 @@ public class JwtTokenProviderTest {
 
 		boolean valid = provider.validateAccessToken(token);
 		assertThat(valid).isTrue();
+	}
+
+	@Test
+	void shouldCreateAccessTokenWithTermsClaims() throws Exception {
+		// given
+		JwtTokenProvider provider = createProvider(mock(RedisService.class), null);
+		Member member = Member.builder()
+			.email("pending@test.com")
+			.password("password")
+			.status(MemberStatus.PENDING_TERMS)
+			.build();
+
+		// when
+		String token = provider.createAccessToken(member);
+		String payloadJson = new String(Base64.getUrlDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8);
+		Map<String, Object> payload = new ObjectMapper().readValue(payloadJson, Map.class);
+
+		// then
+		assertThat(payload.get(JwtKeys.Claims.MEMBER_STATUS)).isEqualTo(MemberStatus.PENDING_TERMS.name());
+		assertThat(payload.get(JwtKeys.Claims.TERMS_AGREED)).isEqualTo(false);
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/security/config/StompHandlerTest.java
+++ b/src/test/java/com/sofa/linkiving/security/config/StompHandlerTest.java
@@ -1,0 +1,49 @@
+package com.sofa.linkiving.security.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import com.sofa.linkiving.domain.member.enums.MemberStatus;
+import com.sofa.linkiving.security.jwt.JwtKeys;
+import com.sofa.linkiving.security.jwt.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class StompHandlerTest {
+
+	@Mock
+	JwtTokenProvider jwtTokenProvider;
+
+	@Test
+	void shouldBlockPendingTermsMemberOnConnect() {
+		// given
+		String token = "access-token";
+		StompHandler stompHandler = new StompHandler(jwtTokenProvider);
+		Message<byte[]> message = connectMessage(token);
+
+		given(jwtTokenProvider.validateAccessToken(token)).willReturn(true);
+		given(jwtTokenProvider.getClaim(token, JwtKeys.Claims.MEMBER_STATUS))
+			.willReturn(MemberStatus.PENDING_TERMS.name());
+
+		// when & then
+		assertThatThrownBy(() -> stompHandler.preSend(message, mock()))
+			.isInstanceOf(MessagingException.class);
+
+		verify(jwtTokenProvider, never()).getAuthentication(token);
+	}
+
+	private Message<byte[]> connectMessage(String token) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+		accessor.setNativeHeader(JwtKeys.Headers.AUTHORIZATION, JwtKeys.Headers.BEARER_PREFIX + token);
+		return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+	}
+}


### PR DESCRIPTION
## 관련이슈
- Close #282

## 요약
- OAuth 최초 가입 회원을 `PENDING_TERMS` 상태로 생성하고 약관 동의 전 `/terms`로 리다이렉트합니다.
- 약관/개인정보 동의 API(`POST /v1/member/terms-agreement`)를 추가하고, 동의 완료 시 `ACTIVE` 전환 및 토큰 재발급을 처리합니다.
- access token에 `memberStatus`, `termsAgreed` 클레임을 추가했습니다.
- 약관 동의 대기 회원은 약관 동의, 토큰 재발급, 로그아웃 외 일반 API 접근 시 403으로 차단합니다.
- refresh token 재발급 시에도 회원 상태를 조회해 access token을 생성하도록 변경했습니다.
- 약관 동의 없이 14일이 지난 `PENDING_TERMS` 회원을 매일 04시에 자동 삭제하는 스케줄러를 추가했습니다.

## 설정
- `app.oauth2.terms-redirect-url`: 약관 동의 페이지 리다이렉트 URL
- `app.member.current-terms-version`: 현재 유효한 약관 버전. 약관 개정 시 함께 갱신 필요
- `app.member.current-privacy-version`: 현재 유효한 개인정보 처리방침 버전. 개인정보 처리방침 개정 시 함께 갱신 필요
- `app.member.pending-terms-retention-days`: 약관 대기 회원 보관 일수, 기본 14
- `app.member.pending-terms-cleanup-cron`: 약관 대기 회원 정리 cron, 기본 `0 0 4 * * *`

```yaml
app:
  oauth2:
    terms-redirect-url: https://linkiving.com/terms
  member:
    current-terms-version: "2026-08-03"
    current-privacy-version: "2026-08-03"
    pending-terms-retention-days: 14
    pending-terms-cleanup-cron: "0 0 4 * * *"
```

## 배포 주의
- 운영 배포 전에 회원 약관 동의 상태 및 동의 이력 저장을 위한 DB 스키마 반영이 필요합니다.
- 기존 회원은 약관 동의 완료 상태로 유지되도록 데이터 반영이 필요합니다.
- 기존 회원은 `status`가 없더라도 `ACTIVE`로 취급되도록 방어 로직을 추가했습니다.

## 테스트
- `./gradlew.bat compileJava compileTestJava` 통과
- `./gradlew.bat checkstyleMain checkstyleTest` 통과
- `./gradlew.bat test --tests "com.sofa.linkiving.domain.member.entity.MemberTest" --tests "com.sofa.linkiving.domain.member.service.MemberServiceTest" --tests "com.sofa.linkiving.domain.member.service.PendingTermsMemberCleanupSchedulerTest" --tests "com.sofa.linkiving.domain.auth.service.AuthServiceTest" --tests "com.sofa.linkiving.global.security.jwt.JwtTokenProviderTest"` 통과
