### PR TITLE
[Analytics] 요약 완료 서버 이벤트 발화 (#274)

### DIFF
--- a/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
@@ -25,7 +25,7 @@ public class SummaryAnalyticsPublisher {
 		long startedAtNanos
 	) {
 		Map<String, Object> params = new HashMap<>();
-		params.put("bookmark_id", linkId);
+		params.put("link_id", linkId);
 		params.put("is_error", isError);
 		params.put("latency_ms", elapsedMillis(startedAtNanos));
 

--- a/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
@@ -24,17 +24,12 @@ public class SummaryAnalyticsPublisher {
 		boolean isError,
 		long startedAtNanos
 	) {
-		if (analyticsContext == null || analyticsContext.clientId() == null || analyticsContext.clientId().isBlank()) {
-			return;
-		}
-
 		Map<String, Object> params = new HashMap<>();
 		params.put("bookmark_id", linkId);
 		params.put("is_error", isError);
 		params.put("latency_ms", elapsedMillis(startedAtNanos));
 
-		String userId = memberId == null ? null : String.valueOf(memberId);
-		ga4Publisher.publish(analyticsContext.clientId(), userId, new Ga4Event("summary_complete", params));
+		ga4Publisher.publish(analyticsContext, memberId, new Ga4Event("summary_complete", params));
 	}
 
 	private long elapsedMillis(long startedAtNanos) {

--- a/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisher.java
@@ -1,0 +1,43 @@
+package com.sofa.linkiving.domain.link.analytics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
+import com.sofa.linkiving.global.analytics.Ga4Event;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SummaryAnalyticsPublisher {
+
+	private final Ga4Publisher ga4Publisher;
+
+	public void publishComplete(
+		AnalyticsContext analyticsContext,
+		Long memberId,
+		Long linkId,
+		boolean isError,
+		long startedAtNanos
+	) {
+		if (analyticsContext == null || analyticsContext.clientId() == null || analyticsContext.clientId().isBlank()) {
+			return;
+		}
+
+		Map<String, Object> params = new HashMap<>();
+		params.put("bookmark_id", linkId);
+		params.put("is_error", isError);
+		params.put("latency_ms", elapsedMillis(startedAtNanos));
+
+		String userId = memberId == null ? null : String.valueOf(memberId);
+		ga4Publisher.publish(analyticsContext.clientId(), userId, new Ga4Event("summary_complete", params));
+	}
+
+	private long elapsedMillis(long startedAtNanos) {
+		return (System.nanoTime() - startedAtNanos) / 1_000_000;
+	}
+}

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkCreatedEvent.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkCreatedEvent.java
@@ -2,16 +2,25 @@ package com.sofa.linkiving.domain.link.event;
 
 import java.util.Map;
 
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
+
 /**
  * 링크 생성 완료 이벤트
  * 트랜잭션 커밋 이후 발행되는 이벤트
  */
 public record LinkCreatedEvent(
 	Long linkId,
+	Long memberId,
 	String email,
-	Map<String, String> logContext
+	Map<String, String> logContext,
+	AnalyticsContext analyticsContext,
+	long summaryStartedAtNanos
 ) {
 	public LinkCreatedEvent(Long linkId, String email) {
-		this(linkId, email, Map.of());
+		this(linkId, null, email, Map.of(), AnalyticsContext.of(null, null), System.nanoTime());
+	}
+
+	public LinkCreatedEvent(Long linkId, Long memberId, String email, Map<String, String> logContext) {
+		this(linkId, memberId, email, logContext, AnalyticsContext.of(null, null), System.nanoTime());
 	}
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/event/LinkEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisher;
 import com.sofa.linkiving.domain.link.dto.response.SummaryStatusRes;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
@@ -37,6 +38,7 @@ public class LinkEventListener {
 	private final ApplicationEventPublisher eventPublisher;
 	private final SummaryWorkerFacade summaryWorkerFacade;
 	private final ObjectProvider<LinkEventListener> selfProvider;
+	private final SummaryAnalyticsPublisher summaryAnalyticsPublisher;
 	private final MeterRegistry meterRegistry;
 	private Counter enqueueFailureCounter;
 
@@ -73,7 +75,12 @@ public class LinkEventListener {
 		backoff = @Backoff(delay = 1000)
 	)
 	public void addToQueueWithRetry(LinkCreatedEvent event) {
-		summaryQueue.addToQueue(event.linkId());
+		summaryQueue.addToQueue(
+			event.linkId(),
+			event.memberId(),
+			event.analyticsContext(),
+			event.summaryStartedAtNanos()
+		);
 	}
 
 	/**
@@ -91,6 +98,13 @@ public class LinkEventListener {
 				event.email(),
 				SummaryStatusRes.failed(event.linkId(), "요약 대기열 등록에 실패했습니다.")
 			));
+			summaryAnalyticsPublisher.publishComplete(
+				event.analyticsContext(),
+				event.memberId(),
+				event.linkId(),
+				true,
+				event.summaryStartedAtNanos()
+			);
 			// TODO: 관리자 알림, 슬랙 발송 또는 실패 큐 적재 등 후속 처리
 		}
 	}

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -67,7 +67,14 @@ public class LinkFacade {
 			String storedImageUrl = processImageUpload(imageUrl);
 			Link link = linkService.createLink(member, url, title, memo, storedImageUrl);
 
-			eventPublisher.publishEvent(new LinkCreatedEvent(link.getId(), member.getEmail(), LogContext.snapshot()));
+			eventPublisher.publishEvent(new LinkCreatedEvent(
+				link.getId(),
+				member.getId(),
+				member.getEmail(),
+				LogContext.snapshot(),
+				analyticsContext,
+				System.nanoTime()
+			));
 			eventPublisher.publishEvent(LinkSyncEvent.createEvent(link));
 			publishLinkSaveSuccess(member, analyticsContext, link);
 
@@ -245,7 +252,7 @@ public class LinkFacade {
 
 	public void retrySummary(Long id, Member member) {
 		linkService.resetSummaryStatusForRetry(id, member);
-		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getEmail(), LogContext.snapshot()));
+		eventPublisher.publishEvent(new LinkCreatedEvent(id, member.getId(), member.getEmail(), LogContext.snapshot()));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/facade/LinkFacade.java
@@ -212,11 +212,7 @@ public class LinkFacade {
 
 	private void publishLinkEvent(Member member, AnalyticsContext analyticsContext, String eventName,
 		Map<String, Object> params) {
-		if (analyticsContext == null || analyticsContext.clientId() == null || analyticsContext.clientId().isBlank()) {
-			return;
-		}
-		String userId = member.getId() == null ? null : String.valueOf(member.getId());
-		ga4Publisher.publish(analyticsContext.clientId(), userId, new Ga4Event(eventName, params));
+		ga4Publisher.publish(analyticsContext, member.getId(), new Ga4Event(eventName, params));
 	}
 
 	private String analyticsSource(AnalyticsContext analyticsContext) {

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryQueue.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
 import com.sofa.linkiving.global.logging.LogContext;
 
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +21,11 @@ public class SummaryQueue {
 	 * 요약 대기 큐에 링크 ID 추가
 	 */
 	public void addToQueue(Long linkId) {
-		summaryQueue.offer(new SummaryTask(linkId, LogContext.snapshot()));
+		addToQueue(linkId, null, AnalyticsContext.of(null, null), System.nanoTime());
+	}
+
+	public void addToQueue(Long linkId, Long memberId, AnalyticsContext analyticsContext, long startedAtNanos) {
+		summaryQueue.offer(new SummaryTask(linkId, memberId, analyticsContext, startedAtNanos, LogContext.snapshot()));
 		log.debug("Link added to summary queue - linkId={}", linkId);
 	}
 

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryTask.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryTask.java
@@ -2,8 +2,13 @@ package com.sofa.linkiving.domain.link.worker;
 
 import java.util.Map;
 
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
+
 public record SummaryTask(
 	Long linkId,
+	Long memberId,
+	AnalyticsContext analyticsContext,
+	long startedAtNanos,
 	Map<String, String> logContext
 ) {
 }

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -10,6 +10,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 import com.sofa.linkiving.domain.link.ai.SummaryClient;
+import com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisher;
 import com.sofa.linkiving.domain.link.config.SummaryWorkerProperties;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.dto.response.SummaryRes;
@@ -47,6 +48,7 @@ public class SummaryWorker {
 	private final ObjectProvider<SummaryWorker> selfProvider;
 	private final MeterRegistry meterRegistry;
 	private final SummaryDeadLetterService summaryDeadLetterService;
+	private final SummaryAnalyticsPublisher summaryAnalyticsPublisher;
 	private Counter generateFailureCounter;
 	private volatile boolean running = true;
 	private Thread workerThread;
@@ -102,7 +104,8 @@ public class SummaryWorker {
 			try {
 				Link link = summaryWorkerFacade.getLinkWithMember(linkId);
 				userEmail = link.getMember().getEmail();
-				LogContext.put(LogContext.MEMBER_ID, link.getMember().getId());
+				Long memberId = link.getMember().getId();
+				LogContext.put(LogContext.MEMBER_ID, memberId);
 
 				if (link.getSummaryStatus() != SummaryStatus.PENDING) {
 					log.warn("Link is not in PENDING state. Skipping summary generation - linkId: {}", linkId);
@@ -123,6 +126,13 @@ public class SummaryWorker {
 						userEmail,
 						SummaryStatusRes.completed(linkId, SummaryRes.from(summary))
 					));
+					summaryAnalyticsPublisher.publishComplete(
+						task.analyticsContext(),
+						firstNonNull(task.memberId(), memberId),
+						linkId,
+						false,
+						task.startedAtNanos()
+					);
 				}
 			} catch (Exception e) {
 				generateFailureCounter.increment();
@@ -148,8 +158,19 @@ public class SummaryWorker {
 						)
 					));
 				}
+				summaryAnalyticsPublisher.publishComplete(
+					task.analyticsContext(),
+					firstNonNull(task.memberId(), failedMemberId),
+					linkId,
+					true,
+					task.startedAtNanos()
+				);
 			}
 		}
+	}
+
+	private Long firstNonNull(Long value, Long fallback) {
+		return value == null ? fallback : value;
 	}
 
 	private void recordDeadLetter(Long linkId, Long memberId, Throwable cause) {

--- a/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
+++ b/src/main/java/com/sofa/linkiving/domain/link/worker/SummaryWorker.java
@@ -133,6 +133,14 @@ public class SummaryWorker {
 						false,
 						task.startedAtNanos()
 					);
+				} else {
+					summaryAnalyticsPublisher.publishComplete(
+						task.analyticsContext(),
+						firstNonNull(task.memberId(), memberId),
+						linkId,
+						true,
+						task.startedAtNanos()
+					);
 				}
 			} catch (Exception e) {
 				generateFailureCounter.increment();

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Publisher.java
@@ -2,6 +2,7 @@ package com.sofa.linkiving.global.analytics;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +15,19 @@ public class Ga4Publisher {
 	private final Ga4MeasurementProtocolClient client;
 
 	@Async("analyticsTaskExecutor")
+	public void publish(AnalyticsContext context, Long memberId, Ga4Event event) {
+		if (context == null || !StringUtils.hasText(context.clientId())) {
+			return;
+		}
+		doSend(context.clientId(), memberId == null ? null : String.valueOf(memberId), event);
+	}
+
+	@Async("analyticsTaskExecutor")
 	public void publish(String clientId, String userId, Ga4Event event) {
+		doSend(clientId, userId, event);
+	}
+
+	private void doSend(String clientId, String userId, Ga4Event event) {
 		try {
 			client.send(clientId, userId, event);
 		} catch (Exception exception) {

--- a/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
@@ -30,7 +30,7 @@ class SummaryAnalyticsPublisherTest {
 
 		Ga4Event event = eventCaptor.getValue();
 		assertThat(event.name()).isEqualTo("summary_complete");
-		assertThat(event.params()).containsEntry("bookmark_id", 1L);
+		assertThat(event.params()).containsEntry("link_id", 1L);
 		assertThat(event.params()).containsEntry("is_error", false);
 		assertThat(event.params()).containsKey("latency_ms");
 	}

--- a/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
@@ -19,13 +19,14 @@ class SummaryAnalyticsPublisherTest {
 	void publishComplete_publishesSummaryCompleteEvent() {
 		// given
 		long startedAtNanos = System.nanoTime() - 1_000_000;
+		AnalyticsContext context = AnalyticsContext.of("123.456", "web");
 
 		// when
-		publisher.publishComplete(AnalyticsContext.of("123.456", "web"), 100L, 1L, false, startedAtNanos);
+		publisher.publishComplete(context, 100L, 1L, false, startedAtNanos);
 
 		// then
 		ArgumentCaptor<Ga4Event> eventCaptor = ArgumentCaptor.forClass(Ga4Event.class);
-		verify(ga4Publisher).publish(eq("123.456"), eq("100"), eventCaptor.capture());
+		verify(ga4Publisher).publish(eq(context), eq(100L), eventCaptor.capture());
 
 		Ga4Event event = eventCaptor.getValue();
 		assertThat(event.name()).isEqualTo("summary_complete");
@@ -35,11 +36,11 @@ class SummaryAnalyticsPublisherTest {
 	}
 
 	@Test
-	void publishComplete_skipsWhenClientIdIsMissing() {
+	void publishComplete_delegatesClientIdPolicyToGa4Publisher() {
 		// when
 		publisher.publishComplete(AnalyticsContext.of(null, "web"), 100L, 1L, true, System.nanoTime());
 
 		// then
-		then(ga4Publisher).shouldHaveNoInteractions();
+		then(ga4Publisher).should().publish(any(AnalyticsContext.class), eq(100L), any(Ga4Event.class));
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/analytics/SummaryAnalyticsPublisherTest.java
@@ -1,0 +1,45 @@
+package com.sofa.linkiving.domain.link.analytics;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
+import com.sofa.linkiving.global.analytics.Ga4Event;
+import com.sofa.linkiving.global.analytics.Ga4Publisher;
+
+class SummaryAnalyticsPublisherTest {
+
+	private final Ga4Publisher ga4Publisher = mock(Ga4Publisher.class);
+	private final SummaryAnalyticsPublisher publisher = new SummaryAnalyticsPublisher(ga4Publisher);
+
+	@Test
+	void publishComplete_publishesSummaryCompleteEvent() {
+		// given
+		long startedAtNanos = System.nanoTime() - 1_000_000;
+
+		// when
+		publisher.publishComplete(AnalyticsContext.of("123.456", "web"), 100L, 1L, false, startedAtNanos);
+
+		// then
+		ArgumentCaptor<Ga4Event> eventCaptor = ArgumentCaptor.forClass(Ga4Event.class);
+		verify(ga4Publisher).publish(eq("123.456"), eq("100"), eventCaptor.capture());
+
+		Ga4Event event = eventCaptor.getValue();
+		assertThat(event.name()).isEqualTo("summary_complete");
+		assertThat(event.params()).containsEntry("bookmark_id", 1L);
+		assertThat(event.params()).containsEntry("is_error", false);
+		assertThat(event.params()).containsKey("latency_ms");
+	}
+
+	@Test
+	void publishComplete_skipsWhenClientIdIsMissing() {
+		// when
+		publisher.publishComplete(AnalyticsContext.of(null, "web"), 100L, 1L, true, System.nanoTime());
+
+		// then
+		then(ga4Publisher).shouldHaveNoInteractions();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/event/LinkEventListenerTest.java
@@ -21,6 +21,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisher;
 import com.sofa.linkiving.domain.link.enums.SummaryStatus;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.link.worker.SummaryQueue;
@@ -41,10 +42,12 @@ class LinkEventListenerTest {
 	private LinkEventListener linkEventListener;
 	@Autowired
 	private SummaryQueue summaryQueue;
+	@Autowired
+	private SummaryAnalyticsPublisher summaryAnalyticsPublisher;
 
 	@BeforeEach
 	void setUp() {
-		reset(summaryQueue, eventPublisher, summaryWorkerFacade);
+		reset(summaryQueue, eventPublisher, summaryWorkerFacade, summaryAnalyticsPublisher);
 	}
 
 	@Test
@@ -52,13 +55,13 @@ class LinkEventListenerTest {
 	void shouldAddQueueAndNotRetry_WhenFirstAttemptSucceeds() {
 		// given
 		LinkCreatedEvent event = new LinkCreatedEvent(1L, "test@test.com");
-		doNothing().when(summaryQueue).addToQueue(anyLong());
+		doNothing().when(summaryQueue).addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when
 		linkEventListener.handleLinkCreated(event);
 
 		// then
-		verify(summaryQueue, times(1)).addToQueue(1L);
+		verify(summaryQueue, times(1)).addToQueue(eq(1L), isNull(), any(), anyLong());
 	}
 
 	@Test
@@ -68,7 +71,7 @@ class LinkEventListenerTest {
 		LinkCreatedEvent event1 = new LinkCreatedEvent(10L, "test1@test.com");
 		LinkCreatedEvent event2 = new LinkCreatedEvent(20L, "test2@test.com");
 		LinkCreatedEvent event3 = new LinkCreatedEvent(30L, "test3@test.com");
-		doNothing().when(summaryQueue).addToQueue(anyLong());
+		doNothing().when(summaryQueue).addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when
 		linkEventListener.handleLinkCreated(event1);
@@ -76,9 +79,9 @@ class LinkEventListenerTest {
 		linkEventListener.handleLinkCreated(event3);
 
 		// then
-		verify(summaryQueue, times(1)).addToQueue(10L);
-		verify(summaryQueue, times(1)).addToQueue(20L);
-		verify(summaryQueue, times(1)).addToQueue(30L);
+		verify(summaryQueue, times(1)).addToQueue(eq(10L), isNull(), any(), anyLong());
+		verify(summaryQueue, times(1)).addToQueue(eq(20L), isNull(), any(), anyLong());
+		verify(summaryQueue, times(1)).addToQueue(eq(30L), isNull(), any(), anyLong());
 	}
 
 	@Test
@@ -90,13 +93,13 @@ class LinkEventListenerTest {
 		doThrow(new RuntimeException("Queue full"))
 			.doThrow(new RuntimeException("Queue full"))
 			.doNothing()
-			.when(summaryQueue).addToQueue(anyLong());
+			.when(summaryQueue).addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when & then
 		assertThatCode(() -> linkEventListener.handleLinkCreated(event))
 			.doesNotThrowAnyException();
 
-		verify(summaryQueue, times(3)).addToQueue(1L);
+		verify(summaryQueue, times(3)).addToQueue(eq(1L), isNull(), any(), anyLong());
 	}
 
 	@Test
@@ -105,13 +108,14 @@ class LinkEventListenerTest {
 		// given
 		LinkCreatedEvent event = new LinkCreatedEvent(2L, "test2@test.com");
 
-		doThrow(new RuntimeException("Queue full")).when(summaryQueue).addToQueue(anyLong());
+		doThrow(new RuntimeException("Queue full")).when(summaryQueue)
+			.addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when
 		linkEventListener.handleLinkCreated(event);
 
 		// then
-		verify(summaryQueue, times(3)).addToQueue(2L);
+		verify(summaryQueue, times(3)).addToQueue(eq(2L), isNull(), any(), anyLong());
 	}
 
 	@Test
@@ -119,7 +123,8 @@ class LinkEventListenerTest {
 	void shouldPublishFailedEvent_WhenAllRetriesFail() {
 		// given
 		LinkCreatedEvent event = new LinkCreatedEvent(2L, "fail@test.com");
-		doThrow(new RuntimeException("Queue Full")).when(summaryQueue).addToQueue(anyLong());
+		doThrow(new RuntimeException("Queue Full")).when(summaryQueue)
+			.addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when
 		linkEventListener.handleLinkCreated(event);
@@ -142,9 +147,10 @@ class LinkEventListenerTest {
 
 		// Facade를 통한 DB 상태 업데이트가 호출되었는지 검증
 		verify(summaryWorkerFacade, times(1)).updateSummaryStatus(2L, SummaryStatus.FAILED);
+		verify(summaryAnalyticsPublisher, times(1)).publishComplete(any(), isNull(), eq(2L), eq(true), anyLong());
 
 		// 큐 적재 로직이 3회 시도되었는지 검증
-		verify(summaryQueue, times(3)).addToQueue(2L);
+		verify(summaryQueue, times(3)).addToQueue(eq(2L), isNull(), any(), anyLong());
 	}
 
 	@Test
@@ -152,7 +158,7 @@ class LinkEventListenerTest {
 	void shouldPublishPendingEvent_WhenQueueSucceeds() {
 		// given
 		LinkCreatedEvent event = new LinkCreatedEvent(1L, "test@test.com");
-		doNothing().when(summaryQueue).addToQueue(anyLong());
+		doNothing().when(summaryQueue).addToQueue(anyLong(), any(), any(), anyLong());
 
 		// when
 		linkEventListener.handleLinkCreated(event);
@@ -191,11 +197,18 @@ class LinkEventListenerTest {
 		}
 
 		@Bean
+		public SummaryAnalyticsPublisher summaryAnalyticsPublisher() {
+			return mock(SummaryAnalyticsPublisher.class);
+		}
+
+		@Bean
 		public LinkEventListener linkEventListener(SummaryQueue summaryQueue,
 			ApplicationEventPublisher eventPublisher,
 			SummaryWorkerFacade summaryWorkerFacade,
+			SummaryAnalyticsPublisher summaryAnalyticsPublisher,
 			ObjectProvider<LinkEventListener> selfProvider) {
 			return new LinkEventListener(summaryQueue, eventPublisher, summaryWorkerFacade, selfProvider,
+				summaryAnalyticsPublisher,
 				meterRegistry());
 		}
 	}

--- a/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/facade/LinkFacadeTest.java
@@ -228,6 +228,8 @@ class LinkFacadeTest {
 			.email("test@example.com")
 			.password("password")
 			.build();
+		ReflectionTestUtils.setField(member, "id", 1L);
+		AnalyticsContext analyticsContext = AnalyticsContext.of("1234567890.1234567890", "web");
 
 		given(imageUploader.uploadFromUrl(originalImageUrl)).willReturn(storedImageUrl);
 
@@ -243,8 +245,7 @@ class LinkFacadeTest {
 		given(linkService.createLink(member, url, title, memo, storedImageUrl)).willReturn(savedLink);
 
 		// when
-		LinkRes result = linkFacade.createLink(member, url, title, memo, originalImageUrl,
-			AnalyticsContext.of("1234567890.1234567890", "web"));
+		LinkRes result = linkFacade.createLink(member, url, title, memo, originalImageUrl, analyticsContext);
 
 		// then
 		assertThat(result).isNotNull();
@@ -252,8 +253,14 @@ class LinkFacadeTest {
 
 		verify(imageUploader, times(1)).uploadFromUrl(originalImageUrl);
 		verify(linkService, times(1)).createLink(member, url, title, memo, storedImageUrl);
-		verify(eventPublisher, times(1)).publishEvent(any(LinkCreatedEvent.class));
-		verify(ga4Publisher, times(2)).publish(eq("1234567890.1234567890"), any(), any());
+		ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+		verify(eventPublisher, times(2)).publishEvent(eventCaptor.capture());
+
+		LinkCreatedEvent createdEvent = (LinkCreatedEvent)eventCaptor.getAllValues().get(0);
+		assertThat(createdEvent.analyticsContext()).isEqualTo(analyticsContext);
+		assertThat(createdEvent.memberId()).isEqualTo(1L);
+
+		verify(ga4Publisher, times(2)).publish(eq(analyticsContext), eq(1L), any(Ga4Event.class));
 	}
 
 	@Test
@@ -284,7 +291,7 @@ class LinkFacadeTest {
 
 		verify(eventPublisher, never()).publishEvent(any());
 		ArgumentCaptor<Ga4Event> captor = ArgumentCaptor.forClass(Ga4Event.class);
-		verify(ga4Publisher, times(2)).publish(eq("1234567890.1234567890"), eq("1"), captor.capture());
+		verify(ga4Publisher, times(2)).publish(eq(context), eq(1L), captor.capture());
 		assertThat(captor.getAllValues()).extracting(Ga4Event::name)
 			.containsExactly("link_save_attempt", "link_save_fail");
 		assertThat(captor.getAllValues().get(1).params())

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
 
 import com.sofa.linkiving.domain.link.ai.SummaryClient;
+import com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisher;
 import com.sofa.linkiving.domain.link.config.SummaryWorkerProperties;
 import com.sofa.linkiving.domain.link.dto.response.RagInitialSummaryRes;
 import com.sofa.linkiving.domain.link.entity.Link;
@@ -30,6 +31,7 @@ import com.sofa.linkiving.domain.link.event.SummaryStatusEvent;
 import com.sofa.linkiving.domain.link.facade.SummaryWorkerFacade;
 import com.sofa.linkiving.domain.link.service.SummaryDeadLetterService;
 import com.sofa.linkiving.domain.member.entity.Member;
+import com.sofa.linkiving.global.analytics.AnalyticsContext;
 import com.sofa.linkiving.infra.feign.EmptyAiResponseException;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -51,6 +53,8 @@ class SummaryWorkerTest {
 	private ObjectProvider<SummaryWorker> selfProvider;
 	@Mock
 	private SummaryDeadLetterService summaryDeadLetterService;
+	@Mock
+	private SummaryAnalyticsPublisher summaryAnalyticsPublisher;
 
 	private SummaryWorker summaryWorker;
 	private Link mockLink;
@@ -60,7 +64,7 @@ class SummaryWorkerTest {
 		MeterRegistry meterRegistry = new SimpleMeterRegistry();
 		SummaryWorkerProperties properties = new SummaryWorkerProperties(Duration.ofMillis(10));
 		summaryWorker = new SummaryWorker(summaryQueue, properties, summaryWorkerFacade, summaryClient, eventPublisher,
-			selfProvider, meterRegistry, summaryDeadLetterService);
+			selfProvider, meterRegistry, summaryDeadLetterService, summaryAnalyticsPublisher);
 
 		mockLink = mock(Link.class);
 		Member mockMember = mock(Member.class);
@@ -80,7 +84,7 @@ class SummaryWorkerTest {
 	}
 
 	private SummaryTask task(Long linkId) {
-		return new SummaryTask(linkId, Map.of());
+		return new SummaryTask(linkId, 100L, AnalyticsContext.of("123.456", "web"), System.nanoTime(), Map.of());
 	}
 
 	@Test
@@ -275,6 +279,13 @@ class SummaryWorkerTest {
 
 		assertThat(captor.getAllValues().get(0).response().status()).isEqualTo(SummaryStatus.PROCESSING);
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.COMPLETED);
+		verify(summaryAnalyticsPublisher, timeout(1000)).publishComplete(
+			any(AnalyticsContext.class),
+			eq(100L),
+			eq(1L),
+			eq(false),
+			anyLong()
+		);
 	}
 
 	@Test
@@ -301,6 +312,13 @@ class SummaryWorkerTest {
 		assertThat(captor.getAllValues().get(1).response().status()).isEqualTo(SummaryStatus.FAILED);
 		assertThat(captor.getAllValues().get(1).response().errorMessage())
 			.contains("Retry limit exceeded");
+		verify(summaryAnalyticsPublisher, timeout(1000)).publishComplete(
+			any(AnalyticsContext.class),
+			eq(100L),
+			eq(1L),
+			eq(true),
+			anyLong()
+		);
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/link/worker/SummaryWorkerTest.java
@@ -375,6 +375,13 @@ class SummaryWorkerTest {
 		verify(eventPublisher, after(300).times(1)).publishEvent(captor.capture());
 
 		assertThat(captor.getValue().response().status()).isEqualTo(SummaryStatus.PROCESSING);
+		verify(summaryAnalyticsPublisher, timeout(1000)).publishComplete(
+			any(AnalyticsContext.class),
+			eq(100L),
+			eq(1L),
+			eq(true),
+			anyLong()
+		);
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4PublisherTest.java
@@ -21,6 +21,30 @@ class Ga4PublisherTest {
 	}
 
 	@Test
+	void publishWithContext_sendsEventToMeasurementProtocolClient() {
+		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
+		Ga4Publisher publisher = new Ga4Publisher(client);
+		Ga4Event event = new Ga4Event("link_save_success", Map.of("source", "web"));
+
+		publisher.publish(AnalyticsContext.of("123.456", "web"), 42L, event);
+
+		verify(client).send("123.456", "42", event);
+	}
+
+	@Test
+	void publishWithContext_skipsWhenClientIdIsMissing() {
+		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
+		Ga4Publisher publisher = new Ga4Publisher(client);
+		Ga4Event event = new Ga4Event("link_save_success", Map.of("source", "web"));
+
+		publisher.publish(AnalyticsContext.of(null, "web"), 42L, event);
+		publisher.publish(AnalyticsContext.of(" ", "web"), 42L, event);
+		publisher.publish(null, 42L, event);
+
+		then(client).shouldHaveNoInteractions();
+	}
+
+	@Test
 	void publish_doesNotPropagateClientException() {
 		Ga4MeasurementProtocolClient client = mock(Ga4MeasurementProtocolClient.class);
 		Ga4Event event = new Ga4Event("link_save_success", Map.of("source", "web"));


### PR DESCRIPTION
﻿## 관련이슈
- Close #274

## 요약
- 요약 생성 성공/실패 시 GA4 Measurement Protocol로 summary_complete 이벤트를 발화합니다.
- 링크 저장 요청의 AnalyticsContext를 LinkCreatedEvent, SummaryQueue, SummaryTask로 전달해 비동기 요약 완료 시점에도 client_id를 사용할 수 있게 했습니다.
- summary_complete 파라미터로 link_id, is_error, latency_ms를 포함합니다.
- 큐 등록 최종 실패와 실제 워커 처리 실패는 is_error=true로 계측합니다.
- 단, 배포/재시작으로 인한 인메모리 큐 유실분과 PENDING이 아닌 상태로 worker가 skip한 경우는 계측에서 제외합니다.
- GA client_id가 없는 재시도/호환 경로는 기존 publisher 정책대로 전송을 skip합니다.

## 검증
- ./gradlew test --tests com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisherTest --tests com.sofa.linkiving.domain.link.worker.SummaryWorkerTest --tests com.sofa.linkiving.domain.link.event.LinkEventListenerTest
- ./gradlew test --tests com.sofa.linkiving.domain.link.analytics.SummaryAnalyticsPublisherTest --tests com.sofa.linkiving.domain.link.worker.SummaryWorkerTest --tests com.sofa.linkiving.domain.link.event.LinkEventListenerTest --tests com.sofa.linkiving.domain.chat.service.RagChatServiceTest

## 참고
- 이 PR은 #274 요약 완료 이벤트 발화를 다룹니다.
- 수동 요약 재시도는 client_id가 없으므로 중복 GA 이벤트를 만들지 않습니다.

