### PR TITLE
Grafana 포트 충돌로 인한 릴리즈 배포 실패 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release tag (for example, v0.1.1)'
         required: true
         type: string
+      allow_existing_tag_mismatch:
+        description: 'Allow deploying the selected ref with an existing tag that points to another commit'
+        required: true
+        default: false
+        type: boolean
   push:
     tags:
       - 'v*'
@@ -35,6 +40,7 @@ jobs:
         shell: bash
         env:
           TAG_NAME: ${{ env.RELEASE_TAG }}
+          ALLOW_EXISTING_TAG_MISMATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_existing_tag_mismatch || false }}
         run: |
           if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid release tag: ${TAG_NAME}" >&2
@@ -46,8 +52,12 @@ jobs:
             HEAD_SHA="$(git rev-parse HEAD)"
 
             if [ "${TAG_SHA}" != "${HEAD_SHA}" ]; then
-              echo "Tag ${TAG_NAME} already points to ${TAG_SHA}, not ${HEAD_SHA}." >&2
-              exit 1
+              if [ "${ALLOW_EXISTING_TAG_MISMATCH}" != "true" ]; then
+                echo "Tag ${TAG_NAME} already points to ${TAG_SHA}, not ${HEAD_SHA}." >&2
+                exit 1
+              fi
+
+              echo "::warning::Deploying ${HEAD_SHA} with existing tag ${TAG_NAME}, which points to ${TAG_SHA}."
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,24 @@
 name: 🚀 Linkiving backend release deploy 🚀
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (for example, v0.1.1)'
+        required: true
+        type: string
   push:
     tags:
       - 'v*'
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
 permissions:
   contents: write
 
 concurrency:
-  group: backend-release-${{ github.ref }}
+  group: backend-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -19,11 +28,33 @@ jobs:
     steps:
       - name: ✨ Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: ✅ Validate release tag
+        shell: bash
+        env:
+          TAG_NAME: ${{ env.RELEASE_TAG }}
+        run: |
+          if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: ${TAG_NAME}" >&2
+            exit 1
+          fi
+
+          if git rev-parse --verify --quiet "refs/tags/${TAG_NAME}" >/dev/null; then
+            TAG_SHA="$(git rev-list -n 1 "${TAG_NAME}")"
+            HEAD_SHA="$(git rev-parse HEAD)"
+
+            if [ "${TAG_SHA}" != "${HEAD_SHA}" ]; then
+              echo "Tag ${TAG_NAME} already points to ${TAG_SHA}, not ${HEAD_SHA}." >&2
+              exit 1
+            fi
+          fi
 
       - name: 📝 Build release notes from changelog
         shell: bash
         env:
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ env.RELEASE_TAG }}
         run: |
           awk -v tag="${TAG_NAME}" '
             $0 == "## [" tag "]" || $0 ~ "^## \\[" tag "\\] " {
@@ -104,7 +135,7 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ github.ref_name }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:${{ env.RELEASE_TAG }}
             ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
 
   backend-docker-pull-and-run:
@@ -135,7 +166,7 @@ jobs:
 
       - name: ✨ 배포 스크립트 실행
         env:
-          IMAGE_TAG: ${{ github.ref_name }}
+          IMAGE_TAG: ${{ env.RELEASE_TAG }}
         run: |
           chmod +x deploy.sh
           ./deploy.sh
@@ -154,4 +185,5 @@ jobs:
       - name: 📝 Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           body_path: release-notes.md

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
     ports:
-      - '3001:3000'
+      - '127.0.0.1:13001:3000'
     restart: unless-stopped
     networks:
       - app-network


### PR DESCRIPTION
## 관련 이슈

- close #290

## PR 설명

### 배경

운영 서버는 Nginx가 외부 HTTPS `3001` 포트를 소유하고 Grafana 요청을 `127.0.0.1:13001`로 프록시합니다.

기존 Compose는 Grafana 컨테이너를 호스트 `3001`에 직접 바인딩해, 릴리즈 배포 중 Grafana 재생성 단계에서 Nginx와 충돌했습니다.

```text
failed to bind host port 0.0.0.0:3001/tcp: address already in use
```

이 오류로 `backend-docker-pull-and-run` job이 중단되고 후속 애플리케이션 Blue-Green 배포와 GitHub Release 생성이 실행되지 않았습니다.

### 변경 사항

- Grafana 호스트 포트를 `3001`에서 `127.0.0.1:13001`로 변경했습니다.
- Grafana를 loopback 인터페이스에만 바인딩해 Nginx 프록시를 통해서만 접근하도록 맞췄습니다.
- Nginx의 외부 HTTPS `3001` 포트와 Docker의 직접 바인딩 충돌을 제거했습니다.
- 릴리즈 워크플로에 필수 `release_tag` 입력을 받는 `workflow_dispatch` 트리거를 추가했습니다.
- 태그 푸시와 수동 실행 모두 이미지 빌드·운영 배포·GitHub Release에서 동일한 릴리즈 태그를 사용합니다.
- 기존 태그가 현재 실행 커밋과 다르면 빌드 전에 중단해 기존 태그와 Docker 이미지가 서로 다른 코드를 가리키는 상황을 방지합니다.
- 긴급 재배포가 필요한 경우 수동 실행에서 `allow_existing_tag_mismatch`를 명시적으로 활성화하면 기존 Git 태그를 이동하지 않고 선택한 ref를 같은 Docker 태그로 다시 빌드·배포할 수 있습니다. 기본값은 비활성화입니다.

```yaml
ports:
  - "127.0.0.1:13001:3000"
```

### 검증

- `git diff --check` 통과
- 운영 서버의 Docker Compose CLI로 수정본 렌더링 확인
  - `host_ip: 127.0.0.1`
  - `published: "13001"`
  - `target: 3000`
- 현재 운영 Nginx 설정이 `listen 3001 ssl` 및 `proxy_pass http://127.0.0.1:13001`을 사용하는 것을 확인
- 릴리즈 워크플로 YAML 파싱 확인
- `v0.1.1` 형식의 수동 입력 허용 및 다른 커밋을 가리키는 기존 `v0.1.0` 입력 차단 확인
- `allow_existing_tag_mismatch=false`에서는 기존 태그 불일치 차단, `true`에서는 경고 후 허용 확인

### 영향

- 애플리케이션 코드와 데이터에는 영향이 없습니다.
- 릴리즈 배포 시 Grafana 재생성이 Nginx 포트와 충돌하지 않습니다.
- Grafana 외부 접근 경로는 기존과 동일하게 Nginx의 HTTPS `3001`을 사용합니다.
- Actions UI에서 브랜치와 `release_tag`를 지정해 릴리즈 워크플로를 수동 실행할 수 있습니다.
- 기존 태그 재사용 옵션을 켜면 Git 태그의 커밋과 실제 배포 이미지의 커밋이 달라질 수 있으므로 긴급 복구 용도로만 사용합니다.

### 별도 이슈

- 애플리케이션 이미지의 `curl` 미설치로 Docker healthcheck가 실패하는 문제는 #289에서 별도로 추적합니다.
