### PR TITLE
Nginx 트래픽 전환 검증 및 롤백 안전성 개선

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [ main ]
 
 jobs:
+  deploy-script-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: ✨ Checkout repository
+        uses: actions/checkout@v5
+
+      - name: 🔍 ShellCheck 설치
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes shellcheck
+
+      - name: 🔍 배포 스크립트 정적 분석
+        run: shellcheck deploy.sh
+
+      - name: 🧪 배포 스크립트 테스트
+        run: bash tests/deploy_test.sh
+
   ci:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: backend-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  group: backend-production-release
   cancel-in-progress: false
 
 jobs:
@@ -177,6 +177,8 @@ jobs:
       - name: ✨ 배포 스크립트 실행
         env:
           IMAGE_TAG: ${{ env.RELEASE_TAG }}
+          TRAFFIC_CHECK_URL: ${{ vars.TRAFFIC_CHECK_URL }}
+          TRAFFIC_CHECK_HOST: ${{ vars.TRAFFIC_CHECK_HOST }}
         run: |
           chmod +x deploy.sh
           ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,165 +4,389 @@
 
 set -euo pipefail
 
-echo "=== Blue-Green 배포 시작 ==="
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}"
 COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.yml"
 
 PROJECT="linkiving-core"
 DEPLOY_IMAGE_TAG="${IMAGE_TAG:-latest}"
+DEPLOY_LOCK_FILE="${DEPLOY_LOCK_FILE:-/var/lock/linkiving-core-deploy.lock}"
+NGINX_UPSTREAM_FILE="${NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/service-url.inc}"
+TRAFFIC_CHECK_URL="${TRAFFIC_CHECK_URL:-http://127.0.0.1/health-check}"
+TRAFFIC_CHECK_HOST="${TRAFFIC_CHECK_HOST:-}"
+TRAFFIC_CHECK_EXPECTED_BODY="${TRAFFIC_CHECK_EXPECTED_BODY:-OK}"
+TRAFFIC_CHECK_CONNECT_TIMEOUT="${TRAFFIC_CHECK_CONNECT_TIMEOUT:-5}"
+TRAFFIC_CHECK_MAX_TIME="${TRAFFIC_CHECK_MAX_TIME:-10}"
+TRAFFIC_SWITCH_DELAY_SECONDS="${TRAFFIC_SWITCH_DELAY_SECONDS:-5}"
+PREVIOUS_STOP_DELAY_SECONDS="${PREVIOUS_STOP_DELAY_SECONDS:-30}"
+HEALTH_CHECK_MAX_RETRY="${HEALTH_CHECK_MAX_RETRY:-30}"
+HEALTH_CHECK_RETRY_INTERVAL_SECONDS="${HEALTH_CHECK_RETRY_INTERVAL_SECONDS:-10}"
+
+NGINX_BACKUP_FILE=""
+CANDIDATE_COLOR=""
+ROLLBACK_REQUIRED=false
+DEPLOYMENT_COMMITTED=false
 
 compose() {
     sudo IMAGE_TAG="${DEPLOY_IMAGE_TAG}" docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" "$@"
 }
 
-# compose 파일 존재 확인
-if [ ! -f "${COMPOSE_FILE}" ]; then
-  echo "❌ Compose file not found: ${COMPOSE_FILE}"
-  echo "현재 위치: $(pwd)"
-  echo "스크립트 위치: ${SCRIPT_DIR}"
-  exit 1
-fi
+container_is_running() {
+    local color="$1"
+    [ -n "$(compose ps -q --status running "${color}")" ]
+}
 
-echo "✅ Using compose file: ${COMPOSE_FILE}"
-echo "✅ Using project name: ${PROJECT}"
-echo "✅ Using image tag: ${DEPLOY_IMAGE_TAG}"
+color_for_port() {
+    case "$1" in
+        8080) printf 'blue\n' ;;
+        8081) printf 'green\n' ;;
+        *) return 1 ;;
+    esac
+}
 
-echo "이미지 업데이트 중..."
-if ! compose pull; then
-    echo "❌ Docker 이미지 pull 실패! GitHub Actions 빌드를 확인해주세요."
-    echo "❌ 배포를 중단합니다."
-    exit 1
-fi
-echo "✅ 새로운 이미지가 성공적으로 pull되었습니다."
+port_for_color() {
+    case "$1" in
+        blue) printf '8080\n' ;;
+        green) printf '8081\n' ;;
+        *) return 1 ;;
+    esac
+}
 
-# Prometheus & Grafana 실행 (설정 변경 시 자동 반영)
-echo "모니터링 서비스 시작 중..."
-compose up -d prometheus grafana alertmanager
-echo "✅ Prometheus & Grafana & Alertmanager가 시작되었습니다."
+opposite_color() {
+    case "$1" in
+        blue) printf 'green\n' ;;
+        green) printf 'blue\n' ;;
+        *) return 1 ;;
+    esac
+}
 
-echo "사용하지 않는 이미지 정리 중..."
-sudo docker image prune -f
+read_nginx_upstream_port() {
+    local file="$1"
+    local ports
 
-# 현재 활성화된 컨테이너 확인
-EXIST_BLUE=$(sudo docker ps --filter "name=blue" --filter "status=running" -q)
+    ports=$(awk '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*(set[[:space:]]+\$[[:alnum:]_]+[[:space:]]+https?:\/\/|proxy_pass[[:space:]]+https?:\/\/|server[[:space:]]+)127\.0\.0\.1:808[01]([\/$;[:space:]]|$)/ {
+            if (match($0, /127\.0\.0\.1:808[01]/)) {
+                print substr($0, RSTART + 10, 4)
+            }
+        }
+    ' "${file}")
 
-if [ -z "$EXIST_BLUE" ]; then
-    echo "BLUE 컨테이너 실행"
-    compose up -d blue
-    BEFORE_COLOR="green"
-    AFTER_COLOR="blue"
-    BEFORE_PORT=8081
-    AFTER_PORT=8080
-else
-    echo "GREEN 컨테이너 실행"
-    compose up -d green
-    BEFORE_COLOR="blue"
-    AFTER_COLOR="green"
-    BEFORE_PORT=8080
-    AFTER_PORT=8081
-fi
-
-echo "${AFTER_COLOR} server up (port:${AFTER_PORT})"
-
-# 서버 응답 확인 (헬스체크)
-echo "서버 헬스체크 시작..."
-HEALTH_CHECK_COUNT=0
-MAX_RETRY=30  # 최대 5분 대기 (10초 * 30회)
-
-HEALTH_URL="http://127.0.0.1:${AFTER_PORT}/health-check"
-
-while [ $HEALTH_CHECK_COUNT -lt $MAX_RETRY ]; do
-    HEALTH_CHECK_COUNT=$((HEALTH_CHECK_COUNT + 1))
-    echo "서버 응답 확인중 (${HEALTH_CHECK_COUNT}/${MAX_RETRY})"
-
-    # curl로 헬스체크 (타임아웃 5초, 실패 시 failed 문자열로 치환)
-    UP=$(curl -s --connect-timeout 5 --max-time 10 "${HEALTH_URL}" 2>/dev/null || echo "failed")
-
-    if echo "${UP}" | grep -q "OK"; then
-        echo "✅ 서버가 정상적으로 구동되었습니다!"
-        break
-    else
-        echo "⏳ 서버 응답 대기 중... (${UP})"
-        sleep 10
-    fi
-done
-
-# 헬스체크 실패 시 롤백
-if [ $HEALTH_CHECK_COUNT -eq $MAX_RETRY ]; then
-    echo "❌ 서버가 정상적으로 구동되지 않았습니다. 롤백을 시작합니다."
-    compose stop "${AFTER_COLOR}"
-    compose rm -f "${AFTER_COLOR}"
-
-    # 이전 컨테이너가 있다면 다시 시작
-    if [ "${BEFORE_COLOR}" != "" ]; then
-        echo "이전 ${BEFORE_COLOR} 컨테이너를 다시 시작합니다."
-        compose up -d "${BEFORE_COLOR}"
+    if [ "$(printf '%s\n' "${ports}" | awk 'NF { count++ } END { print count + 0 }')" -ne 1 ]; then
+        return 1
     fi
 
-    echo "❌ 배포 실패 - 롤백 완료"
-    exit 1
-fi
+    printf '%s\n' "${ports}"
+}
 
-# Nginx 설정 파일 백업
-if [ -f /etc/nginx/conf.d/service-url.inc ]; then
-    sudo cp /etc/nginx/conf.d/service-url.inc /etc/nginx/conf.d/service-url.inc.backup
-fi
+http_check() {
+    local url="$1"
+    local expected_body="$2"
+    local hostname="${3:-}"
+    local request_url="${url}"
+    local response trimmed scheme remainder authority connect_host connect_port path
+    local curl_args=(
+        --fail
+        --silent
+        --show-error
+        --connect-timeout "${TRAFFIC_CHECK_CONNECT_TIMEOUT}"
+        --max-time "${TRAFFIC_CHECK_MAX_TIME}"
+    )
 
-# Nginx 설정 업데이트
-echo "Nginx 설정 업데이트 중..."
-if [ -f /etc/nginx/conf.d/service-url.inc ]; then
-    sudo sed -i "s/${BEFORE_PORT}/${AFTER_PORT}/g" /etc/nginx/conf.d/service-url.inc
+    if [ -n "${hostname}" ]; then
+        if [[ ! "${url}" =~ ^https?:// ]] || [[ "${hostname}" == *:* ]] || [[ "${hostname}" == */* ]]; then
+            echo "TRAFFIC_CHECK_HOST에는 포트나 경로가 없는 호스트명을 설정해야 합니다." >&2
+            return 1
+        fi
 
-    # Nginx 설정 문법 검사
-    if sudo nginx -t; then
-        sudo nginx -s reload
-        echo "✅ Nginx 설정이 성공적으로 업데이트되었습니다."
+        scheme="${url%%://*}"
+        remainder="${url#*://}"
+        authority="${remainder%%/*}"
+        connect_host="${authority%%:*}"
+        if [[ "${authority}" == *:* ]]; then
+            connect_port="${authority##*:}"
+        elif [ "${scheme}" = "https" ]; then
+            connect_port=443
+        else
+            connect_port=80
+        fi
+
+        if [[ "${remainder}" == */* ]]; then
+            path="/${remainder#*/}"
+        else
+            path=""
+        fi
+
+        request_url="${scheme}://${hostname}:${connect_port}${path}"
+        curl_args+=(--resolve "${hostname}:${connect_port}:${connect_host}")
+    fi
+
+    if ! response=$(curl "${curl_args[@]}" "${request_url}" 2>&1); then
+        echo "  curl: ${response:-응답 없음}" >&2
+        return 1
+    fi
+
+    trimmed=$(printf '%s' "${response}" | awk '{ sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); printf "%s", $0 }')
+    [[ "${trimmed}" == "${expected_body}" ]]
+}
+
+remove_candidate_container() {
+    local color="$1"
+
+    compose stop "${color}" >/dev/null 2>&1 || true
+    compose rm -f "${color}" >/dev/null 2>&1 || true
+}
+
+create_nginx_backup() {
+    local directory basename
+    directory=$(dirname "${NGINX_UPSTREAM_FILE}")
+    basename=$(basename "${NGINX_UPSTREAM_FILE}")
+    NGINX_BACKUP_FILE=$(sudo mktemp "${directory}/.${basename}.backup.XXXXXX")
+    sudo cp --preserve=all "${NGINX_UPSTREAM_FILE}" "${NGINX_BACKUP_FILE}"
+}
+
+replace_nginx_file_atomically() {
+    local source="$1"
+    local directory basename temporary
+    directory=$(dirname "${NGINX_UPSTREAM_FILE}")
+    basename=$(basename "${NGINX_UPSTREAM_FILE}")
+    temporary=$(sudo mktemp "${directory}/.${basename}.new.XXXXXX")
+
+    if ! sudo cp --preserve=all "${source}" "${temporary}"; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+
+    if ! sudo mv -f "${temporary}" "${NGINX_UPSTREAM_FILE}"; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+}
+
+write_nginx_upstream_port() {
+    local expected_port="$1"
+    local target_port="$2"
+    local current_port directory basename temporary
+
+    current_port=$(read_nginx_upstream_port "${NGINX_UPSTREAM_FILE}") || return 1
+    [ "${current_port}" = "${expected_port}" ] || return 1
+    [ "${current_port}" != "${target_port}" ] || return 0
+
+    directory=$(dirname "${NGINX_UPSTREAM_FILE}")
+    basename=$(basename "${NGINX_UPSTREAM_FILE}")
+    temporary=$(sudo mktemp "${directory}/.${basename}.new.XXXXXX")
+    if ! sudo cp --preserve=all "${NGINX_UPSTREAM_FILE}" "${temporary}"; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+
+    if ! sudo sed -i -E "/^[[:space:]]*#/! {/^[[:space:]]*(set[[:space:]]+\\\$[[:alnum:]_]+[[:space:]]+https?:\\/\\/|proxy_pass[[:space:]]+https?:\\/\\/|server[[:space:]]+)127\\.0\\.0\\.1:${expected_port}([\\/$;[:space:]]|$)/ s/127\\.0\\.0\\.1:${expected_port}/127.0.0.1:${target_port}/}" "${temporary}"; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+
+    if [ "$(read_nginx_upstream_port "${temporary}")" != "${target_port}" ]; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+
+    if ! sudo mv -f "${temporary}" "${NGINX_UPSTREAM_FILE}"; then
+        sudo rm -f "${temporary}" || true
+        return 1
+    fi
+}
+
+restore_nginx_upstream() {
+    if [ -z "${NGINX_BACKUP_FILE}" ] || ! sudo test -f "${NGINX_BACKUP_FILE}"; then
+        echo "❌ 복원할 Nginx upstream 백업이 없습니다."
+        return 1
+    fi
+
+    if ! replace_nginx_file_atomically "${NGINX_BACKUP_FILE}"; then
+        echo "❌ Nginx upstream 백업 복원에 실패했습니다."
+        return 1
+    fi
+
+    if ! sudo nginx -t || ! sudo nginx -s reload; then
+        echo "❌ 복원된 Nginx 설정 적용에 실패했습니다."
+        return 1
+    fi
+
+    echo "✅ Nginx upstream을 이전 설정으로 복원했습니다."
+}
+
+cleanup_nginx_backup() {
+    if [ -z "${NGINX_BACKUP_FILE}" ]; then
+        return 0
+    fi
+
+    if sudo rm -f "${NGINX_BACKUP_FILE}"; then
+        NGINX_BACKUP_FILE=""
+        return 0
+    fi
+
+    echo "⚠️ Nginx 백업 삭제에 실패했습니다: ${NGINX_BACKUP_FILE}" >&2
+    return 1
+}
+
+handle_exit() {
+    local status="$1"
+    trap - EXIT INT TERM
+
+    if [ "${status}" -ne 0 ] && [ "${ROLLBACK_REQUIRED}" = true ] && [ "${DEPLOYMENT_COMMITTED}" != true ]; then
+        echo "❌ 완료 전 배포가 중단되어 Nginx upstream을 롤백합니다."
+        if restore_nginx_upstream; then
+            [ -z "${CANDIDATE_COLOR}" ] || remove_candidate_container "${CANDIDATE_COLOR}"
+            cleanup_nginx_backup || true
+        else
+            echo "❌ 자동 롤백에 실패했습니다. 이전/후보 컨테이너와 백업 ${NGINX_BACKUP_FILE}을 유지합니다."
+        fi
+    elif [ "${status}" -ne 0 ] && [ -n "${CANDIDATE_COLOR}" ] && [ "${DEPLOYMENT_COMMITTED}" != true ]; then
+        remove_candidate_container "${CANDIDATE_COLOR}"
+    fi
+
+    if [ "${DEPLOYMENT_COMMITTED}" = true ] && [ -n "${NGINX_BACKUP_FILE}" ]; then
+        cleanup_nginx_backup || true
+    elif [ "${status}" -ne 0 ] && [ -n "${NGINX_BACKUP_FILE}" ]; then
+        echo "⚠️ 장애 확인을 위해 Nginx 백업을 보존합니다: ${NGINX_BACKUP_FILE}"
+    fi
+
+    exit "${status}"
+}
+
+acquire_deploy_lock() {
+    sudo touch "${DEPLOY_LOCK_FILE}"
+    sudo chown "$(id -u):$(id -g)" "${DEPLOY_LOCK_FILE}"
+    exec 9>"${DEPLOY_LOCK_FILE}"
+    if ! flock -n 9; then
+        echo "❌ 다른 배포가 진행 중입니다."
+        return 1
+    fi
+}
+
+select_deployment_plan() {
+    local upstream_port="$1"
+    local active_running="$2"
+    local standby_running="$3"
+    local active_color standby_color standby_port
+    active_color=$(color_for_port "${upstream_port}") || return 1
+    standby_color=$(opposite_color "${active_color}")
+    standby_port=$(port_for_color "${standby_color}")
+
+    if [ "${active_running}" = true ]; then
+        printf '%s %s %s %s %s\n' "${active_color}" "${upstream_port}" "${standby_color}" "${standby_port}" true
+    elif [ "${standby_running}" = false ]; then
+        printf '%s %s %s %s %s\n' none "${upstream_port}" "${active_color}" "${upstream_port}" false
     else
-        echo "❌ Nginx 설정 오류. 백업 파일로 복원합니다."
-        sudo cp /etc/nginx/conf.d/service-url.inc.backup /etc/nginx/conf.d/service-url.inc
-        sudo nginx -s reload
+        return 1
+    fi
+}
+
+main() {
+    trap 'handle_exit $?' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    acquire_deploy_lock
+    echo "=== Blue-Green 배포 시작 ==="
+
+    if [ ! -f "${COMPOSE_FILE}" ]; then
+        echo "❌ Compose file not found: ${COMPOSE_FILE}"
         exit 1
     fi
-else
-    echo "⚠️  Nginx 설정 파일을 찾을 수 없습니다: /etc/nginx/conf.d/service-url.inc"
+    if [ ! -f "${NGINX_UPSTREAM_FILE}" ]; then
+        echo "❌ Nginx 설정 파일을 찾을 수 없습니다: ${NGINX_UPSTREAM_FILE}"
+        exit 1
+    fi
+
+    local upstream_port active_color standby_color active_running standby_running
+    local before_color before_port after_color after_port switch_required server_healthy count health_url
+    upstream_port=$(read_nginx_upstream_port "${NGINX_UPSTREAM_FILE}") || {
+        echo "❌ Nginx upstream 대상은 지원되는 directive에 정확히 하나만 있어야 합니다."
+        exit 1
+    }
+    active_color=$(color_for_port "${upstream_port}")
+    standby_color=$(opposite_color "${active_color}")
+    active_running=false
+    standby_running=false
+    container_is_running "${active_color}" && active_running=true
+    container_is_running "${standby_color}" && standby_running=true
+
+    if ! read -r before_color before_port after_color after_port switch_required \
+        < <(select_deployment_plan "${upstream_port}" "${active_running}" "${standby_running}"); then
+        echo "❌ Nginx upstream(${active_color})과 실행 중인 컨테이너(${standby_color})가 일치하지 않습니다."
+        echo "❌ 자동 변경 없이 배포를 중단합니다."
+        exit 1
+    fi
+    if [ "${before_color}" = none ]; then
+        echo "실행 중인 컨테이너가 없어 현재 upstream 슬롯을 복구합니다."
+        before_color=""
+    fi
+
+    CANDIDATE_COLOR="${after_color}"
+
+    echo "Docker 이미지 pull..."
+    compose pull
+    sudo docker image prune -f
+
+    echo "${after_color} 컨테이너 실행"
+    compose up -d "${after_color}"
+    echo "${after_color} server up (port:${after_port})"
+
+    server_healthy=false
+    count=0
+    health_url="http://127.0.0.1:${after_port}/health-check"
+    echo "서버 헬스체크 시작..."
+    while [ "${count}" -lt "${HEALTH_CHECK_MAX_RETRY}" ]; do
+        count=$((count + 1))
+        echo "서버 응답 확인중 (${count}/${HEALTH_CHECK_MAX_RETRY})"
+        if http_check "${health_url}" "OK"; then
+            server_healthy=true
+            break
+        fi
+        sleep "${HEALTH_CHECK_RETRY_INTERVAL_SECONDS}"
+    done
+    if [ "${server_healthy}" != true ]; then
+        echo "❌ 후보 서버가 정상적으로 구동되지 않았습니다."
+        exit 1
+    fi
+
+    create_nginx_backup
+    ROLLBACK_REQUIRED=true
+
+    if [ "${switch_required}" = true ]; then
+        echo "Nginx upstream을 ${before_port}에서 ${after_port}로 전환합니다."
+        write_nginx_upstream_port "${before_port}" "${after_port}"
+        sudo nginx -t
+        sudo nginx -s reload
+    else
+        echo "Nginx upstream은 이미 복구 슬롯(${after_port})을 가리키고 있습니다."
+    fi
+
+    sleep "${TRAFFIC_SWITCH_DELAY_SECONDS}"
+    if ! http_check "${TRAFFIC_CHECK_URL}" "${TRAFFIC_CHECK_EXPECTED_BODY}" "${TRAFFIC_CHECK_HOST}"; then
+        echo "❌ Nginx 경유 트래픽 확인에 실패했습니다."
+        exit 1
+    fi
+
+    if [ -n "${before_color}" ]; then
+        echo "이전 컨테이너 종료 전 ${PREVIOUS_STOP_DELAY_SECONDS}초 대기..."
+        sleep "${PREVIOUS_STOP_DELAY_SECONDS}"
+        DEPLOYMENT_COMMITTED=true
+        ROLLBACK_REQUIRED=false
+        compose stop "${before_color}" >/dev/null 2>&1 || true
+        compose rm -f "${before_color}" >/dev/null 2>&1 || true
+    else
+        DEPLOYMENT_COMMITTED=true
+        ROLLBACK_REQUIRED=false
+    fi
+
+    echo "✅ Active Container: ${after_color} (Port: ${after_port})"
+    sudo docker ps --filter "name=blue" --filter "name=green" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+    echo "=== 배포 완료 ==="
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
 fi
-
-# 트래픽 전환 확인 (Nginx 기준 헬스체크)
-echo "트래픽 전환 확인 중..."
-sleep 5
-NGINX_CHECK=$(curl -s --connect-timeout 5 http://127.0.0.1/health-check 2>/dev/null || echo "failed")
-if echo "${NGINX_CHECK}" | grep -q "OK"; then
-    echo "✅ 트래픽이 성공적으로 전환되었습니다."
-else
-    echo "⚠️ 트래픽 전환 확인 실패. 수동으로 확인해주세요."
-fi
-
-# 이전 컨테이너 종료 (안전하게)
-if [ "${BEFORE_COLOR}" != "" ]; then
-    echo "${BEFORE_COLOR} server down (port:${BEFORE_PORT})"
-
-    # 잠시 대기 후 이전 컨테이너 종료
-    echo "이전 컨테이너 종료 전 30초 대기..."
-    sleep 30
-
-    compose stop "${BEFORE_COLOR}" 2>/dev/null || true
-    compose rm -f "${BEFORE_COLOR}" 2>/dev/null || true
-    echo "✅ 이전 ${BEFORE_COLOR} 컨테이너가 종료되었습니다."
-fi
-
-# 배포 완료
-echo ""
-echo "🎉 Deploy Completed!!"
-echo "✅ Active Container: ${AFTER_COLOR} (Port: ${AFTER_PORT})"
-echo "✅ Deployment Time: $(date)"
-echo ""
-
-# 최종 상태 확인
-echo "=== 배포 후 상태 확인 ==="
-echo "실행 중인 컨테이너:"
-sudo docker ps --filter "name=blue" --filter "name=green" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-
-echo ""
-echo "=== 배포 완료 ==="

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../deploy.sh
+source "${ROOT_DIR}/deploy.sh"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+    [ "${expected}" = "${actual}" ] || fail "${message} (expected=${expected}, actual=${actual})"
+}
+
+test_http_check_requires_exact_trimmed_body() {
+    curl() { printf ' \nOK\n '; }
+    http_check "http://health.test/health-check" "OK" || fail "공백을 제거한 정확한 응답은 성공해야 합니다."
+
+    curl() { printf 'NOT_OK'; }
+    if http_check "http://health.test/health-check" "OK"; then
+        fail "부분 문자열이 포함된 응답은 성공하면 안 됩니다."
+    fi
+}
+
+test_http_check_uses_resolve_for_https_sni() {
+    curl() {
+        [[ " $* " == *" --resolve service.example.com:443:127.0.0.1 "* ]] || return 1
+        [[ " $* " == *" https://service.example.com:443/health-check "* ]] || return 1
+        printf 'OK'
+    }
+
+    http_check "https://127.0.0.1/health-check" "OK" "service.example.com" \
+        || fail "HTTPS 검증은 실제 호스트명과 --resolve로 SNI를 맞춰야 합니다."
+}
+
+test_http_check_rejects_curl_failure() {
+    local error_output
+    curl() {
+        echo "connection refused" >&2
+        return 7
+    }
+    if error_output=$(http_check "http://health.test/health-check" "OK" 2>&1); then
+        fail "curl HTTP 오류를 성공으로 처리하면 안 됩니다."
+    fi
+    [[ "${error_output}" == *"curl: connection refused"* ]] \
+        || fail "curl 실패 원인이 배포 로그에 남아야 합니다."
+}
+
+test_read_nginx_upstream_port_requires_one_target() {
+    local directory file
+    directory=$(mktemp -d)
+    file="${directory}/service-url.inc"
+
+    printf 'set $service_url http://127.0.0.1:8080;\n' > "${file}"
+    assert_equals 8080 "$(read_nginx_upstream_port "${file}")" "set directive의 포트를 읽어야 합니다."
+
+    printf 'proxy_pass http://127.0.0.1:8081;\n' > "${file}"
+    assert_equals 8081 "$(read_nginx_upstream_port "${file}")" "proxy_pass directive의 포트를 읽어야 합니다."
+
+    printf 'proxy_pass http://127.0.0.1:8080/;\n' > "${file}"
+    assert_equals 8080 "$(read_nginx_upstream_port "${file}")" \
+        "trailing slash가 있는 proxy_pass의 포트를 읽어야 합니다."
+
+    printf 'proxy_pass http://127.0.0.1:8081$request_uri;\n' > "${file}"
+    assert_equals 8081 "$(read_nginx_upstream_port "${file}")" \
+        "request_uri 변수가 있는 proxy_pass의 포트를 읽어야 합니다."
+
+    printf '# proxy_pass http://127.0.0.1:8080;\nserver 127.0.0.1:8081;\n' > "${file}"
+    assert_equals 8081 "$(read_nginx_upstream_port "${file}")" "주석은 upstream으로 세면 안 됩니다."
+
+    printf 'server 127.0.0.1:8080;\nserver 127.0.0.1:8081;\n' > "${file}"
+    if read_nginx_upstream_port "${file}" >/dev/null; then
+        fail "여러 upstream 대상이 있으면 중단해야 합니다."
+    fi
+
+    rm -rf "${directory}"
+}
+
+test_deployment_plan_follows_nginx() {
+    assert_equals "blue 8080 green 8081 true" \
+        "$(select_deployment_plan 8080 true true)" \
+        "양쪽 슬롯이 실행 중이어도 Nginx의 반대편을 후보로 선택해야 합니다."
+    assert_equals "green 8081 blue 8080 true" \
+        "$(select_deployment_plan 8081 true true)" \
+        "green upstream이면 blue를 후보로 선택해야 합니다."
+}
+
+test_deployment_plan_recovers_current_upstream() {
+    assert_equals "none 8081 green 8081 false" \
+        "$(select_deployment_plan 8081 false false)" \
+        "첫 배포/복구에서는 이미 설정된 upstream 슬롯을 기동해야 합니다."
+}
+
+test_deployment_plan_rejects_mismatch() {
+    if select_deployment_plan 8080 false true >/dev/null; then
+        fail "Nginx active는 멈추고 반대 슬롯만 실행 중인 불일치를 자동 전환하면 안 됩니다."
+    fi
+}
+
+test_interrupted_switch_rolls_back() {
+    local directory marker
+    directory=$(mktemp -d)
+    marker="${directory}/marker"
+    if (
+        ROLLBACK_REQUIRED=true
+        DEPLOYMENT_COMMITTED=false
+        NGINX_BACKUP_FILE="${directory}/backup"
+        CANDIDATE_COLOR=green
+        touch "${NGINX_BACKUP_FILE}"
+        sudo() { "$@"; }
+        restore_nginx_upstream() { printf 'restored\n' >> "${marker}"; }
+        remove_candidate_container() { printf 'removed:%s\n' "$1" >> "${marker}"; }
+        handle_exit 143
+    ); then
+        fail "중단된 배포는 실패 상태를 유지해야 합니다."
+    fi
+    assert_equals $'restored\nremoved:green' "$(<"${marker}")" \
+        "트래픽 전환 후 중단되면 upstream 복원 후 후보를 제거해야 합니다."
+    [ ! -e "${directory}/backup" ] || fail "롤백 성공 후 Nginx 백업을 삭제해야 합니다."
+    rm -rf "${directory}"
+}
+
+test_interrupted_switch_preserves_backup_when_restore_fails() {
+    local directory marker backup
+    directory=$(mktemp -d)
+    marker="${directory}/marker"
+    backup="${directory}/backup"
+    touch "${backup}"
+    if (
+        ROLLBACK_REQUIRED=true
+        DEPLOYMENT_COMMITTED=false
+        NGINX_BACKUP_FILE="${backup}"
+        CANDIDATE_COLOR=green
+        sudo() { "$@"; }
+        restore_nginx_upstream() { return 1; }
+        remove_candidate_container() { printf 'removed\n' >> "${marker}"; }
+        handle_exit 1
+    ); then
+        fail "롤백 실패는 실패 상태를 유지해야 합니다."
+    fi
+    [ -e "${backup}" ] || fail "롤백 실패 시 복구용 Nginx 백업을 보존해야 합니다."
+    [ ! -e "${marker}" ] || fail "롤백 실패 시 후보 컨테이너를 자동 제거하면 안 됩니다."
+    rm -rf "${directory}"
+}
+
+test_committed_switch_does_not_roll_back() {
+    local directory marker
+    directory=$(mktemp -d)
+    marker="${directory}/marker"
+    if (
+        ROLLBACK_REQUIRED=false
+        DEPLOYMENT_COMMITTED=true
+        NGINX_BACKUP_FILE=""
+        CANDIDATE_COLOR=green
+        restore_nginx_upstream() { printf 'restored\n' >> "${marker}"; }
+        remove_candidate_container() { printf 'removed\n' >> "${marker}"; }
+        handle_exit 143
+    ); then
+        fail "중단 상태는 유지해야 합니다."
+    fi
+    [ ! -e "${marker}" ] || fail "커밋된 전환은 이전 upstream으로 되돌리면 안 됩니다."
+    rm -rf "${directory}"
+}
+
+test_http_check_requires_exact_trimmed_body
+test_http_check_uses_resolve_for_https_sni
+test_http_check_rejects_curl_failure
+test_read_nginx_upstream_port_requires_one_target
+test_deployment_plan_follows_nginx
+test_deployment_plan_recovers_current_upstream
+test_deployment_plan_rejects_mismatch
+test_interrupted_switch_rolls_back
+test_interrupted_switch_preserves_backup_when_restore_fails
+test_committed_switch_does_not_roll_back
+
+echo "deploy.sh tests passed"


### PR DESCRIPTION
## 관련 이슈

- close #292

## PR 설명

- Nginx upstream 포트를 기준으로 활성/후보 슬롯을 결정하고, 컨테이너 상태가 설정과 불일치하면 자동 변경 없이 배포를 중단합니다.
- 첫 배포와 장애 복구 시 upstream이 이미 후보 포트를 가리키는 경우 해당 슬롯을 정상적으로 기동합니다.
- GitHub Actions와 배포 호스트에 고정된 배포 잠금을 적용해 릴리즈 간 동시 실행을 방지합니다.
- upstream directive를 정확히 하나만 식별하고, 같은 디렉터리의 임시 파일을 통해 원본 메타데이터를 보존한 채 원자적으로 교체합니다.
- 트래픽 확인 응답을 공백 제거 후 정확히 비교하며, HTTPS 가상 호스트 검증 시 `curl --resolve`로 Host와 TLS SNI를 일치시킵니다.
- 트래픽 전환 후 오류나 종료 신호가 발생하면 upstream을 복원한 뒤 후보 컨테이너를 정리합니다. 복원에 실패한 경우 점검을 위해 양쪽 컨테이너와 백업을 유지합니다.

### 운영 설정

HTTPS loopback 검증이 필요한 환경에서는 Repository variables를 다음 형식으로 설정합니다.

```text
TRAFFIC_CHECK_URL=https://127.0.0.1/health-check
TRAFFIC_CHECK_HOST=service.example.com
```

`TRAFFIC_CHECK_HOST`에는 포트와 경로를 제외한 인증서의 호스트명을 입력합니다.