### PR TITLE
Docker healthcheck 실행 안정화

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '8080:8080'
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health-check" ]
+      test: [ "CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/health-check" ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -39,7 +39,7 @@ services:
     ports:
       - '8081:8080'
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health-check" ]
+      test: [ "CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/health-check" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/local-bundle/docker-compose.yml
+++ b/docker/local-bundle/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       - TZ=Asia/Seoul
     ports:
       - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/health-check"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## 관련 이슈

- close #289

## PR 설명

운영 healthcheck가 컨테이너 내부의 `curl`에 의존해 이미지 구성에 따라 애플리케이션이 정상이어도 `unhealthy`로 판정될 수 있는 문제를 수정합니다.

- Corretto Alpine 이미지에 기본 포함된 BusyBox `wget`으로 운영 healthcheck를 실행합니다.
- `/health-check`가 HEAD 요청을 허용하지 않으므로 `--spider` 대신 GET 응답 본문을 `/dev/null`로 버리는 방식을 사용합니다.
- local-bundle 앱에도 동일한 healthcheck를 추가해 PostgreSQL·Redis뿐 아니라 애플리케이션 상태도 확인합니다.
- 별도 네트워크 도구 패키지를 이미지에 추가하지 않습니다.