### PR TITLE
GA 질의 추적 정합성 및 DebugView 검증 지원

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - LANG=ko_KR.UTF-8
       - TZ=Asia/Seoul
       - AI_SERVER_URL=http://n8n-app:5678
+      - ANALYTICS_GA4_DEBUG_MODE=${ANALYTICS_GA4_DEBUG_MODE:-false}
     ports:
       - '8080:8080'
     healthcheck:
@@ -34,6 +35,7 @@ services:
       - LANG=ko_KR.UTF-8
       - TZ=Asia/Seoul
       - AI_SERVER_URL=http://n8n-app:5678
+      - ANALYTICS_GA4_DEBUG_MODE=${ANALYTICS_GA4_DEBUG_MODE:-false}
     ports:
       - '8081:8080'
     healthcheck:

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/MessageCommandService.java
@@ -25,11 +25,12 @@ public class MessageCommandService {
 		return messageRepository.save(message);
 	}
 
-	public Message saveUserMessage(Chat chat, String content) {
+	public Message saveUserMessage(Chat chat, String content, String queryId) {
 		Message message = Message.builder()
 			.chat(chat)
 			.type(Type.USER)
 			.content(content)
+			.queryId(queryId)
 			.build();
 
 		return messageRepository.save(message);

--- a/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
+++ b/src/main/java/com/sofa/linkiving/domain/chat/service/RagChatService.java
@@ -66,7 +66,7 @@ public class RagChatService {
 					publishQuerySubmit(member, clientId, queryId, linkCountAtQuery);
 				}
 
-				Message question = messageCommandService.saveUserMessage(chat, userMessage);
+				Message question = messageCommandService.saveUserMessage(chat, userMessage, queryId);
 				List<Message> history = messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(
 					question.getId(), chat);
 				Collections.reverse(history);

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClient.java
@@ -30,10 +30,14 @@ public class Ga4MeasurementProtocolClient {
 		}
 
 		Map<String, Object> payload = new HashMap<>();
+		Map<String, Object> eventParams = new HashMap<>(event.params());
+		if (properties.debugMode()) {
+			eventParams.put("debug_mode", true);
+		}
 		payload.put("client_id", clientId);
 		payload.put("events", List.of(Map.of(
 				"name", event.name(),
-				"params", event.params()
+				"params", eventParams
 		)));
 
 		if (userId != null && !userId.isBlank()) {

--- a/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
+++ b/src/main/java/com/sofa/linkiving/global/analytics/Ga4Properties.java
@@ -8,7 +8,8 @@ public record Ga4Properties(
 	boolean enabled,
 	String measurementId,
 	String apiSecret,
-	String endpoint
+	String endpoint,
+	boolean debugMode
 ) {
 	private static final String DEFAULT_ENDPOINT = "https://www.google-analytics.com";
 
@@ -24,7 +25,7 @@ public record Ga4Properties(
 
 	@Override
 	public String toString() {
-		return "Ga4Properties[enabled=%s, measurementId=%s, apiSecret=****, endpoint=%s]"
-			.formatted(enabled, measurementId, endpoint);
+		return "Ga4Properties[enabled=%s, measurementId=%s, apiSecret=****, endpoint=%s, debugMode=%s]"
+			.formatted(enabled, measurementId, endpoint, debugMode);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/MessageCommandServiceTest.java
@@ -62,12 +62,13 @@ public class MessageCommandServiceTest {
 		// given
 		Chat chat = mock(Chat.class);
 		String content = "유저 질문";
+		String queryId = "query-123";
 
 		// save 호출 시 입력된 객체를 그대로 반환하도록 설정
 		given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
 
 		// when
-		Message savedMessage = messageCommandService.saveUserMessage(chat, content);
+		Message savedMessage = messageCommandService.saveUserMessage(chat, content, queryId);
 
 		// then
 		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
@@ -77,6 +78,7 @@ public class MessageCommandServiceTest {
 		assertThat(captured.getChat()).isEqualTo(chat);
 		assertThat(captured.getContent()).isEqualTo(content);
 		assertThat(captured.getType()).isEqualTo(Type.USER);
+		assertThat(captured.getQueryId()).isEqualTo(queryId);
 	}
 
 	@Test

--- a/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
+++ b/src/test/java/com/sofa/linkiving/domain/chat/service/RagChatServiceTest.java
@@ -73,7 +73,7 @@ public class RagChatServiceTest {
 		// 2. 유저 메시지 저장
 		Message questionMsg = mock(Message.class);
 		given(questionMsg.getId()).willReturn(50L);
-		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+		given(messageCommandService.saveUserMessage(eq(chat), eq(userMessage), anyString())).willReturn(questionMsg);
 
 		// 3. 과거 대화 내역 조회
 		Message historyMsg = mock(Message.class);
@@ -118,7 +118,7 @@ public class RagChatServiceTest {
 		assertThat(result.links()).hasSize(1);
 
 		// 순서대로 호출되었는지 검증
-		verify(messageCommandService).saveUserMessage(chat, userMessage);
+		verify(messageCommandService).saveUserMessage(eq(chat), eq(userMessage), anyString());
 		verify(answerClient).generateAnswer(any(RagAnswerReq.class));
 		verify(linkQueryService).findAllByIdInWithSummary(eq(List.of(10L, 20L)), eq(member));
 		verify(messageCommandService).saveAiMessage(eq(chat), eq("AI 답변입니다."), anyString(), eq(List.of(link1)));
@@ -148,7 +148,7 @@ public class RagChatServiceTest {
 
 		Message questionMsg = mock(Message.class);
 		given(questionMsg.getId()).willReturn(50L);
-		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+		given(messageCommandService.saveUserMessage(eq(chat), eq(userMessage), anyString())).willReturn(questionMsg);
 
 		given(messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(anyLong(), any()))
 			.willReturn(Collections.emptyList());
@@ -172,7 +172,7 @@ public class RagChatServiceTest {
 
 		Message questionMsg = mock(Message.class);
 		given(questionMsg.getId()).willReturn(50L);
-		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+		given(messageCommandService.saveUserMessage(eq(chat), eq(userMessage), anyString())).willReturn(questionMsg);
 
 		given(messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(50L, chat))
 			.willReturn(Collections.emptyList());
@@ -221,6 +221,10 @@ public class RagChatServiceTest {
 		assertThat(complete.params()).containsEntry("top_similarity", 0.91);
 		assertThat(complete.params()).containsKey("latency_ms");
 		assertThat(complete.params().get("query_id")).isEqualTo(submit.params().get("query_id"));
+		verify(messageCommandService).saveUserMessage(eq(chat), eq(userMessage),
+			eq((String)submit.params().get("query_id")));
+		verify(messageCommandService).saveAiMessage(eq(chat), eq("AI answer"),
+			eq((String)submit.params().get("query_id")), eq(List.of(link1)));
 		assertThat(complete.params()).doesNotContainValue(userMessage);
 		assertThat(complete.params()).doesNotContainValue("AI answer");
 	}
@@ -234,7 +238,7 @@ public class RagChatServiceTest {
 
 		Message questionMsg = mock(Message.class);
 		given(questionMsg.getId()).willReturn(50L);
-		given(messageCommandService.saveUserMessage(chat, userMessage)).willReturn(questionMsg);
+		given(messageCommandService.saveUserMessage(eq(chat), eq(userMessage), anyString())).willReturn(questionMsg);
 
 		given(messageQueryService.findTop7ByChatIdAndIdLessThanOrderByIdDesc(anyLong(), any()))
 			.willReturn(Collections.emptyList());
@@ -260,6 +264,8 @@ public class RagChatServiceTest {
 		assertThat(complete.params()).containsEntry("error_type", "UNKNOWN");
 		assertThat(complete.params()).containsKey("latency_ms");
 		assertThat(complete.params().get("query_id")).isEqualTo(submit.params().get("query_id"));
+		verify(messageCommandService).saveUserMessage(eq(chat), eq(userMessage),
+			eq((String)submit.params().get("query_id")));
 		assertThat(complete.params()).doesNotContainValue(userMessage);
 	}
 }

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
@@ -1,5 +1,6 @@
 package com.sofa.linkiving.global.analytics;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.client.ExpectedCount.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4MeasurementProtocolClientTest.java
@@ -18,7 +18,7 @@ class Ga4MeasurementProtocolClientTest {
 	void send_postsMeasurementProtocolPayload() {
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null, false);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
 		server.expect(once(), requestTo(
@@ -29,6 +29,7 @@ class Ga4MeasurementProtocolClientTest {
 			.andExpect(jsonPath("$.user_id").value("42"))
 			.andExpect(jsonPath("$.events[0].name").value("link_save_success"))
 			.andExpect(jsonPath("$.events[0].params.source").value("web"))
+			.andExpect(jsonPath("$.events[0].params.debug_mode").doesNotExist())
 			.andRespond(withSuccess());
 
 		client.send("123.456", "42", new Ga4Event("link_save_success", Map.of("source", "web")));
@@ -40,7 +41,7 @@ class Ga4MeasurementProtocolClientTest {
 	void send_skipsWhenDisabled() {
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-		Ga4Properties properties = new Ga4Properties(false, "G-TEST", "secret", null);
+		Ga4Properties properties = new Ga4Properties(false, "G-TEST", "secret", null, false);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
 		client.send("123.456", "42", new Ga4Event("link_save_success", Map.of()));
@@ -52,7 +53,7 @@ class Ga4MeasurementProtocolClientTest {
 	void send_omitsUserIdWhenMissing() {
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null, false);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
 		server.expect(once(), requestTo(
@@ -73,11 +74,31 @@ class Ga4MeasurementProtocolClientTest {
 	void send_skipsWhenClientIdIsMissing() {
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null);
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null, false);
 		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
 
 		client.send(" ", "42", new Ga4Event("link_save_success", Map.of()));
 
+		server.verify();
+	}
+
+	@Test
+	void send_addsDebugModeWithoutMutatingEventParamsWhenEnabled() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://www.google-analytics.com");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		Ga4Properties properties = new Ga4Properties(true, "G-TEST", "secret", null, true);
+		Ga4MeasurementProtocolClient client = new Ga4MeasurementProtocolClient(builder.build(), properties);
+		Map<String, Object> originalParams = Map.of("source", "web");
+
+		server.expect(once(), requestTo(
+				"https://www.google-analytics.com/mp/collect?measurement_id=G-TEST&api_secret=secret"))
+			.andExpect(jsonPath("$.events[0].params.source").value("web"))
+			.andExpect(jsonPath("$.events[0].params.debug_mode").value(true))
+			.andRespond(withSuccess());
+
+		client.send("123.456", "42", new Ga4Event("query_submit", originalParams));
+
+		assertThat(originalParams).doesNotContainKey("debug_mode");
 		server.verify();
 	}
 }

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4PropertiesTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4PropertiesTest.java
@@ -1,0 +1,33 @@
+package com.sofa.linkiving.global.analytics;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+class Ga4PropertiesTest {
+
+	@Test
+	void debugMode_defaultsToFalseWhenPropertyIsMissing() {
+		Ga4Properties properties = bind(Map.of("analytics.ga4.enabled", "true"));
+
+		assertThat(properties.debugMode()).isFalse();
+	}
+
+	@Test
+	void debugMode_bindsFromConfigurationProperty() {
+		Ga4Properties properties = bind(Map.of("analytics.ga4.debug-mode", "true"));
+
+		assertThat(properties.debugMode()).isTrue();
+	}
+
+	private Ga4Properties bind(Map<String, String> values) {
+		return new Binder(new MapConfigurationPropertySource(values))
+			.bind("analytics.ga4", Bindable.of(Ga4Properties.class))
+			.orElseThrow();
+	}
+}

--- a/src/test/java/com/sofa/linkiving/global/analytics/Ga4PropertiesTest.java
+++ b/src/test/java/com/sofa/linkiving/global/analytics/Ga4PropertiesTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 class Ga4PropertiesTest {
 
@@ -25,9 +27,22 @@ class Ga4PropertiesTest {
 		assertThat(properties.debugMode()).isTrue();
 	}
 
+	@Test
+	void debugMode_bindsFromEnvironmentVariable() {
+		StandardEnvironment environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new SystemEnvironmentPropertySource(
+			"env", Map.of("ANALYTICS_GA4_DEBUG_MODE", "true")));
+
+		Ga4Properties properties = Binder.get(environment)
+			.bind("analytics.ga4", Bindable.of(Ga4Properties.class))
+			.orElseThrow(() -> new IllegalStateException("GA4 properties binding failed"));
+
+		assertThat(properties.debugMode()).isTrue();
+	}
+
 	private Ga4Properties bind(Map<String, String> values) {
 		return new Binder(new MapConfigurationPropertySource(values))
 			.bind("analytics.ga4", Bindable.of(Ga4Properties.class))
-			.orElseThrow();
+			.orElseThrow(() -> new IllegalStateException("GA4 properties binding failed"));
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- close #293

## PR 설명

- 질의 처리 시작 시 생성한 `query_id`를 USER 메시지 저장까지 전달해 USER/AI 메시지와 GA 이벤트가 동일한 값을 사용하도록 합니다.
- 정상 응답과 오류 응답 모두 같은 `query_id`를 유지합니다.
- Measurement Protocol 이벤트에 `debug_mode`를 선택적으로 추가할 수 있도록 설정을 제공합니다.
- 질문과 답변 원문은 GA payload 및 애플리케이션 로그에 추가하지 않습니다.

GA4 DebugView 검증 시에만 다음 환경변수를 활성화하고, 검증 직후 `false`로 되돌려 애플리케이션을 재시작해야 합니다.

```text
ANALYTICS_GA4_DEBUG_MODE=true
```

환경변수가 없으면 기본값은 `false`입니다. 기존 `messages.query_id` 컬럼을 사용하므로 별도 DB 스키마 변경은 없습니다.
